### PR TITLE
upgrade redis-namespace gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ gem "sidekiq", "2.13.0"
 gem "statsd-ruby", "1.2.1", require: "statsd"
 gem "logstasher", "0.2.5"
 
+# pin to version that includes security vulnerability fix, needed by sidekiq
+gem "redis-namespace", "1.3.1"
+
 group :development do
   gem "quiet_assets", "1.0.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,7 @@ DEPENDENCIES
   quiet_assets (= 1.0.2)
   rails (= 3.2.14)
   redis-activesupport (= 3.2.3)!
+  redis-namespace (= 1.3.1)
   redis-rails (= 3.2.3)
   shoulda (~> 3.3.2)
   sidekiq (= 2.13.0)


### PR DESCRIPTION
This is in response to a security advisory:
http://blog.steveklabnik.com/posts/2013-08-03-redis-namespace-1-3-1--security-release
