### PR TITLE
Bump `gds-api-adapters`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'whenever', '0.9.0', require: false
 if ENV['API_DEV']
   gem "gds-api-adapters", :path => '../gds-api-adapters'
 else
-  gem "gds-api-adapters", "8.3.2"
+  gem "gds-api-adapters", "10.6.2"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (2.1.1)
       formtastic (~> 2.2)
-    gds-api-adapters (8.3.2)
+    gds-api-adapters (10.6.2)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -290,7 +290,7 @@ DEPENDENCIES
   capybara (= 1.1.2)
   cucumber-rails (= 1.3.0)
   formtastic-bootstrap (= 2.1.1)
-  gds-api-adapters (= 8.3.2)
+  gds-api-adapters (= 10.6.2)
   gds-sso (= 9.2.0)
   gds_zendesk (= 1.0.2)
   jquery-rails


### PR DESCRIPTION
This picks up better exception messaging when the upload of service feedback
to the PP fails because a dataset is missing.
