### PR TITLE
log queue size to common gauge

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -41,7 +41,7 @@ class RequestsController < ApplicationController
   private
   def log_queue_sizes
     Sidekiq::Stats.new.queues.each do |queue_name, queue_size|
-      Statsd.new(::STATSD_HOST).gauge("#{::STATSD_PREFIX}.queues.#{queue_name}", queue_size)
+      Statsd.new(::STATSD_HOST).gauge("govuk.apps.support.queues.#{queue_name}", queue_size)
     end
   end
 


### PR DESCRIPTION
prior to this change, ENV['GOVUK_STATSD_PREFIX'] was used as the prefix
for the statsd gauge name. However this includes the node name in it, which
doesn't make a lot of sense for a shared queue
