### PR TITLE
Feedex: handle invalid URLs

### DIFF
--- a/lib/support/requests/anonymous/anonymous_contact.rb
+++ b/lib/support/requests/anonymous/anonymous_contact.rb
@@ -31,7 +31,7 @@ module Support
         end
 
         def self.find_all_starting_with_path(path)
-          where("url is not null and url like ?", "%" + path + "%").free_of_personal_info.order("created_at desc").select { |pr| pr.path.start_with?(path) }
+          where("url is not null and url like ?", "%" + path + "%").free_of_personal_info.order("created_at desc").select { |pr| pr.path && pr.path.start_with?(path) }
         end
 
         private

--- a/test/unit/support/requests/anonymous/anonymous_contact_test.rb
+++ b/test/unit/support/requests/anonymous/anonymous_contact_test.rb
@@ -60,6 +60,12 @@ module Support
             assert result.include?(b)
           end
 
+          should "ignore feedback with invalid URLs" do
+            contact(url: "https://www.gov.uk/abc def")
+
+            assert_equal [], TestContact.find_all_starting_with_path("/abc")
+          end
+
           should "return the results in reverse chronological order" do
             a, b, c = contact, contact, contact
             a.created_at = Time.now - 1.hour


### PR DESCRIPTION
Currently, the feedex search functionality assumes that URLs are valid.
Unfortunately, the LongFormContact class permits the creation of invalid URLs.
This is a work-around until the validations are tightened up and the data is cleaned
up.
