### PR TITLE
remove old unused '/problem_reports' route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,6 @@ Support::Application.routes.draw do
   resource :foi_requests, only: :create
   resource :named_contacts, only: :create
 
-  # this is a legacy route that can be removed once the switch-over
-  # to the namespaced endpoint occurs
-  resource :problem_reports, only: :create, to: "anonymous_feedback/problem_reports"
-
   namespace :anonymous_feedback do
     resource :problem_reports, only: :create
   end

--- a/features/problem_reports.feature
+++ b/features/problem_reports.feature
@@ -25,11 +25,3 @@ Feature: Problem reports
       referrer: https://www.gov.uk/z
       javascript_enabled: true
       """
-
-  Scenario: successful submission on legacy endpoint (this can be removed when the legacy endpoint is deleted)
-    When the user submits the following problem report through the API on the legacy endpoint:
-      | What you were doing | What went wrong | URL                    | User agent | JS? | Referrer             | Source            | Page owner |
-      | Eating sandwich     | Fell on floor   | https://www.gov.uk/x/y | Safari     | yes | https://www.gov.uk/z | inside_government | hmrc       |
-    Then the following ticket is raised in ZenDesk:
-      | Subject | Requester email      |
-      | /x/y    | api-user@example.com |


### PR DESCRIPTION
since the feedback app points to '/anonymous_feedback/problem_reports',
the old '/problem_reports' endpoint can be dropped
