### PR TITLE
Bump the redis-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,7 @@ if ENV['GDS_ZENDESK_DEV']
 else
   gem "gds_zendesk", '1.0.1'
 end
-gem 'redis-rails', '3.2.3'
-gem 'redis-activesupport', '3.2.3', :git => "https://github.com/alphagov/redis-store", :branch => "connection_url", :ref => '2f9efcf48e124be3279e2f8864c979f999bed2ad'
+gem 'redis-rails', '3.2.4'
 gem "sidekiq", "2.13.0"
 gem "statsd-ruby", "1.2.1", require: "statsd"
 gem "logstasher", "0.2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/redis-store
-  revision: 2f9efcf48e124be3279e2f8864c979f999bed2ad
-  ref: 2f9efcf48e124be3279e2f8864c979f999bed2ad
-  branch: connection_url
-  specs:
-    redis-actionpack (3.2.3)
-      actionpack (~> 3.2.3)
-      redis-rack (~> 1.4.0)
-      redis-store (~> 1.1.0)
-    redis-activesupport (3.2.3)
-      activesupport (~> 3.2.3)
-      redis-store (~> 1.1.0)
-    redis-rack (1.4.2)
-      rack (~> 1.4.1)
-      redis-store (~> 1.1.0)
-    redis-rails (3.2.3)
-      redis-actionpack (~> 3.2.3)
-      redis-activesupport (~> 3.2.3)
-      redis-store (~> 1.1.0)
-
 GEM
   remote: https://rubygems.org/
   remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
@@ -210,10 +189,24 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redis (3.0.4)
+    redis-actionpack (3.2.4)
+      actionpack (~> 3.2.0)
+      redis-rack (~> 1.4.4)
+      redis-store (~> 1.1.4)
+    redis-activesupport (3.2.5)
+      activesupport (~> 3.2.0)
+      redis-store (~> 1.1.0)
     redis-namespace (1.3.1)
       redis (~> 3.0.0)
-    redis-store (1.1.2)
-      redis (>= 2.2.0)
+    redis-rack (1.4.4)
+      rack (~> 1.4.0)
+      redis-store (~> 1.1.4)
+    redis-rails (3.2.4)
+      redis-actionpack (~> 3.2.4)
+      redis-activesupport (~> 3.2.4)
+      redis-store (~> 1.1.4)
+    redis-store (1.1.4)
+      redis (>= 2.2)
     ref (1.0.5)
     rubyzip (0.9.9)
     selenium-webdriver (2.25.0)
@@ -299,9 +292,8 @@ DEPENDENCIES
   poltergeist (= 0.7.0)
   quiet_assets (= 1.0.2)
   rails (= 3.2.16)
-  redis-activesupport (= 3.2.3)!
   redis-namespace (= 1.3.1)
-  redis-rails (= 3.2.3)
+  redis-rails (= 3.2.4)
   shoulda (~> 3.3.2)
   sidekiq (= 2.13.0)
   statsd-ruby (= 1.2.1)


### PR DESCRIPTION
Before this change, this app was running with a patched version
of the redis-activesupport gem which fixed a pretty nasty bug (
https://github.com/redis-store/redis-store/pull/166). This bug
was fixed upstream (https://github.com/redis-store/redis-store/pull/190)
and released with redis-activesupport 3.2.4 so we don't need to
maintain a separate branch any more.
