### PR TITLE
Don't report on spam to the performance platform

### DIFF
--- a/lib/support/requests/anonymous/service_feedback_aggregated_metrics.rb
+++ b/lib/support/requests/anonymous/service_feedback_aggregated_metrics.rb
@@ -43,7 +43,7 @@ module Support
         end
 
         def filter_by_day_and_slug
-          ServiceFeedback.where(slug: @slug, created_at: time_interval)
+          ServiceFeedback.where(slug: @slug, created_at: time_interval).only_actionable
         end
 
         def time_interval


### PR DESCRIPTION
This change ensures that duplicates aren't reported on to the performance platform.
