### PR TITLE
don't catch zendesk exceptions in the worker

### DIFF
--- a/app/workers/zendesk_ticket_worker.rb
+++ b/app/workers/zendesk_ticket_worker.rb
@@ -9,9 +9,5 @@ class ZendeskTicketWorker
     else
       GDS_ZENDESK_CLIENT.ticket.create!(HashWithIndifferentAccess.new(ticket_options))
     end
-  rescue ZendeskAPI::Error::ClientError => e
-    data = { data: { ticket: ticket_options } } 
-    data[:data][:zendesk_errors] = e.errors if e.respond_to?(:errors)
-    ExceptionNotifier::Notifier.background_exception_notification(e, data).deliver
   end
 end

--- a/test/unit/workers/zendesk_ticket_worker_test.rb
+++ b/test/unit/workers/zendesk_ticket_worker_test.rb
@@ -11,16 +11,6 @@ class ZendeskTicketWorkerTest < ActiveSupport::TestCase
     assert_requested(stub)
   end
 
-  should "send an email notification if there was an error submitting to Zendesk" do
-    zendesk_is_unavailable
-
-    ExceptionNotifier::Notifier.expects(:background_exception_notification)
-                         .with(kind_of(ZendeskAPI::Error::ClientError), has_key(:data))
-                         .returns(stub("mailer", deliver: true))
-
-    ZendeskTicketWorker.new.perform("some" => "options", "requester" => { "email" => "a@b.com" })
-  end
-
   should "not raise a ticket if the user is suspended" do
     zendesk_has_user(email: "a@b.com", "suspended" => true)
 


### PR DESCRIPTION
Before this change, the sidekiq worker caught exceptions arising
as a result of trying to raise the Zendesk ticket, and feeding them
into the exception notifier. 

This isn't needed, because:
1. sidekiq automatically integrates with exception notifier already
2. catching the exception actually means that the retry mechanism isn't
   triggered
