### PR TITLE
campaign request: make ERG reference num optional

### DIFF
--- a/app/views/campaign_requests/_campaign_details.html.erb
+++ b/app/views/campaign_requests/_campaign_details.html.erb
@@ -2,7 +2,7 @@
   <%= r.inputs :name => "Campaign details" do %>
     <%= r.input :title, label: "Campaign title", required: true, input_html: {:class => "span6", :"aria-required" => true} %>
 
-    <%= r.input :erg_reference_number, label: "ERG reference number", required: true, input_html: {:class => "span6", :"aria-required" => true} %>
+    <%= r.input :erg_reference_number, label: "ERG reference number", input_html: {:class => "span6"} %>
 
     <%= r.input :start_date, label: "Start date", required: false, input_html: {:"calendar-enabled" => true, :placeholder => "dd-mm-YYYY", :value => r.object.start_date} %>
     <%= r.input :description, as: :text, label: "Campaign description", required: true, input_html: {:class => "span6", :rows => 6, :cols => 50, :"aria-required" => true } %>

--- a/lib/support/gds/campaign.rb
+++ b/lib/support/gds/campaign.rb
@@ -5,7 +5,7 @@ module Support
     class Campaign < ActiveModel::TablelessModel
       attr_accessor :title, :erg_reference_number, :start_date, :description, :affiliated_group_or_company, :info_url
 
-      validates_presence_of :title, :erg_reference_number, :description
+      validates_presence_of :title, :description
       validates_date :start_date, :allow_nil => true, :allow_blank => true, :on_or_after => :today
     end
   end

--- a/test/unit/support/gds/campaign_test.rb
+++ b/test/unit/support/gds/campaign_test.rb
@@ -13,7 +13,6 @@ module Support
       end
 
       should validate_presence_of(:title)
-      should validate_presence_of(:erg_reference_number)
       should validate_presence_of(:description)
 
       should allow_value("some group or company").for(:affiliated_group_or_company)


### PR DESCRIPTION
only the largest campaigns will have gone through the process to get
this number, so its absence shouldn't hold up a request
