### PR TITLE
Bugfix: allowing launch dates in time constraints

### DIFF
--- a/app/models/time_constraint.rb
+++ b/app/models/time_constraint.rb
@@ -5,5 +5,5 @@ class TimeConstraint < TablelessModel
 
   validates_date :needed_by_date, :allow_nil => true, :allow_blank => true, :on_or_after => :today
   validates_date :not_before_date, :allow_nil => true, :allow_blank => true, :on_or_after => :today
-  validates_date :not_before_date, :before => :needed_by_date, :unless => Proc.new { |c| c.needed_by_date.blank? || c.not_before_date.blank? }
+  validates_date :not_before_date, :on_or_before => :needed_by_date, :unless => Proc.new { |c| c.needed_by_date.blank? || c.not_before_date.blank? }
 end

--- a/test/unit/models/time_constraint_test.rb
+++ b/test/unit/models/time_constraint_test.rb
@@ -36,4 +36,10 @@ class TimeConstraintTest < Test::Unit::TestCase
   should "allow a blank not_before_date if the needed_by_date is set" do
     assert TimeConstraint.new(:needed_by_date => as_str(Date.tomorrow)).valid?
   end
+
+  should "allow launch dates (i.e. not_before_date = needed_by_date)" do
+    constraint = TimeConstraint.new(not_before_date: as_str(Date.tomorrow), 
+                                    needed_by_date: as_str(Date.tomorrow))
+    assert constraint.valid?
+  end
 end


### PR DESCRIPTION
This pull request makes it possible to specify a time constraint
for a launch date (i.e. when the 'needed by' date is the same
as the 'don't publish before' date).
