### PR TITLE
better email field validation

### DIFF
--- a/app/models/shared/requester.rb
+++ b/app/models/shared/requester.rb
@@ -4,9 +4,14 @@ class Requester < TablelessModel
   attr_accessor :email
 
   validates_presence_of :email
-  validates :email, :format => {:with => /@/}
+
+  validates :email, format: { with: /@/ }
 
   validate :collaborator_emails_are_all_valid
+
+  def email=(new_email)
+    @email = new_email.nil? ? nil : new_email.gsub("\s", "")
+  end
 
   def collaborator_emails
     @collaborator_emails || []

--- a/test/unit/models/requester_test.rb
+++ b/test/unit/models/requester_test.rb
@@ -4,12 +4,23 @@ class RequesterTest < Test::Unit::TestCase
   should validate_presence_of(:email)
 
   should allow_value("ab@c.com").for(:email)
+  should allow_value("ab@ c.com").for(:email)
+  should allow_value("ab @c.com").for(:email)
+  should allow_value("ab@c.com ").for(:email)
+  should allow_value(" ab@c.com").for(:email)
   should_not allow_value("ab").for(:email)
 
   should allow_value("").for(:collaborator_emails)
   should allow_value("ab@c.com").for(:collaborator_emails)
   should allow_value("ab@c.com, de@f.com").for(:collaborator_emails)
   should_not allow_value("ab, de@f.com").for(:collaborator_emails)
+
+  should "remove all whitespace from the email" do
+    assert_equal "ab@c.com", Requester.new(email: " ab@c.com").email
+    assert_equal "ab@c.com", Requester.new(email: "ab@c.com ").email
+    assert_equal "ab@c.com", Requester.new(email: "ab @c.com").email
+    assert_equal "ab@c.com", Requester.new(email: "ab@ c.com").email
+  end
 
   should "have an empty list of collaborator emails if not set" do
     assert_equal [], Requester.new.collaborator_emails


### PR DESCRIPTION
Users keep hitting problems when they append/prepend whitespace to
the email field (or stick spaces somewhere in the middle).

Until it is possible to take the email from the SSO, this change
tightens the validation around the requester's email address and
strips out leading & trailing whitespace.
