### PR TITLE
adding "related urls" to content change request

### DIFF
--- a/app/models/content_change_request.rb
+++ b/app/models/content_change_request.rb
@@ -8,6 +8,6 @@ class ContentChangeRequest < TablelessModel
   include WithTimeConstraint
   include WithRequestContext
 
-  attr_accessor :details_of_change, :url
+  attr_accessor :details_of_change, :url, :related_urls
   validates_presence_of :details_of_change
 end

--- a/app/views/content_change_requests/_request_details.html.erb
+++ b/app/views/content_change_requests/_request_details.html.erb
@@ -2,5 +2,9 @@
 
 <%= f.inputs name: "URL affected" do %>
   <%= f.input :url, label: "URL", input_html: { class: "span6", placeholder: "https://www.gov.uk/" } %>
-  <%= f.input :details_of_change, as: :text, label: "Details of the requested change", required: true, input_html: { :class => "span6", :rows => 6, :cols => 50, :"aria-required" => true } %>
+
+  <%= f.input :details_of_change, as: :text, label: "Details of the requested change", required: true, input_html: { :class => "span6", :rows => 16, :cols => 50, :"aria-required" => true } %>
+
+  <%= f.input :related_urls, as: :text, label: "Does this affect any other URLs? (please specify one per line)", input_html: { class: "span6", rows: 4, cols: 50 } %>
+
 <% end %>

--- a/features/content_change_requests.feature
+++ b/features/content_change_requests.feature
@@ -10,8 +10,8 @@ Feature: Content change requests
 
   Scenario: successful Mainstream content change request 
     When the user submits the following content change request:
-      | Context                       | Details of change | URL             | Needed by date | Not before date | Reason  |
-      | Mainstream (business/citizen) | Out of date XX YY | http://gov.uk/X | 31-12-2020     | 01-12-2020      | New law |
+      | Context                       | Details of change | URL             | Related URLs | Needed by date | Not before date | Reason  |
+      | Mainstream (business/citizen) | Out of date XX YY | http://gov.uk/X | XXXXX        | 31-12-2020     | 01-12-2020      | New law |
 
     Then the following ticket is raised in ZenDesk:
       | Subject                | Requester email      |
@@ -27,6 +27,9 @@ Feature: Content change requests
 
       [URL of content to be changed]
       http://gov.uk/X
+
+      [Related URLs]
+      XXXXX
 
       [Details of what should be added, amended or removed]
       Out of date XX YY

--- a/features/step_definitions/request_steps.rb
+++ b/features/step_definitions/request_steps.rb
@@ -69,6 +69,7 @@ When /^the user submits the following content change request:$/ do |request_deta
 
   fill_in "Details of the requested change", :with => @request_details["Details of change"]
   fill_in "URL", :with => @request_details["URL"]
+  fill_in "Does this affect any other URLs? (please specify one per line)", :with => @request_details["Related URLs"]
 
   step "the user fills out the time constraints"
   step "the user submits the request successfully"

--- a/lib/content_change_request_zendesk_ticket.rb
+++ b/lib/content_change_request_zendesk_ticket.rb
@@ -17,6 +17,8 @@ class ContentChangeRequestZendeskTicket < ZendeskTicket
                                                        label: "Which part of GOV.UK is this about?"),
       CommentSnippet.new(on: @request,                 field: :url,
                                                        label: "URL of content to be changed"),
+      CommentSnippet.new(on: @request,                 field: :related_urls,
+                                                       label: "Related URLs"),
       CommentSnippet.new(on: @request,                 field: :details_of_change,
                                                        label: "Details of what should be added, amended or removed"),
       CommentSnippet.new(on: @request.time_constraint, field: :time_constraint_reason)

--- a/test/unit/models/content_change_request_test.rb
+++ b/test/unit/models/content_change_request_test.rb
@@ -7,6 +7,7 @@ class ContentChangeRequestTest < Test::Unit::TestCase
   should validate_presence_of(:request_context)
 
   should allow_value("https://www.gov.uk").for(:url)
+  should allow_value("https://www.gov.uk/A\nhttps://www.gov.uk/A").for(:related_urls)
 
   should "allow time constraints" do
     request = ContentChangeRequest.new(:time_constraint => stub("time constraint", :valid? => true))


### PR DESCRIPTION
This allows users to provide any other URLs that need to be updated by the submitted content change request.
