### PR TITLE
inferring the requester's name from the email

### DIFF
--- a/app/models/requester.rb
+++ b/app/models/requester.rb
@@ -1,12 +1,18 @@
 require 'tableless_model'
+require 'name_guesser'
 
 class Requester < TablelessModel
   attr_accessor :email
+  attr_writer :name
 
   validates_presence_of :email
   validates :email, :format => {:with => /@/}
 
   validate :collaborator_emails_are_all_valid
+
+  def name
+    @name || NameGuesser.new.guess_from_email(self.email)
+  end
 
   def collaborator_emails
     @collaborator_emails || []

--- a/lib/name_guesser.rb
+++ b/lib/name_guesser.rb
@@ -1,0 +1,17 @@
+class NameGuesser
+  def guess_from_email(email)
+    return nil if email.nil?
+
+    local_part = email.split("@")[0]
+    if local_part_firstname_dot_lastname?(local_part)
+      local_part.split(".").map(&:capitalize).join(" ")
+    else
+      local_part.capitalize
+    end
+  end
+
+  protected
+  def local_part_firstname_dot_lastname?(local_part)
+    local_part.split(".").size == 2
+  end
+end

--- a/lib/zendesk_ticket.rb
+++ b/lib/zendesk_ticket.rb
@@ -10,7 +10,7 @@ class ZendeskTicket
     @requester = request.requester
   end
 
-  def_delegators :@requester, :email, :collaborator_emails
+  def_delegators :@requester, :name, :email, :collaborator_emails
 
   def comment
     applicable_snippets = comment_snippets.select(&:applies?)

--- a/lib/zendesk_tickets.rb
+++ b/lib/zendesk_tickets.rb
@@ -15,7 +15,7 @@ class ZendeskTickets
       :subject => ticket_to_raise.subject,
       :description => "Created via Govt API",
       :priority => "normal",
-      :requester => {"locale_id" => 1, "email" => ticket_to_raise.email},
+      :requester => {"locale_id" => 1, "email" => ticket_to_raise.email, "name" => ticket_to_raise.name},
       :collaborators => ticket_to_raise.collaborator_emails,
       :fields => [{"id" => ZendeskTickets.field_ids[:needed_by_date],  "value" => ticket_to_raise.needed_by_date},
                   {"id" => ZendeskTickets.field_ids[:not_before_date], "value" => ticket_to_raise.not_before_date}],

--- a/test/unit/models/requester_test.rb
+++ b/test/unit/models/requester_test.rb
@@ -14,4 +14,8 @@ class RequesterTest < Test::Unit::TestCase
   should "have an empty list of collaborator emails if not set" do
     assert_equal [], Requester.new.collaborator_emails
   end
+
+  should "guess the name from the email if the name is not explicitly set" do
+    assert_equal "John Smith", Requester.new(email: "john.smith@abc.com").name
+  end
 end

--- a/test/unit/name_guesser_test.rb
+++ b/test/unit/name_guesser_test.rb
@@ -1,0 +1,21 @@
+require 'test/unit'
+require 'shoulda/context'
+require 'name_guesser'
+
+class NameGuesserTest < Test::Unit::TestCase
+  context "given an email with format 'firstname.lastname@host'" do
+    should "guess the name as Firstname Lastname" do
+      assert_equal "First Last", NameGuesser.new.guess_from_email("first.last@email.com")
+    end
+  end
+
+  context "given an email which is not 'firstname.lastname@host', e.g. 'abc@host'" do
+    should "capitalise the first letter" do
+      assert_equal "Abc", NameGuesser.new.guess_from_email("abc@email.com")
+    end
+  end
+
+  should "handle the case when email is nil" do
+    assert_nil NameGuesser.new.guess_from_email(nil)
+  end
+end

--- a/test/unit/zendesk/zendesk_ticket_test.rb
+++ b/test/unit/zendesk/zendesk_ticket_test.rb
@@ -29,8 +29,9 @@ class ZendeskTicketTest < Test::Unit::TestCase
 
   context "any request" do
     should "set the requester details correctly" do
-      ticket = new_ticket(with_requester(email: "ab@c.com"))
+      ticket = new_ticket(with_requester(email: "ab@c.com", name: "A B"))
       assert_equal "ab@c.com", ticket.email
+      assert_equal "A B", ticket.name
     end
 
     should "have the request-specific tags as defined on the subclass" do


### PR DESCRIPTION
For requests from users who are already in Zendesk,
a name is not necessary (just the email). Even if a name is provided
on the ticket, Zendesk ignores it. For users not yet in
Zendesk, a name must be provided on the ticket.

Since the forms no longer ask for the name (and very soon
the name will be coming from SSO), Zendesk rejects tickets from new
requesters. The stop-gap solution is to infer the name from the email address.
