### PR TITLE
error handling and logging improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :assets do
 end
 
 gem 'aws-ses', require: 'aws/ses'
-gem 'exception_notification', '~> 2.4.1', require: 'exception_notifier'
+gem "exception_notification", '3.0.1'
 gem 'gds-sso', '3.0.5'
 gem 'cancan', '1.6.9'
 gem 'jquery-rails'
@@ -23,7 +23,7 @@ gem 'validates_timeliness', '3.0.14'
 if ENV['GDS_ZENDESK_DEV']
   gem "gds_zendesk", :path => '../gds_zendesk'
 else
-  gem "gds_zendesk", '0.0.5'
+  gem "gds_zendesk", '0.1.0'
 end
 gem 'redis-rails', '3.2.3'
 gem 'redis-activesupport', '3.2.3', :git => "https://github.com/alphagov/redis-store", :branch => "connection_url", :ref => '2f9efcf48e124be3279e2f8864c979f999bed2ad'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,8 @@ GEM
     diff-lcs (1.1.3)
     erubis (2.7.0)
     eventmachine (1.0.0)
-    exception_notification (2.4.1)
+    exception_notification (3.0.1)
+      actionmailer (>= 3.0.4)
     execjs (1.4.0)
       multi_json (~> 1.0)
     faraday (0.8.7)
@@ -109,9 +110,9 @@ GEM
       rack-accept (~> 0.4.4)
       rails (>= 3.0.0)
       warden (~> 1.2)
-    gds_zendesk (0.0.5)
+    gds_zendesk (0.1.0)
       null_logger (= 0.0.1)
-      zendesk_api (= 0.1.2)
+      zendesk_api (= 0.4.0.rc1)
     gherkin (2.11.2)
       json (>= 1.4.6)
     hashie (2.0.3)
@@ -257,13 +258,13 @@ GEM
     xml-simple (1.1.1)
     xpath (0.1.4)
       nokogiri (~> 1.3)
-    zendesk_api (0.1.2)
+    zendesk_api (0.4.0.rc1)
       faraday (>= 0.8.0)
       faraday_middleware (>= 0.8.7)
-      hashie
+      hashie (>= 1.2)
       inflection
-      json
       mime-types
+      multi_json
       multipart-post
 
 PLATFORMS
@@ -275,10 +276,10 @@ DEPENDENCIES
   capybara (= 1.1.2)
   coffee-rails (~> 3.2.1)
   cucumber-rails (= 1.3.0)
-  exception_notification (~> 2.4.1)
+  exception_notification (= 3.0.1)
   formtastic-bootstrap (= 2.0.0)
   gds-sso (= 3.0.5)
-  gds_zendesk (= 0.0.5)
+  gds_zendesk (= 0.1.0)
   jquery-rails
   jquery-ui-rails (= 2.0.2)
   less-rails-bootstrap (= 2.1.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,14 @@ class ApplicationController < ActionController::Base
   before_filter :authenticate_user!
   
   protect_from_forgery
+
+  protected
+  def exception_notification_for(e)
+    if e.respond_to?(:errors)
+      message = { data: { message: "Zendesk errors: #{e.errors}" } }
+      ExceptionNotifier::Notifier.exception_notification(request.env, e, message).deliver
+    else
+      ExceptionNotifier::Notifier.exception_notification(request.env, e).deliver
+    end
+  end
 end

--- a/app/controllers/create_new_user_requests_controller.rb
+++ b/app/controllers/create_new_user_requests_controller.rb
@@ -2,7 +2,7 @@ require 'zendesk/ticket/create_new_user_request_ticket'
 require 'support/requests/create_new_user_request'
 require 'support/gds/requested_user'
 require 'gds_zendesk/users'
-require 'gds_zendesk/zendesk_error'
+require 'zendesk_api/error'
 
 class CreateNewUserRequestsController < RequestsController
   include Support::Requests
@@ -28,8 +28,8 @@ class CreateNewUserRequestsController < RequestsController
   def create_or_update_user_in_zendesk(requested_user)
     begin
       GDSZendesk::Users.new(GDS_ZENDESK_CLIENT).create_or_update_user(requested_user)
-    rescue GDSZendesk::ZendeskError => e
-      ExceptionNotifier::Notifier.exception_notification(request.env, e).deliver
+    rescue ZendeskAPI::Error::ClientError => e
+      exception_notification_for(e)
     end
   end
 end

--- a/test/functional/create_new_user_requests_controller_test.rb
+++ b/test/functional/create_new_user_requests_controller_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require 'gds_zendesk/zendesk_error'
+require 'zendesk_api/error'
 
 class CreateNewUserRequestsControllerTest < ActionController::TestCase
   include TestData
@@ -29,7 +29,7 @@ class CreateNewUserRequestsControllerTest < ActionController::TestCase
       @zendesk_api.users.should_raise_error
 
       ExceptionNotifier::Notifier.expects(:exception_notification)
-                                 .with(anything, kind_of(GDSZendesk::ZendeskError))
+                                 .with(anything, kind_of(ZendeskAPI::Error::ClientError), anything)
                                  .returns(stub("mailer", deliver: true))
 
       post :create, valid_create_new_user_request_params

--- a/test/functional/requests_controller_test.rb
+++ b/test/functional/requests_controller_test.rb
@@ -119,7 +119,7 @@ class RequestsControllerTest < ActionController::TestCase
 
       @controller.expects(:render).with("support/zendesk_error", has_entry(status: 500))
       ExceptionNotifier::Notifier.expects(:exception_notification)
-                           .with(anything, kind_of(GDSZendesk::ZendeskError))
+                           .with(anything, kind_of(ZendeskAPI::Error::ClientError), has_key(:data))
                            .returns(stub("mailer", deliver: true))
 
       post :create, params


### PR DESCRIPTION
this change bumps the `gds_zendesk` and `exception_notification` gems.
This brings the support app more in line with the feedback app, more
specifically, more granular exception handling and report.
