### PR TITLE
move contents to ticket description

### DIFF
--- a/features/analytics_requests.feature
+++ b/features/analytics_requests.feature
@@ -16,7 +16,7 @@ Feature: Analytics requests
       | Subject               | Requester email      |
       | Request for analytics | john.smith@email.com |
     And the ticket is tagged with "govt_form analytics"
-    And the comment on the ticket is:
+    And the description on the ticket is:
       """
       [Which part of GOV.UK is this about?]
       Mainstream (business/citizen)

--- a/features/campaign_requests.feature
+++ b/features/campaign_requests.feature
@@ -16,7 +16,7 @@ Feature: Campaign requests
       | Subject  | Requester email      |
       | Campaign | john.smith@email.com |
     And the ticket is tagged with "govt_form campaign"
-    And the comment on the ticket is:
+    And the description on the ticket is:
       """
       [Campaign title]
       Workplace pensions

--- a/features/content_change_requests.feature
+++ b/features/content_change_requests.feature
@@ -20,7 +20,7 @@ Feature: Content change requests
       | Need by date | Not before date |
       | 31-12-2020   | 01-12-2020      |
     And the ticket is tagged with "govt_form content_amend"
-    And the comment on the ticket is:
+    And the description on the ticket is:
       """
       [Which part of GOV.UK is this about?]
       Mainstream (business/citizen)

--- a/features/create_new_user_requests.feature
+++ b/features/create_new_user_requests.feature
@@ -17,7 +17,7 @@ Feature: Create new user requests
       | Subject         | Requester email      |
       | Create new user | john.smith@email.com |
     And the ticket is tagged with "govt_form new_user"
-    And the comment on the ticket is:
+    And the description on the ticket is:
       """
       [Tool/Role]
       Departmental Contact Form

--- a/features/general_requests.feature
+++ b/features/general_requests.feature
@@ -16,7 +16,7 @@ Feature: General requests
       | Subject                   | Requester email      | Requester name       |
       | Govt Agency General Issue | john.smith@email.com | John Smith           | 
     And the ticket is tagged with "govt_form govt_agency_general"
-    And the comment on the ticket is:
+    And the description on the ticket is:
       """
       [Url]
       https://www.gov.uk

--- a/features/new_feature_requests.feature
+++ b/features/new_feature_requests.feature
@@ -20,7 +20,7 @@ Feature: New feature requests
       | Need by date | Not before date |
       | 31-12-2020   | 01-12-2020      |
     And the ticket is tagged with "govt_form new_feature_request inside_government"
-    And the comment on the ticket is:
+    And the description on the ticket is:
       """
       [Which part of GOV.UK is this about?]
       Inside Government

--- a/features/remove_user_requests.feature
+++ b/features/remove_user_requests.feature
@@ -19,7 +19,7 @@ Feature: Remove user requests
     And the time constraints on the ticket are:
       | Not before date |
       | 31-12-2020      |
-    And the comment on the ticket is:
+    And the description on the ticket is:
       """
       [Tool/Role]
       Departmental Contact Form

--- a/features/step_definitions/zendesk_steps.rb
+++ b/features/step_definitions/zendesk_steps.rb
@@ -11,8 +11,8 @@ Then /^the ticket is tagged with "(.*?)"$/ do |expected_tags|
   assert_equal expected_tags, @raised_ticket.tags.join(" ")
 end
 
-Then /^the comment on the ticket is:$/ do |expected_comment_string|
-  assert_equal expected_comment_string, @raised_ticket.comment
+Then /^the description on the ticket is:$/ do |expected_comment_string|
+  assert_equal expected_comment_string, @raised_ticket.description
 end
 
 Then /^the time constraints on the ticket are:$/ do |ticket_properties_table|

--- a/features/technical_fault_reports.feature
+++ b/features/technical_fault_reports.feature
@@ -16,7 +16,7 @@ Feature: Technical fault reports
       | Subject                | Requester email      |
       | Technical fault report | john.smith@email.com |
     And the ticket is tagged with "govt_form technical_fault fault_with_gov_uk"
-    And the comment on the ticket is:
+    And the description on the ticket is:
       """
       [Location of fault]
       GOV.UK itself

--- a/lib/zendesk_tickets.rb
+++ b/lib/zendesk_tickets.rb
@@ -8,13 +8,12 @@ class ZendeskTickets
   def raise_ticket(ticket_to_raise)
     @client.ticket.create(
       :subject => ticket_to_raise.subject,
-      :description => "Created via Govt API",
       :priority => "normal",
       :requester => {"locale_id" => 1, "email" => ticket_to_raise.email, "name" => ticket_to_raise.name},
       :collaborators => ticket_to_raise.collaborator_emails,
       :fields => [{"id" => GDSZendesk::FIELD_MAPPINGS[:needed_by_date],  "value" => ticket_to_raise.needed_by_date},
                   {"id" => GDSZendesk::FIELD_MAPPINGS[:not_before_date], "value" => ticket_to_raise.not_before_date}],
       :tags => ticket_to_raise.tags,
-      :comment => {:value => ticket_to_raise.comment})
+      :description => ticket_to_raise.comment)
   end
 end

--- a/test/functional/general_requests_controller_test.rb
+++ b/test/functional/general_requests_controller_test.rb
@@ -10,7 +10,7 @@ class GeneralRequestsControllerTest < ActionController::TestCase
 
       post :create, params
 
-      assert_includes @zendesk_api.ticket.comment, "Mozilla/5.0"
+      assert_includes @zendesk_api.ticket.description, "Mozilla/5.0"
     end
   end
 end


### PR DESCRIPTION
before this change, the body of the ticket was created as a ticket comment
in Zendesk. This meant that the text was in the "ticket_audit" resource,
instead of the "ticket" resource in Zendesk world. Now it is the ticket
description.

This change brings the support app in line with the feedback app in this respect.
