### PR TITLE
don't update Zendesk user for change user requests

### DIFF
--- a/app/controllers/create_or_change_user_requests_controller.rb
+++ b/app/controllers/create_or_change_user_requests_controller.rb
@@ -21,7 +21,7 @@ class CreateOrChangeUserRequestsController < RequestsController
 
   def process_valid_request(submitted_request)
     super(submitted_request)
-    create_or_update_user_in_zendesk(submitted_request.requested_user)
+    create_or_update_user_in_zendesk(submitted_request.requested_user) if submitted_request.for_new_user?
   end
 
   def create_or_update_user_in_zendesk(requested_user)

--- a/lib/support/requests/create_or_change_user_request.rb
+++ b/lib/support/requests/create_or_change_user_request.rb
@@ -27,6 +27,10 @@ module Support
         super
       end
 
+      def for_new_user?
+        action == "create_new_user"
+      end
+
       def formatted_action
         Hash[action_options].key(action)
       end

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -1,9 +1,22 @@
 module TestData
-  def valid_create_or_change_user_request_params
+  def valid_create_user_request_params
     { "support_requests_create_or_change_user_request" =>
       { "requester_attributes" => valid_requester_params,
         "requested_user_attributes" => valid_requested_user_params,
         "action" => "create_new_user",
+        "tool_role" => "govt_form",
+        "additional_comments"=>"" }
+    }
+  end
+
+  def valid_change_user_request_params
+    { "support_requests_create_or_change_user_request" =>
+      { "requester_attributes" => valid_requester_params,
+        "requested_user_attributes" => {
+          "name"=>"subject",
+          "email"=>"subject@digital.cabinet-office.gov.uk",          
+        },
+        "action" => "change_user",
         "tool_role" => "govt_form",
         "additional_comments"=>"" }
     }

--- a/test/unit/support/requests/create_or_change_user_request_test.rb
+++ b/test/unit/support/requests/create_or_change_user_request_test.rb
@@ -20,11 +20,14 @@ module Support
       should allow_value("a comment").for(:additional_comments)
 
       should "provide action choices" do
-        assert !CreateOrChangeUserRequest.new.action_options.empty?
+        assert !request.action_options.empty?
       end
 
       should "provide formatted action" do
-        assert_equal "New user account", CreateOrChangeUserRequest.new(action: "create_new_user").formatted_action
+        assert_equal "New user account", request(action: "create_new_user").formatted_action
+
+        assert request(action: "create_new_user").for_new_user?
+        refute request(action: "change_user").for_new_user?
       end
 
       should "validate that the requested user is valid" do


### PR DESCRIPTION
change user requests may not have the full user details, so
we might lose information if we write to Zendesk
