### PR TITLE
Going from 3 to 1 URL box on the "content change request" form

### DIFF
--- a/app/models/content_change_request.rb
+++ b/app/models/content_change_request.rb
@@ -8,6 +8,6 @@ class ContentChangeRequest < TablelessModel
   include WithTimeConstraint
   include WithRequestContext
 
-  attr_accessor :details_of_change, :url1, :url2, :url3
+  attr_accessor :details_of_change, :url
   validates_presence_of :details_of_change
 end

--- a/app/views/content_change_requests/_request_details.html.erb
+++ b/app/views/content_change_requests/_request_details.html.erb
@@ -1,8 +1,6 @@
 <%= render :partial => "support/request_context", :locals => {:f => f} %>
 
-<%= f.inputs :name => "URL(s) affected" do %>
-  <%= f.input :url1, :label => "URL 1", :input_html => {:class => "span6", :placeholder => "https://www.gov.uk/"} %>
-  <%= f.input :url2, :label => "URL 2", :input_html => {:class => "span6", :placeholder => "https://www.gov.uk/"} %>
-  <%= f.input :url3, :label => "URL 3", :input_html => {:class => "span6", :placeholder => "https://www.gov.uk/"} %>
+<%= f.inputs :name => "URL affected" do %>
+  <%= f.input :url, :label => "URL", :input_html => {:class => "span6", :placeholder => "https://www.gov.uk/"} %>
   <%= f.input :details_of_change, :as => :text, :label => "Details of the requested change", :required => :true, :input_html => {:class => "span6", :rows => 6, :cols => 50, :"aria-required" => true } %>
 <% end %>

--- a/features/content_change_requests.feature
+++ b/features/content_change_requests.feature
@@ -10,8 +10,8 @@ Feature: Content change requests
 
   Scenario: successful Mainstream content change request 
     When the user submits the following content change request:
-      | Context                       | Details of change | URL 1           | URL 2           | Needed by date | Not before date | Reason  |
-      | Mainstream (business/citizen) | Out of date XX YY | http://gov.uk/X | http://gov.uk/Y | 31-12-2020     | 01-12-2020      | New law |
+      | Context                       | Details of change | URL             | Needed by date | Not before date | Reason  |
+      | Mainstream (business/citizen) | Out of date XX YY | http://gov.uk/X | 31-12-2020     | 01-12-2020      | New law |
 
     Then the following ticket is raised in ZenDesk:
       | Subject                | Requester email      |
@@ -25,9 +25,8 @@ Feature: Content change requests
       [Which part of GOV.UK is this about?]
       Mainstream (business/citizen)
 
-      [URl(s) of content to be changed]
+      [URL of content to be changed]
       http://gov.uk/X
-      http://gov.uk/Y
 
       [Details of what should be added, amended or removed]
       Out of date XX YY

--- a/features/step_definitions/request_steps.rb
+++ b/features/step_definitions/request_steps.rb
@@ -68,9 +68,7 @@ When /^the user submits the following content change request:$/ do |request_deta
   end
 
   fill_in "Details of the requested change", :with => @request_details["Details of change"]
-  fill_in "URL 1", :with => @request_details["URL 1"]
-  fill_in "URL 2", :with => @request_details["URL 2"]
-  fill_in "URL 3", :with => @request_details["URL 3"]
+  fill_in "URL", :with => @request_details["URL"]
 
   step "the user fills out the time constraints"
   step "the user submits the request successfully"

--- a/lib/content_change_request_zendesk_ticket.rb
+++ b/lib/content_change_request_zendesk_ticket.rb
@@ -15,8 +15,8 @@ class ContentChangeRequestZendeskTicket < ZendeskTicket
     [ 
       CommentSnippet.new(on: @request,                 field: :formatted_request_context,
                                                        label: "Which part of GOV.UK is this about?"),
-      CommentSnippet.new(on: @request,                 fields: [:url1, :url2, :url3],
-                                                       label: "URl(s) of content to be changed"),
+      CommentSnippet.new(on: @request,                 field: :url,
+                                                       label: "URL of content to be changed"),
       CommentSnippet.new(on: @request,                 field: :details_of_change,
                                                        label: "Details of what should be added, amended or removed"),
       CommentSnippet.new(on: @request.time_constraint, field: :time_constraint_reason)

--- a/test/unit/models/content_change_request_test.rb
+++ b/test/unit/models/content_change_request_test.rb
@@ -6,9 +6,7 @@ class ContentChangeRequestTest < Test::Unit::TestCase
 
   should validate_presence_of(:request_context)
 
-  should allow_value("https://www.gov.uk").for(:url1)
-  should allow_value("https://www.gov.uk").for(:url2)
-  should allow_value("https://www.gov.uk").for(:url3)
+  should allow_value("https://www.gov.uk").for(:url)
 
   should "allow time constraints" do
     request = ContentChangeRequest.new(:time_constraint => stub("time constraint", :valid? => true))


### PR DESCRIPTION
The reason for this is to discourage users from submitting 3 different problems in a single request.
