### PR TITLE
don't raise tickets requested by suspended users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'validates_timeliness', '3.0.14'
 if ENV['GDS_ZENDESK_DEV']
   gem "gds_zendesk", :path => '../gds_zendesk'
 else
-  gem "gds_zendesk", '0.1.1'
+  gem "gds_zendesk", '0.2.0'
 end
 gem 'redis-rails', '3.2.3'
 gem 'redis-activesupport', '3.2.3', :git => "https://github.com/alphagov/redis-store", :branch => "connection_url", :ref => '2f9efcf48e124be3279e2f8864c979f999bed2ad'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
       rack-accept (~> 0.4.4)
       rails (>= 3.0.0)
       warden (~> 1.2)
-    gds_zendesk (0.1.1)
+    gds_zendesk (0.2.0)
       null_logger (= 0.0.1)
       zendesk_api (= 0.4.0.rc1)
     gherkin (2.11.2)
@@ -277,7 +277,7 @@ DEPENDENCIES
   exception_notification (= 3.0.1)
   formtastic-bootstrap (= 2.1.1)
   gds-sso (= 3.0.5)
-  gds_zendesk (= 0.1.1)
+  gds_zendesk (= 0.2.0)
   jquery-rails
   jquery-ui-rails (= 2.0.2)
   less-rails-bootstrap (= 2.1.1)

--- a/app/workers/zendesk_ticket_worker.rb
+++ b/app/workers/zendesk_ticket_worker.rb
@@ -4,7 +4,11 @@ class ZendeskTicketWorker
   include Sidekiq::Worker
   
   def perform(ticket_options)
-    GDS_ZENDESK_CLIENT.ticket.create(HashWithIndifferentAccess.new(ticket_options))
+    if GDS_ZENDESK_CLIENT.users.suspended?(ticket_options["requester"]["email"])
+      Statsd.new(::STATSD_HOST).increment("#{::STATSD_PREFIX}.report_a_problem.submission_from_suspended_user")
+    else
+      GDS_ZENDESK_CLIENT.ticket.create(HashWithIndifferentAccess.new(ticket_options))
+    end
   rescue ZendeskAPI::Error::ClientError => e
     data = { data: { ticket: ticket_options } } 
     data[:data][:zendesk_errors] = e.errors if e.respond_to?(:errors)

--- a/test/unit/workers/zendesk_ticket_worker_test.rb
+++ b/test/unit/workers/zendesk_ticket_worker_test.rb
@@ -7,7 +7,14 @@ class ZendeskTicketWorkerTest < Test::Unit::TestCase
                          .with(kind_of(ZendeskAPI::Error::ClientError), has_key(:data))
                          .returns(stub("mailer", deliver: true))
 
-    ZendeskTicketWorker.new.perform(some: "options")
+    ZendeskTicketWorker.new.perform("some" => "options", "requester" => { "email" => "a@b.com" })
+  end
+
+  should "not raise a ticket if the user is suspended" do
+    GDS_ZENDESK_CLIENT.users.should_be_suspended
+
+    ZendeskTicketWorker.new.perform("some" => "options", "requester" => { "email" => "a@b.com" })
+    refute GDS_ZENDESK_CLIENT.ticket.raised?
   end
 
   def teardown


### PR DESCRIPTION
When a suspended user is set as the requester on a ticket, the Zendesk API
rejects the ticket creation. This change introduces a check to see whether
the user is suspended or not, and then raises or ignores the ticket.
