### PR TITLE
Better handling of zendesk errors

### DIFF
--- a/app/controllers/create_new_user_requests_controller.rb
+++ b/app/controllers/create_new_user_requests_controller.rb
@@ -17,6 +17,14 @@ class CreateNewUserRequestsController < RequestsController
 
   def process_valid_request(submitted_request)
     super(submitted_request)
-    ZendeskUsers.new(client).create_or_update_user(submitted_request.requested_user)
+    create_or_update_user_in_zendesk(submitted_request.requested_user)
+  end
+
+  def create_or_update_user_in_zendesk(requested_user)
+    begin
+      ZendeskUsers.new(client).create_or_update_user(requested_user)
+    rescue ZendeskError => e
+      ExceptionNotifier::Notifier.exception_notification(request.env, e).deliver
+    end
   end
 end

--- a/test/functional/create_new_user_requests_controller_test.rb
+++ b/test/functional/create_new_user_requests_controller_test.rb
@@ -30,6 +30,18 @@ class CreateNewUserRequestsControllerTest < ActionController::TestCase
       assert_equal expected_created_user_attributes, @zendesk_api.users.created_user_attributes
     end
 
+    should "not expose an error to the user when automatic user creation goes wrong" do
+      @zendesk_api.users.should_raise_error
+
+      ExceptionNotifier::Notifier.expects(:exception_notification)
+                                 .with(anything, kind_of(ZendeskError))
+                                 .returns(stub("mailer", deliver: true))
+
+      post :create, valid_create_new_user_request_params
+
+      assert_redirected_to "/acknowledge"
+    end
+
     context "concerning Inside Government" do
       should "tag the ticket with an inside_government tag" do
         params = valid_create_new_user_request_params.tap {|p| p["create_new_user_request"].merge!("tool_role" => "inside_government_editor")}

--- a/test/zendesk_api_stubs.rb
+++ b/test/zendesk_api_stubs.rb
@@ -1,4 +1,5 @@
 require 'zendesk_tickets'
+require 'zendesk_error'
 
 module ZendeskApiStubsHelper
   def stub_zendesk_ticket_submission
@@ -50,6 +51,11 @@ class ZenDeskAPIUsersDouble
 
   def initialize
     @created_user_attributes = {}
+    @should_raise_error = false
+  end
+
+  def should_raise_error
+    @should_raise_error = true
   end
 
   def search(attributes)
@@ -57,7 +63,11 @@ class ZenDeskAPIUsersDouble
   end
 
   def create(new_user_attributes)
-    @created_user_attributes = new_user_attributes
+    if @should_raise_error
+      raise ZendeskError, "error creating users"
+    else
+      @created_user_attributes = new_user_attributes
+    end
   end
 end
 


### PR DESCRIPTION
A successful submission of a "create new user" request triggers:
1) creation of a Zendesk ticket for the request
2) creation (or update) of a Zendesk user for the requested user.

As it stands, if automatic user creation goes wrong in Zendesk, the user gets a 500, even if the Zendesk ticket has been successfully raised.
With this pull request, an error upon user creation is raised through the ExceptionNotifier and the user doesn't see a 500.
