### PR TITLE
Add "manage users" permission

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,6 +6,7 @@ class Ability
     can :manage, :all if user.has_permission?('single_points_of_contact')
     can :manage, CampaignRequest if user.has_permission?('campaign_requesters')    
     can :manage, [ NewFeatureRequest, ContentChangeRequest ] if user.has_permission?('content_requesters')
+    can :manage, [ CreateNewUserRequest, RemoveUserRequest ] if user.has_permission?('user_managers')
 
     can :manage, [GeneralRequest, AnalyticsRequest]
   end

--- a/features/permissions.feature
+++ b/features/permissions.feature
@@ -5,11 +5,11 @@ Feature: Request permissions
 
   Scenario: permissions per role
     * The role/request matrix:
-    | Role                   | Content requesters | Campaign requesters | Single points of contact | Anyone |
-    | Analytics              | Y                  | Y                   | Y                        | Y      |
-    | Campaign               | N                  | Y                   | Y                        | N      |
-    | Content change         | Y                  | N                   | Y                        | N      |
-    | Create new user        | N                  | N                   | Y                        | N      |
-    | General                | Y                  | Y                   | Y                        | Y      |
-    | New feature            | Y                  | N                   | Y                        | N      |
-    | Remove user            | N                  | N                   | Y                        | N      |
+    | Role                   | Content requesters | Campaign requesters | Single points of contact | User managers | Anyone |
+    | Analytics              | Y                  | Y                   | Y                        | Y             | Y      |
+    | Campaign               | N                  | Y                   | Y                        | N             | N      |
+    | Content change         | Y                  | N                   | Y                        | N             | N      |
+    | Create new user        | N                  | N                   | Y                        | Y             | N      |
+    | General                | Y                  | Y                   | Y                        | Y             | Y      |
+    | New feature            | Y                  | N                   | Y                        | N             | N      |
+    | Remove user            | N                  | N                   | Y                        | Y             | N      |

--- a/features/step_definitions/permissions_steps.rb
+++ b/features/step_definitions/permissions_steps.rb
@@ -10,6 +10,7 @@ def perms_for(role)
   when "Content requesters" then ["content_requesters"]
   when "Campaign requesters" then ["campaign_requesters"]
   when "Single points of contact" then ["single_points_of_contact"]
+  when "User managers" then ["user_managers"]
   else
     raise "unexpected role: #{role}"
   end


### PR DESCRIPTION
The first commit transposes the permission spec, so it's easier to see the changes if the two commits are viewed separately.

There is a signonotron PR which adds the actual permission (https://github.com/alphagov/signonotron2/pull/69).
