### PR TITLE
refactoring: draw rails routes from request groups

### DIFF
--- a/app/models/request_groups.rb
+++ b/app/models/request_groups.rb
@@ -13,4 +13,8 @@ class RequestGroups
   def each(&block)
     @groups.each(&block)
   end
+
+  def all_request_classes
+    @groups.collect(&:request_classes).flatten
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,10 @@
+require 'request_groups'
+
 Support::Application.routes.draw do
-  resource :content_change_request, :only => [:new, :create]
-  resource :create_new_user_request, :only => [:new, :create]
-  resource :remove_user_request, :only => [:new, :create]
-  resource :general_request, :only => [:new, :create]
-  resource :new_feature_request, :only => [:new, :create]
-  resource :campaign_request, :only => [:new, :create]
+  RequestGroups.new.all_request_classes.each do |request_class|
+    resource request_class.name.underscore, only: [:new, :create]
+  end
 
   match "acknowledge" => "support#acknowledge"
-  root :to => 'support#landing'
+  root to: 'support#landing'
 end


### PR DESCRIPTION
Right now, the Rails routes are implicitly based on the requests that we have. This PR makes that dependency explicit, reducing the number of places that need to change when a new type of request is added.
