### PR TITLE
Postprocess service feedback records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'gds-sso', '9.2.0'
 gem 'cancan', '1.6.9'
 gem 'jquery-rails'
 gem 'jquery-ui-rails', '2.0.2'
-gem 'plek', '1.1.0'
+gem 'plek', '1.7.0'
 gem 'formtastic-bootstrap', '2.1.1'
 gem 'validates_timeliness', '3.0.14'
 if ENV['GDS_ZENDESK_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,8 +162,7 @@ GEM
       multi_json (~> 1.3)
       oauth2 (~> 0.9.3)
       omniauth (~> 1.2)
-    plek (1.1.0)
-      builder
+    plek (1.7.0)
     poltergeist (0.7.0)
       capybara (~> 1.1)
       childprocess (~> 0.3)
@@ -307,7 +306,7 @@ DEPENDENCIES
   logstasher (= 0.4.1)
   mocha (= 0.13.3)
   mysql2 (= 0.3.14)
-  plek (= 1.1.0)
+  plek (= 1.7.0)
   poltergeist (= 0.7.0)
   quiet_assets (= 1.0.2)
   rails (= 3.2.16)

--- a/db/migrate/20140205172712_fix_service_feedback_records.rb
+++ b/db/migrate/20140205172712_fix_service_feedback_records.rb
@@ -1,0 +1,9 @@
+class FixServiceFeedbackRecords < ActiveRecord::Migration
+  def up
+    ActiveRecord::Base.connection.execute("UPDATE anonymous_contacts SET slug = REPLACE(slug,'done/','')")
+    ActiveRecord::Base.connection.execute("UPDATE anonymous_contacts
+                                              SET url = CONCAT('#{Plek.new.website_root}/done/', slug)
+                                            WHERE type = 'Support::Requests::Anonymous::ServiceFeedback'
+                                              AND url is null")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131107150757) do
+ActiveRecord::Schema.define(:version => 20140205172712) do
 
   create_table "anonymous_contacts", :force => true do |t|
     t.string   "type"


### PR DESCRIPTION
This change brings the existing stored service feedback records
to be consistent with the changes introduced by https://github.com/alphagov/frontend/pull/514

Plek has been bumped so that `Plek#website_root` can be used in the migration.
