### PR TITLE
Remove sidekiq-starting rake task

### DIFF
--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -1,6 +1,0 @@
-desc "Start the sidekiq workers"
-namespace :jobs do
-  task :work do
-    exec("bundle exec sidekiq -C ./config/sidekiq.yml")
-  end
-end


### PR DESCRIPTION
This is no longer needed because `delayed_job_worker` is no longer being used in prod (`procfile_worker` is used instead, which uses `foreman`).
