### PR TITLE
enable i18n enforce_available_locales

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,7 @@ module Support
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    I18n.config.enforce_available_locales = true
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"


### PR DESCRIPTION
This silences a configuration warning introduced by i18n 0.6.9
