### PR TITLE
Exclude all 404 problem reports from FeedEx

### DIFF
--- a/db/migrate/20140630065039_mark_all_404_problem_reports_as_non_actionable.rb
+++ b/db/migrate/20140630065039_mark_all_404_problem_reports_as_non_actionable.rb
@@ -1,0 +1,15 @@
+class MarkAll404ProblemReportsAsNonActionable < ActiveRecord::Migration
+  class AnonymousContact < ActiveRecord::Base; end
+
+  def up
+    AnonymousContact.
+      where(what_wrong: "broken link (404)").
+      update_all(is_actionable: false, reason_why_not_actionable: 'non-actionable broken link reports')
+  end
+
+  def down
+    AnonymousContact.
+      where(what_wrong: "broken link (404)").
+      update_all(is_actionable: true, reason_why_not_actionable: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140417161720) do
+ActiveRecord::Schema.define(:version => 20140630065039) do
 
   create_table "anonymous_contacts", :force => true do |t|
     t.string   "type"


### PR DESCRIPTION
We're no longer capturing user feedback on the GOV.UK 404 pages (because there are better
means to capture this information, like using GA 404 page visits, or looking at CDN logs).
404 problem reports are usually most often typos by the user, as opposed to
problems with the content, and haven't proven particularly useful to content designers.
