### PR TITLE
don't ask about roles for "remove user" requests

### DIFF
--- a/app/views/remove_user_requests/_request_details.html.erb
+++ b/app/views/remove_user_requests/_request_details.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: 'support/tool_role_choice', locals: { f: f } %>
-
 <div id="user_details" %>
   <%= f.inputs "User details" do %>
     <%= f.input :user_name, label: "Name", required: true, input_html: {:class => "span6", :"aria-required" => true } %>

--- a/features/remove_user_requests.feature
+++ b/features/remove_user_requests.feature
@@ -10,8 +10,8 @@ Feature: Remove user requests
 
   Scenario: successful remove user request for publisher
     When the user submits the following remove user request:
-      | Tool/Role                 | User's name  | User's email | Not before date | Reason for removal |
-      | Departmental Contact Form | Bob Wasfired | bob@gov.uk   | 31-12-2020      | XXXX               |
+      | User's name  | User's email | Not before date | Reason for removal |
+      | Bob Wasfired | bob@gov.uk   | 31-12-2020      | XXXX               |
     Then the following ticket is raised in ZenDesk:
       | Subject     | Requester email      | Phone | Job title |
       | Remove user | john.smith@email.com | 12345 | Developer |
@@ -21,9 +21,6 @@ Feature: Remove user requests
       | 31-12-2020      |
     And the description on the ticket is:
       """
-      [Tool/Role]
-      Departmental Contact Form
-
       [User name]
       Bob Wasfired
 

--- a/features/step_definitions/request_steps.rb
+++ b/features/step_definitions/request_steps.rb
@@ -107,10 +107,6 @@ When /^the user submits the following remove user request:$/ do |request_details
 
   assert page.has_content?("Request to remove user access")
 
-  within "#tool-role-choice" do
-    choose @request_details["Tool/Role"]
-  end
-
   within("#user_details") do
     fill_in "Name", :with => @request_details["User's name"]
     fill_in "Email", :with => @request_details["User's email"]

--- a/lib/support/requests/remove_user_request.rb
+++ b/lib/support/requests/remove_user_request.rb
@@ -5,7 +5,6 @@ require 'support/requests/with_time_constraint'
 module Support
   module Requests
     class RemoveUserRequest < Request
-      include Support::GDS::WithToolRoleChoice
       include WithTimeConstraint
 
       attr_accessor :user_name, :user_email, :reason_for_removal

--- a/lib/zendesk/ticket/remove_user_request_ticket.rb
+++ b/lib/zendesk/ticket/remove_user_request_ticket.rb
@@ -9,14 +9,12 @@ module Zendesk
       end
 
       def tags
-        super + ["remove_user"] + inside_government_tag_if_needed
+        super + ["remove_user"]
       end
 
       protected
       def comment_snippets
         [ 
-          LabelledSnippet.new(on: @request, field: :formatted_tool_role,
-                                            label: "Tool/Role"),
           LabelledSnippet.new(on: @request, field: :user_name),
           LabelledSnippet.new(on: @request, field: :user_email),
           LabelledSnippet.new(on: @request, field: :reason_for_removal)

--- a/test/unit/support/requests/remove_user_request_test.rb
+++ b/test/unit/support/requests/remove_user_request_test.rb
@@ -15,7 +15,6 @@ module Support
       should validate_presence_of(:requester)
       should validate_presence_of(:user_name)
       should validate_presence_of(:user_email)
-      should validate_presence_of(:tool_role)
 
       should allow_value("ab@c.com").for(:user_email)
       should_not allow_value("ab").for(:user_email)

--- a/test/unit/zendesk/ticket/remove_user_request_ticket_test.rb
+++ b/test/unit/zendesk/ticket/remove_user_request_ticket_test.rb
@@ -6,16 +6,13 @@ require 'ostruct'
 module Zendesk
   module Ticket
     class RemoveUserRequestTicketTest < Test::Unit::TestCase
-      def ticket_with(opts)
+      def ticket(opts = {})
         RemoveUserRequestTicket.new(stub_everything("request", opts))
       end
 
-      context "an inside government request" do
-        should "be tagged with inside_government" do
-          tags_on_ticket = ticket_with(:inside_government_related? => true).tags
-          assert_includes tags_on_ticket, "remove_user"
-          assert_includes tags_on_ticket, "inside_government"
-        end
+      should "be tagged with remove_user" do
+        tags_on_ticket = ticket.tags
+        assert_includes tags_on_ticket, "remove_user"
       end
     end
   end


### PR DESCRIPTION
asking about roles doesn't really make sense. Generally the request is when
the user leaves an organisation completely, and there's now an alternative
path for requesting changes to permissions.
