### PR TITLE
removing the requester email from collaborators

### DIFF
--- a/app/models/shared/requester.rb
+++ b/app/models/shared/requester.rb
@@ -18,7 +18,9 @@ class Requester < TablelessModel
   end
 
   def collaborator_emails=(emails_as_string)
-    @collaborator_emails = emails_as_string.split(",").collect(&:strip)
+    collaborator_emails = emails_as_string.split(",").collect(&:strip)
+    filtered_collaborators = collaborator_emails.reject { |collab| collab == email }
+    @collaborator_emails = filtered_collaborators
   end
 
   def collaborator_emails_are_all_valid

--- a/test/unit/models/requester_test.rb
+++ b/test/unit/models/requester_test.rb
@@ -25,4 +25,9 @@ class RequesterTest < Test::Unit::TestCase
   should "have an empty list of collaborator emails if not set" do
     assert_equal [], Requester.new.collaborator_emails
   end
+
+  should "remove the requester from the collaborators (as Zendesk doesn't allow this)" do
+    requester = Requester.new(email: "requester@x.com", collaborator_emails: "a@b.com, requester@x.com, c@d.com")
+    assert_equal ["a@b.com", "c@d.com"], requester.collaborator_emails
+  end
 end


### PR DESCRIPTION
Zendesk does not allow for the requester email to be within the list
of collaborators. This change takes the requester out of the collabs
if set.
