### PR TITLE
Service feedback upload to PP: don't ignore 404s

### DIFF
--- a/app/workers/service_feedback_pp_uploader_worker.rb
+++ b/app/workers/service_feedback_pp_uploader_worker.rb
@@ -14,8 +14,6 @@ class ServiceFeedbackPPUploaderWorker
     )
     request_details = ServiceFeedbackAggregatedMetrics.new(Date.new(year, month, day), transaction_slug).to_h
     api.submit_service_feedback_day_aggregate(transaction_slug, request_details)
-  rescue GdsApi::HTTPNotFound
-    $statsd.increment("#{::STATSD_PREFIX}.#{transaction_slug}.404")
   end
 
   def self.run

--- a/test/unit/workers/service_feedback_pp_uploader_worker_test.rb
+++ b/test/unit/workers/service_feedback_pp_uploader_worker_test.rb
@@ -18,7 +18,7 @@ class ServiceFeedbackPPUploaderWorkerTest < ActiveSupport::TestCase
     ServiceFeedbackAggregatedMetrics.stubs(:new).
       with(Date.new(2013,2,10),"apply_carers_allowance").
       returns(stub(to_h: { some: "carers_allowance_data"}))
-    
+
     stub_post1 = stub_service_feedback_day_aggregate_submission("apply_carers_allowance", { some: "carers_allowance_data"})
     stub_post2 = stub_service_feedback_day_aggregate_submission("waste_carrier_or_broker_registration", { some: "waste_carrier_data"})
 
@@ -26,18 +26,5 @@ class ServiceFeedbackPPUploaderWorkerTest < ActiveSupport::TestCase
 
     assert_requested(stub_post1)
     assert_requested(stub_post2)
-  end
-
-  should "not raise an exception, increment a counter if PP upload returns 404" do
-    stub_service_feedback_bucket_unavailable_for("some_slug")
-    $statsd.expects(:increment).with("#{::STATSD_PREFIX}.some_slug.404")
-
-    Date.stubs(:yesterday).returns(Date.new(2013,2,10))
-    ServiceFeedback.stubs(:transaction_slugs).returns(["some_slug"])
-    ServiceFeedbackAggregatedMetrics.stubs(:new).
-      with(Date.new(2013,2,10),"some_slug").
-      returns(stub(to_h: { some: "waste_carrier_data"}))
-
-    assert_nothing_raised { ServiceFeedbackPPUploaderWorker.run }
   end
 end


### PR DESCRIPTION
This change reverts to the default gds-api-adapters behaviour
of blowing up when a 404 happens during an upload.

Previously, it was agreed with the PP team that when an upload failed
due to a 404 (ie the bucket was missing), it wasn't a problem that we
would lose the data for that day. Now, we would like to use the missing
data bucket exception as a prompt to go and create the bucket; also,
this means that sidekiq retries will ensure that no data is lost.
