### PR TITLE
move authorisation out of ApplicationController

### DIFF
--- a/app/controllers/anonymous_feedback/problem_reports/explore_controller.rb
+++ b/app/controllers/anonymous_feedback/problem_reports/explore_controller.rb
@@ -1,7 +1,7 @@
 require 'support/requests/anonymous/problem_report'
 require 'support/requests/anonymous/explore'
 
-class AnonymousFeedback::ProblemReports::ExploreController < ApplicationController
+class AnonymousFeedback::ProblemReports::ExploreController < AuthorisationController
   authorize_resource class: Support::Requests::Anonymous::ProblemReport
 
   def new

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,3 @@
-require 'support/permissions/ability'
-
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   
@@ -7,20 +5,7 @@ class ApplicationController < ActionController::Base
   
   protect_from_forgery
 
-  check_authorization
-
-  rescue_from CanCan::AccessDenied do |exception|
-    respond_to do |format|
-      format.html { render "support/forbidden", status: 403 }
-      format.json { render json: {"error" => "You have not been granted permission to make these requests."}, status: 403 }
-    end
-  end
-
   protected
-  def current_ability
-    @current_ability ||= Support::Permissions::Ability.new(current_user)
-  end
-
   def exception_notification_for(e)
     exception_class_name = e.class.name.demodulize.downcase
     $statsd.increment("#{::STATSD_PREFIX}.exception.#{exception_class_name}")

--- a/app/controllers/authorisation_controller.rb
+++ b/app/controllers/authorisation_controller.rb
@@ -1,0 +1,17 @@
+require 'support/permissions/ability'
+
+class AuthorisationController < ApplicationController  
+  check_authorization
+
+  rescue_from CanCan::AccessDenied do |exception|
+    respond_to do |format|
+      format.html { render "support/forbidden", status: 403 }
+      format.json { render json: {"error" => "You have not been granted permission to make these requests."}, status: 403 }
+    end
+  end
+
+  protected
+  def current_ability
+    @current_ability ||= Support::Permissions::Ability.new(current_user)
+  end
+end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,7 +1,7 @@
 require "zendesk_tickets"
 require 'support/requests/requester'
 
-class RequestsController < ApplicationController
+class RequestsController < AuthorisationController
   def new
     @request = new_request
     authorize! :new, @request

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -1,6 +1,6 @@
 require 'sidekiq'
 
-class SupportController < ApplicationController
+class SupportController < AuthorisationController
   skip_authorization_check
   skip_before_filter :authenticate_support_user!, only: [:queue_status]
 


### PR DESCRIPTION
Commit f15311c027 moved authorisation into ApplicationController, which had the unfortunate side-effect of breaking SSO functionality (eg being able to assign new perms to users). The reason for that `gds-sso` controllers extend `ApplicationController` and hence broke because they didn't implement authorisation.

A [pull request](https://github.com/alphagov/gds-sso/pull/28) has been raised to fix the underlying issue, but while that request is merged (and the work needed to bump the `gds-sso` gem to the latest  version is carried out), this is a workaround to make the app work again.
