### PR TITLE
Add style guide (from govuk_admin_template)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,8 +11,7 @@ module ApplicationHelper
   end
 
   def in_feedex?
-    current_page?(controller: "anonymous_feedback/explore", action: :new) ||
-      current_page?(controller: 'anonymous_feedback', action: :index)
+    current_page?('/anonymous_feedback')
   end
 
   def nav_link_to(section, options = { is_active: false })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 require 'support/navigation/section_groups'
 
 Support::Application.routes.draw do
+  mount GovukAdminTemplate::Engine, at: "/style-guide", as: "style_guide"
+
   Support::Navigation::SectionGroups.new.all_request_class_names.each do |request_class_name|
     resource request_class_name.underscore, only: [:new, :create]
   end


### PR DESCRIPTION
This allows previewing how template styles mix with the application styles.
The style guide is available under `/style-guide`.

The change to the application helper fixes a bug caused by `current_page?`
being unable to deal with having both a module called `AnonymousFeedback`
and a controller called `AnonymousFeedbackController`.
