### PR TITLE
detect personal information for anonymous contacts

### DIFF
--- a/db/migrate/20131028112613_add_personal_information_detection_to_anonymous_contacts.rb
+++ b/db/migrate/20131028112613_add_personal_information_detection_to_anonymous_contacts.rb
@@ -1,0 +1,5 @@
+class AddPersonalInformationDetectionToAnonymousContacts < ActiveRecord::Migration
+  def change
+    add_column :anonymous_contacts, :personal_information_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131025135336) do
+ActiveRecord::Schema.define(:version => 20131028112613) do
 
   create_table "anonymous_contacts", :force => true do |t|
     t.string   "type"
@@ -24,8 +24,9 @@ ActiveRecord::Schema.define(:version => 20131025135336) do
     t.string   "user_agent"
     t.string   "referrer"
     t.boolean  "javascript_enabled"
-    t.datetime "created_at",         :null => false
-    t.datetime "updated_at",         :null => false
+    t.datetime "created_at",                  :null => false
+    t.datetime "updated_at",                  :null => false
+    t.string   "personal_information_status"
   end
 
 end

--- a/lib/support/requests/anonymous/anonymous_contact.rb
+++ b/lib/support/requests/anonymous/anonymous_contact.rb
@@ -1,11 +1,14 @@
 require 'support/requests/requester'
+require 'support/requests/anonymous/field_which_may_contain_personal_information'
 
 module Support
   module Requests
     module Anonymous
       class AnonymousContact < ActiveRecord::Base
-        attr_accessible :referrer, :javascript_enabled, :user_agent
+        attr_accessible :referrer, :javascript_enabled, :user_agent, :personal_information_status
         validates :referrer, url: true, allow_nil: true
+
+        before_save :detect_personal_information
 
         def requester
           Requester.anonymous
@@ -13,6 +16,17 @@ module Support
 
         validates :details, length: { maximum: 2 ** 16 }
         validates_inclusion_of :javascript_enabled, in: [ true, false ]
+        validates_inclusion_of :personal_information_status, in: [ "suspected", "absent" ], allow_nil: true
+
+        private
+        def detect_personal_information
+          self.personal_information_status ||= personal_info_present? ? "suspected" : "absent"
+        end
+
+        def personal_info_present?
+          free_text_fields = [ self.details, self.what_wrong, self.what_doing ]
+          free_text_fields.any? { |text| FieldWhichMayContainPersonalInformation.new(text).include_personal_info? }
+        end
       end
     end
   end

--- a/lib/support/requests/anonymous/field_which_may_contain_personal_information.rb
+++ b/lib/support/requests/anonymous/field_which_may_contain_personal_information.rb
@@ -1,0 +1,27 @@
+module Support
+  module Requests
+    module Anonymous
+      class FieldWhichMayContainPersonalInformation
+        NATIONAL_INSURANCE_NUMBER_PATTERN = /[a-zA-Z]{2}[0-9]{6}[a-zA-Z]{1}/
+        EMAIL_ADDRESS_PATTERN = /@/
+
+        def initialize(text)
+          @text = text
+        end
+
+        def include_personal_info?
+          include_email_address? or include_national_insurance_number?
+        end
+
+        private
+        def include_email_address?
+          not @text.nil? and @text =~ EMAIL_ADDRESS_PATTERN
+        end
+
+        def include_national_insurance_number?
+          not @text.nil? and @text.gsub(/\s/, '') =~ NATIONAL_INSURANCE_NUMBER_PATTERN
+        end
+      end
+    end
+  end
+end

--- a/test/unit/support/requests/anonymous/anonymous_contact_test.rb
+++ b/test/unit/support/requests/anonymous/anonymous_contact_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+require 'support/requests/anonymous/anonymous_contact'
+
+class TestContact < Support::Requests::Anonymous::AnonymousContact
+  attr_accessible :details, :what_wrong, :what_doing
+end
+
+module Support
+  module Requests
+    module Anonymous
+      class AnonymousContactTest < Test::Unit::TestCase
+        def new_contact(options)
+          defaults = { javascript_enabled: true }
+          TestContact.new(defaults.merge(options))
+        end
+
+        def contact(options)
+          new_contact(options).tap { |c| c.save! }
+        end
+
+        should "not detect personal info when none is present in free text fields" do
+          assert_equal "absent", contact(details: "abc", what_wrong: "abc", what_doing: "abc").personal_information_status
+        end
+
+        should "notice when an email is present in one of the free text fields" do
+          assert_equal "suspected", contact(details: "contact me at name@domain.com please").personal_information_status
+          assert_equal "suspected", contact(what_doing: "contact me at name@domain.com please").personal_information_status
+          assert_equal "suspected", contact(what_wrong: "contact me at name@domain.com please").personal_information_status
+        end
+
+        should "notice when a national insurance number is present in one of the free text fields" do
+          assert_equal "suspected", contact(details: "my NI number is QQ 12 34 56 A thanks").personal_information_status
+          assert_equal "suspected", contact(what_doing: "my NI number is QQ 12 34 56 A thanks").personal_information_status
+          assert_equal "suspected", contact(what_wrong: "my NI number is QQ 12 34 56 A thanks").personal_information_status
+        end
+
+        should "validate the personal_information_status field" do
+          assert new_contact(personal_information_status: nil).valid?
+          assert new_contact(personal_information_status: "suspected").valid?
+          assert new_contact(personal_information_status: "absent").valid?
+
+          refute new_contact(personal_information_status: "abcde").valid?
+        end
+      end
+    end
+  end
+end

--- a/test/unit/support/requests/anonymous/field_which_may_contain_personal_information.rb
+++ b/test/unit/support/requests/anonymous/field_which_may_contain_personal_information.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+require 'support/requests/anonymous/field_which_may_contain_personal_information'
+
+module Support
+  module Requests
+    module Anonymous
+      def field_with(text)
+        FieldWhichMayContainPersonalInformation.new(text)
+      end
+
+      class FieldWhichMayContainPersonalInformationTest < Test::Unit::TestCase
+        should "not detect personal info when none is present" do
+          refute field_with("abcde").include_personal_info?
+        end
+
+        should "notice when an email is present" do
+          assert field_with("contact me at name@domain.com please").include_personal_info?
+        end
+
+        should "notice when a national insurance number is present" do
+          assert field_with("QQ 12 34 56 A").include_personal_info?
+          assert field_with("my NI number is QQ 12 34 56 A thanks").include_personal_info?
+          assert field_with("QQ123456A").include_personal_info?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Users tend to provide their personal details (email address, NI number) even if we explicitly ask
them not to. In order to avoid storing an ever-increasing amount of personal information within the contacts
database, this change introduces a rudimentary mechanism for flagging personal data.

If a new record is deemed to contain an email address or NI number, the `personal_information_status`
field will be set to `suspected`. Once there is an API and frontend for the contacts DB:
- "suspected" entries won't be shown to users who query the contacts DB
- there will be tooling to approve or anonymise suspected entries

/cc @bradleywright could you have a look please?
