### PR TITLE
Don't use a read-only field in Zd ticket creation

### DIFF
--- a/features/step_definitions/zendesk_steps.rb
+++ b/features/step_definitions/zendesk_steps.rb
@@ -22,7 +22,7 @@ Then /^the ticket is tagged with "(.*?)"$/ do |expected_tags|
 end
 
 Then /^the description on the ticket is:$/ do |expected_comment_string|
-  assert_created_ticket_has(description: expected_comment_string)
+  assert_created_ticket_has(comment: expected_comment_string)
 end
 
 Then /^the time constraints on the ticket are:$/ do |ticket_properties_table|

--- a/lib/zendesk_tickets.rb
+++ b/lib/zendesk_tickets.rb
@@ -10,6 +10,6 @@ class ZendeskTickets
       :fields => [{"id" => GDSZendesk::FIELD_MAPPINGS[:needed_by_date],  "value" => ticket_to_raise.needed_by_date},
                   {"id" => GDSZendesk::FIELD_MAPPINGS[:not_before_date], "value" => ticket_to_raise.not_before_date}],
       :tags => ticket_to_raise.tags,
-      :description => ticket_to_raise.comment})
+      :comment => ticket_to_raise.comment})
   end
 end


### PR DESCRIPTION
According to the [Zendesk changes roadmap](http://developer.zendesk.com/documentation/rest_api/changes_roadmap.html#january-2,-2014,), the description field
on tickets is read-only and shouldn't be used during ticket creation.
The 'comment' field should be used instead.

Without this change, Zendesk ticket creation will stop working in early Feb.
