### PR TITLE
setting name as email on zendesk ticket

### DIFF
--- a/features/general_requests.feature
+++ b/features/general_requests.feature
@@ -13,8 +13,8 @@ Feature: General requests
       | Details          | URL               |
       | The site is down | https://www.gov.uk |
     Then the following ticket is raised in ZenDesk:
-      | Subject                   | Requester email      |
-      | Govt Agency General Issue | john.smith@email.com |
+      | Subject                   | Requester email      | Requester name       |
+      | Govt Agency General Issue | john.smith@email.com | john.smith@email.com | 
     And the ticket is tagged with "govt_form govt_agency_general"
     And the comment on the ticket is:
       """

--- a/features/remove_user_requests.feature
+++ b/features/remove_user_requests.feature
@@ -13,8 +13,8 @@ Feature: Remove user requests
       | Tool/Role                 | User's name  | User's email | Not before date | Reason for removal |
       | Departmental Contact Form | Bob Wasfired | bob@gov.uk   | 31-12-2020      | XXXX               |
     Then the following ticket is raised in ZenDesk:
-      | Subject     | Requester email      | Requester name | Phone | Job title |
-      | Remove user | john.smith@email.com | John Smith     | 12345 | Developer |
+      | Subject     | Requester email      | Phone | Job title |
+      | Remove user | john.smith@email.com | 12345 | Developer |
     And the ticket is tagged with "govt_form remove_user"
     And the time constraints on the ticket are:
       | Not before date |

--- a/features/step_definitions/zendesk_steps.rb
+++ b/features/step_definitions/zendesk_steps.rb
@@ -4,6 +4,7 @@ Then /^the following ticket is raised in ZenDesk:$/ do |ticket_properties_table|
 
   assert_equal expected_ticket_props["Subject"],         @raised_ticket.subject if expected_ticket_props["Subject"]
   assert_equal expected_ticket_props["Requester email"], @raised_ticket.email if expected_ticket_props["Requester email"]
+  assert_equal expected_ticket_props["Requester name"],  @raised_ticket.name if expected_ticket_props["Requester name"]
 end
 
 Then /^the ticket is tagged with "(.*?)"$/ do |expected_tags|

--- a/lib/zendesk_tickets.rb
+++ b/lib/zendesk_tickets.rb
@@ -15,7 +15,7 @@ class ZendeskTickets
       :subject => ticket_to_raise.subject,
       :description => "Created via Govt API",
       :priority => "normal",
-      :requester => {"locale_id" => 1, "email" => ticket_to_raise.email},
+      :requester => {"locale_id" => 1, "email" => ticket_to_raise.email, "name" => ticket_to_raise.email},
       :collaborators => ticket_to_raise.collaborator_emails,
       :fields => [{"id" => ZendeskTickets.field_ids[:needed_by_date],  "value" => ticket_to_raise.needed_by_date},
                   {"id" => ZendeskTickets.field_ids[:not_before_date], "value" => ticket_to_raise.not_before_date}],


### PR DESCRIPTION
For requests from users who are already in Zendesk,
a name is not necessary (just the email). Even if a name is provided
on the ticket, Zendesk ignores it. For users not yet in
Zendesk, a name must be provided on the ticket.

Since the forms no longer ask for the name (and very soon
the name will be coming from SSO), Zendesk rejects tickets from new
requesters. The stop-gap solution is to use the email address
as the name.
