### PR TITLE
Feedex: limit the maximum number of results

### DIFF
--- a/lib/support/requests/anonymous/anonymous_contact.rb
+++ b/lib/support/requests/anonymous/anonymous_contact.rb
@@ -5,6 +5,8 @@ module Support
   module Requests
     module Anonymous
       class AnonymousContact < ActiveRecord::Base
+        MAXIMUM_NUMBER_OF_RESULTS = 5000
+
         attr_accessible :referrer, :javascript_enabled, :user_agent, :personal_information_status
         validates :referrer, url: true, allow_nil: true
 
@@ -31,7 +33,11 @@ module Support
         end
 
         def self.find_all_starting_with_path(path)
-          where("url is not null and url like ?", "%" + path + "%").free_of_personal_info.order("created_at desc").select { |pr| pr.path && pr.path.start_with?(path) }
+          where("url is not null and url like ?", "%" + path + "%").
+            free_of_personal_info.
+            order("created_at desc").
+            limit(MAXIMUM_NUMBER_OF_RESULTS).
+            select { |pr| pr.path && pr.path.start_with?(path) }
         end
 
         private


### PR DESCRIPTION
Trying to show too many results in feedex will cause the app to time out.
This change introduces a limit (max 5000 results) to stop this from happening.
The limit is a somewhat arbitrary number, but should be enough results to provide
some insight but not enough to crash the app.

This limiting will become less relevant when filtering options (eg by date) become available.
