### PR TITLE
Capture URL with service feedback

### DIFF
--- a/lib/support/requests/anonymous/service_feedback.rb
+++ b/lib/support/requests/anonymous/service_feedback.rb
@@ -4,11 +4,12 @@ module Support
   module Requests
     module Anonymous
       class ServiceFeedback < AnonymousContact
-        attr_accessible :details, :slug, :service_satisfaction_rating
+        attr_accessible :details, :slug, :service_satisfaction_rating, :url
 
         validates_presence_of :slug, :service_satisfaction_rating
         validates :details, length: { maximum: 2 ** 16 }
         validates_inclusion_of :service_satisfaction_rating, in: (1..5).to_a
+        validates :url, url: true, length: { maximum: 2048 }, allow_nil: true
       end
     end
   end

--- a/test/unit/support/requests/anonymous/service_feedback_test.rb
+++ b/test/unit/support/requests/anonymous/service_feedback_test.rb
@@ -10,6 +10,12 @@ module Support
         should validate_presence_of(:slug)
 
         should ensure_inclusion_of(:service_satisfaction_rating).in_range(1..5)
+
+        should allow_value("https://www.gov.uk/something").for(:url)
+        should allow_value(nil).for(:url)
+        should allow_value("http://" + ("a" * 2040)).for(:url)
+        should_not allow_value("http://" + ("a" * 2050)).for(:url)
+        should_not allow_value("http://bla.example.org:9292/méh/fào?bar").for(:url)
       end
     end
   end


### PR DESCRIPTION
This change allows using the URL of the page which generated the service
feedback as the anchor in the feedback explorer.

This PR completes the service URL feedback propagation (https://github.com/alphagov/frontend/pull/514, https://github.com/alphagov/feedback/pull/108).
