### PR TITLE
Timeout request if authentication takes too long

### DIFF
--- a/test/functional/application_controller_test.rb
+++ b/test/functional/application_controller_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class TestController < ApplicationController
+  def index
+    raise "should never reach this point because authentication should time out"
+  end
+
+  private
+  def authenticate_user!
+    sleep 1
+  end
+
+  def default_timeout_in_seconds
+    0.5
+  end
+end
+
+class ApplicationControllerTest < ActionController::TestCase
+  setup do
+    @controller = TestController.new
+
+    Rails.application.routes.draw do
+      match 'index' => "test#index"
+    end
+  end
+
+  teardown do
+    Rails.application.reload_routes!
+  end
+
+  should "acknowledge a valid request" do
+    get :index
+    assert_response 503
+  end
+end


### PR DESCRIPTION
It's possible that gds-sso authentication takes too long (>5 secs).
In those cases, if the request was made by an upstream system (as
opposed to an end-user), then the upstream request may time out.

Because apps within the stack are talking to each other over https,
the upstream request timeout doesn't necessarily cancel the request
in this app, but the upstream system retries, so this scenario can lead
to multiple successful support app requests (and hence data duplication).

This change times out authentication after several seconds (3 by default).
