### PR TITLE
Bugfix to remote sign-out after gds-sso version bump

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,12 @@ class User < OpenStruct
   def self.where(options)
     uid = options[:uid]
     auth_hash = Rails.cache.fetch(prefixed_key(uid))
-    auth_hash ? [ User.new(auth_hash) ] : []
+    return [] unless auth_hash && user_matches?(options, User.new(auth_hash))
+    [ User.new(auth_hash) ]
+  end
+
+  def self.user_matches?(options, user)
+    options.all? { |key, value| user.send(key.to_sym) == value }
   end
 
   def self.create!(auth_hash, options={})

--- a/test/unit/models/user_test.rb
+++ b/test/unit/models/user_test.rb
@@ -26,7 +26,7 @@ class UserTest < Test::Unit::TestCase
     user.update_attribute(:remotely_signed_out, true)
     assert user.remotely_signed_out?
 
-    assert User.where(uid: "12345").first.remotely_signed_out?
+    assert User.where(uid: "12345", remotely_signed_out: false).empty?
   end
 
   should "support mass updating of attributes" do


### PR DESCRIPTION
This is needed for [remote sign-out to work properly](https://github.com/alphagov/gds-sso/blob/master/lib/gds-sso/warden_config.rb#L30).
