### PR TITLE
Make FeedEx available to all users by default

### DIFF
--- a/lib/support/permissions/ability.rb
+++ b/lib/support/permissions/ability.rb
@@ -15,8 +15,8 @@ module Support
         can :create, [ CreateOrChangeUserRequest, RemoveUserRequest ] if user.has_permission?('user_managers')
         can :create, [ FoiRequest, Anonymous::ProblemReport, Anonymous::LongFormContact, NamedContact ] if user.has_permission?('api_users')
 
-        can :read, Anonymous::AnonymousContact if user.has_permission?('feedex')
-        can :create, Support::Requests::Anonymous::Explore if user.has_permission?('feedex')
+        can :read, Anonymous::AnonymousContact
+        can :create, Support::Requests::Anonymous::Explore
         can :create, [GeneralRequest, AnalyticsRequest, ContentAdviceRequest, TechnicalFaultReport, UnpublishContentRequest]
       end
     end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -5,7 +5,7 @@ namespace :users do
       "uid" => 'dummy-user',
       "name" => 'Ms Example',
       "email" => 'example@example.com',
-      "permissions" => ['single_points_of_contact', 'feedex', 'api_users']
+      "permissions" => ['single_points_of_contact', 'api_users']
     )
     puts "Created dummy user: #{user}"
   end

--- a/spec/controllers/anonymous_feedback/explore_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/explore_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe AnonymousFeedback::ExploreController, :type => :controller do
   before do
-    login_as create(:feedex_user)
+    login_as create(:user)
   end
 
   it "shows the new form again for invalid requests" do

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe AnonymousFeedbackController, :type => :controller do
   before do
-    login_as create(:feedex_user)
+    login_as create(:user)
   end
 
   context "invalid input" do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,7 +4,6 @@ FactoryGirl.define do
     sequence(:email) {|n| "person-#{n}@example.com" }
     permissions { [ "signin" ] }
 
-    factory :feedex_user do permissions { [ "signin", "feedex" ] } end
     factory :api_user do permissions { [ "signin", "api_users" ] } end
     factory :user_manager do permissions { [ "signin", "user_managers" ] } end
     factory :content_requester do permissions { [ "signin", "content_requesters" ] } end

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature "Exploring anonymous feedback" do
   background do
-    login_as create(:feedex_user)
+    login_as create(:user)
   end
 
   scenario "exploring feedback by URL" do

--- a/spec/features/redirects_spec.rb
+++ b/spec/features/redirects_spec.rb
@@ -3,7 +3,7 @@ require 'uri'
 
 describe "legacy feedex URL redirect" do
   before do
-    login_as create(:feedex_user)
+    login_as create(:user)
   end
 
   it "redirects the legacy feedex landing page to the current feedex landing page" do

--- a/spec/features/user_satisfaction_survey_spec.rb
+++ b/spec/features/user_satisfaction_survey_spec.rb
@@ -6,7 +6,7 @@ feature "User satisfaction survey submissions" do
   # I want to record and view bugs, gripes and improvement suggestions submitted by the service users
 
   background do
-    login_as create(:feedex_user)
+    login_as create(:user)
     the_date_is("2013-02-28")
   end
 

--- a/spec/integration/deduplication_spec.rb
+++ b/spec/integration/deduplication_spec.rb
@@ -5,7 +5,7 @@ require 'deduplication_worker'
 
 describe "de-duplication" do
   before do
-    login_as create(:feedex_user)
+    login_as create(:user)
   end
 
   it "flags and removes duplicate service feedback from results" do

--- a/spec/models/support/permissions/ability_spec.rb
+++ b/spec/models/support/permissions/ability_spec.rb
@@ -14,13 +14,6 @@ module Support
         it { should be_able_to(:create, Support::Requests::CampaignRequest) }
         it { should be_able_to(:create, Support::Requests::ContentChangeRequest) }
       end
-
-      context "for a FeedEx user" do
-        let(:user_permissions) { ["feedex"] }
-
-        it { should be_able_to(:read, Support::Requests::Anonymous::ProblemReport) }
-        it { should be_able_to(:create, Support::Requests::Anonymous::Explore) }
-      end
     end
   end
 end

--- a/spec/models/support/requests/permissions_spec.rb
+++ b/spec/models/support/requests/permissions_spec.rb
@@ -94,15 +94,6 @@ module Support
         ] }
         it_behaves_like "a role"
       end
-
-      context "for feedex role" do
-        subject { create(:feedex_user) }
-        it "can access anonymous feedback" do
-          expect(subject).to be_able_to(:read, Anonymous::ProblemReport)
-          expect(subject).to be_able_to(:read, Anonymous::LongFormContact)
-          expect(subject).to be_able_to(:read, Anonymous::ServiceFeedback)
-        end
-      end
     end
   end
 end

--- a/spec/views/support/_new_request_links.html.erb_spec.rb
+++ b/spec/views/support/_new_request_links.html.erb_spec.rb
@@ -24,14 +24,4 @@ describe 'support/_new_request_links' do
     render "support/new_request_links", section_groups: section_groups
     expect(rendered).to have_selector("#feedex a", text: "Feedback explorer")
   end
-
-  context "for a user who doesn't have access to feedex" do
-    let(:user) { build(:user_who_cannot_access_anything) }
-
-    it "greys out the feedex link" do
-      render "support/new_request_links", section_groups: section_groups
-      expect(rendered).to have_selector("#feedex.disabled a")
-      expect(rendered).to have_selector("ul.dropdown-menu li.disabled")
-    end
-  end
 end


### PR DESCRIPTION
FeedEx was initially fenced off behind a specific permission
while its usefulness was being tested. Since then, there's been sufficient
uptake of the available features to warrant a wider release.

This change allows anyone with a GOV.UK Signon account to browse
anonymous feedback left on GOV.UK.
