### PR TITLE
JSON logs in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'redis-rails', '3.2.3'
 gem 'redis-activesupport', '3.2.3', :git => "https://github.com/alphagov/redis-store", :branch => "connection_url", :ref => '2f9efcf48e124be3279e2f8864c979f999bed2ad'
 gem "sidekiq", "2.13.0"
 gem "statsd-ruby", "1.2.1", require: "statsd"
+gem "logstasher", "0.2.5"
 
 group :development do
   gem "quiet_assets", "1.0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,9 @@ GEM
     libv8 (3.3.10.4)
     libwebsocket (0.1.5)
       addressable
+    logstash-event (1.1.5)
+    logstasher (0.2.5)
+      logstash-event
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -281,6 +284,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails (= 2.0.2)
   less-rails-bootstrap (= 2.1.1)
+  logstasher (= 0.2.5)
   mocha (= 0.13.3)
   plek (= 1.1.0)
   poltergeist (= 0.7.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,4 +62,8 @@ Support::Application.configure do
   config.active_support.deprecation = :notify
 
   config.action_mailer.delivery_method = :ses
+
+  config.logstasher.enabled = true
+  config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
+  config.logstasher.supress_app_log = true
 end

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,0 +1,6 @@
+if Object.const_defined?('LogStasher') && LogStasher.enabled
+  LogStasher.add_custom_fields do |fields|
+    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
+    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
+  end
+end


### PR DESCRIPTION
This change introduces the 'logstasher' gem to make the production
logs be in JSON format, so that it's easier for kibana to parse
