### PR TITLE
Create emergency contact details and navigation

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -31,3 +31,14 @@ thead {
 .list-group.disabled {
   color: $nav-disabled-link-hover-color;
 }
+
+.danger-callout {
+  border-left-color: #d9534f;
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+}
+
+.rounded-callout {
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+}

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -1,5 +1,6 @@
 require 'sidekiq'
 require 'support/navigation/feedex_section'
+require 'support/navigation/emergency_contact_details_section'
 
 class SupportController < AuthorisationController
   include Support::Navigation
@@ -8,8 +9,14 @@ class SupportController < AuthorisationController
   skip_before_filter :authenticate_support_user!, only: [:queue_status]
 
   def landing
-    all_sections = SectionGroups.new(current_user).all_sections + [ FeedexSection.new(current_user) ]
+    all_sections = SectionGroups.new(current_user).all_sections +
+      [ FeedexSection.new(current_user), EmergencyContactDetailsSection.new(current_user) ]
     @accessible_sections, @inaccessible_sections = all_sections.partition(&:accessible?)
+  end
+
+  def emergency_contact_details
+    @primary_contact_details = EMERGENCY_CONTACT_DETAILS[:primary_contacts]
+    @secondary_contact_details = EMERGENCY_CONTACT_DETAILS[:secondary_contacts]
   end
 
   def acknowledge

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,5 @@
 require 'support/navigation/feedex_section'
+require 'support/navigation/emergency_contact_details_section'
 require 'support/navigation/section_groups'
 
 module ApplicationHelper
@@ -8,6 +9,10 @@ module ApplicationHelper
 
   def feedex_section
     Support::Navigation::FeedexSection.new(current_user)
+  end
+
+  def emergency_contact_details_section
+    Support::Navigation::EmergencyContactDetailsSection.new(current_user)
   end
 
   def in_feedex?

--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -1,0 +1,99 @@
+<%= content_for :page_title, "Emergency Contact Details" %>
+<%= content_for :header, "GOV.UK Emergency Contact Details" %>
+
+<% breadcrumb :emergency_contact_details %>
+
+<main class="add-bottom-padding">
+<p class="subtitle text-muted">Current at 1 July 2014</p>
+<section>
+  <blockquote class="bg-danger danger-callout">
+    <p>First read the guidance on <%= link_to "publishing procedures for national emergencies", "https://insidegovuk.blog.gov.uk/gov-uk-support-requests-our-processes-and-response-times/#urgent" %> and <%= link_to "GOV.UK contact procedures", "https://insidegovuk.blog.gov.uk/2013/10/24/gov-uk-support-requests-a-brief-guide-to-our-standardsurgent/" %>.</p>
+  </blockquote>
+</section>
+<section class="add-bottom-padding add-top-padding">
+  <h2 class="add-bottom-padding">Primary Contacts</h2>
+
+  <h3>National emergencies</h3>
+  <div class="row">
+    <div class="col-md-12">
+      <p class="lead remove-bottom-margin"><%= @primary_contact_details[:national_emergencies][:phone] %></p>
+      <p class="text-muted">24 hours, 7 days a week</p>
+    </div>
+    <div class="col-md-6">
+      <ul>
+        <li>Use for sudden, critical national emergencies such as terrorist attacks.</li>
+        <li>This number will put you in contact with the GOV.UK operations manager, who will establish your identity and put the GOV.UK site into ‘emergency’ mode.</li>
+        <li>For use only by the communications coordinator in the lead crisis response department.</li>
+        <li><%= link_to "Further information and guidance", "https://insidegovuk.blog.gov.uk/gov-uk-national-emergency-publishing-procedures/" %>.</li>
+      </ul>
+    </div>
+  </div>
+
+  <h3>Major technical problems with GOV.UK site</h3>
+  <div class="row">
+    <div class="col-md-12">
+      <p class="lead remove-bottom-margin"><%= @primary_contact_details[:major_technical_problems][:phone] %></p>
+      <p class="text-muted">24 hours, 7 days a week</p>
+    </div>
+    <div class="col-md-6">
+      <ul>
+        <li>Use for critical, high-profile technical issues with the GOV.UK site - eg pages not loading or search not working.</li>
+        <li>This number will put you in contact with the GOV.UK operations manager, who will advise on next steps.</li>
+      </ul>
+    </div>
+  </div>
+
+  <h3>Urgent changes to GOV.UK mainstream content</h3>
+  <div class="row">
+    <div class="col-md-12">
+      <p class="lead remove-bottom-margin"><%= @primary_contact_details[:urgent_mainstream_content_change][:phone] %></p>
+      <p class="text-muted">Daily, 8am - 10pm<br>(including bank holidays and weekends)</p>
+    </div>
+    <div class="col-md-6">
+      <ul>
+        <li>Use to request urgent GOV.UK content updates in cases in which the public or government is facing immediate and significant financial, legal, or physical risk.</li>
+        <li>This number will put you in touch with a GOV.UK mainstream content manager.</li>
+        <li><%= link_to "Create a content request on the internal support form", new_content_change_request_path %> before you phone.</li>
+        <li><%= link_to "Read the full guidelines", "https://insidegovuk.blog.gov.uk/gov-uk-support-requests-our-processes-and-response-times/" %>.</li>
+      </ul>
+    </div>
+  </div>
+
+  <h3>Urgent changes to GOV.UK government content</h3>
+  <div class="row">
+    <div class="col-md-12">
+      <p class="lead remove-bottom-margin"><%= @primary_contact_details[:urgent_department_content_change][:phone] %></p>
+      <p class="text-muted">Monday to Friday, 9am - 5.30pm<br>(excluding bank holidays and weekends)</p>
+    </div>
+    <div class="col-md-6">
+      <ul>
+        <li>Use if you are unable to publish at a critical time, or to make changes to government content managed by GDS.</li>
+        <li>This number will put you in touch with a GOV.UK Departments and Policy content manager.</li>
+        <li><%= link_to "Create a content request on the internal support form", new_content_change_request_path %> before you phone.</li>
+        <li><%= link_to "Read the full guidelines", "https://insidegovuk.blog.gov.uk/gov-uk-support-requests-our-processes-and-response-times/" %>.</li>
+        </ul>
+    </div>
+  </div>
+</section>
+
+<section class="add-bottom-padding add-top-padding">
+  <h2>Secondary Contacts</h2>
+  <blockquote class="rounded-callout">
+    <p>If you are unable to get an answer on the primary numbers, try an alternative number.</p>
+  </blockquote>
+  <div class="row">
+    <div class="col-md-6">
+      <p><%= @secondary_contact_details[:operations_manager][:name] %><br>
+      <span class="text-muted">GOV.UK Operations Manager</span></p>
+      <%= mail_to @secondary_contact_details[:operations_manager][:email] %>
+      <p><%= @secondary_contact_details[:operations_manager][:phone] %></p>
+    </div>
+    <div class="col-md-6">
+      <p><%= @secondary_contact_details[:deputy_director][:name] %><br>
+      <span class="text-muted">GOV.UK Deputy Director</span></p>
+      <%= mail_to @secondary_contact_details[:deputy_director][:email] %>
+      <p><%= @secondary_contact_details[:deputy_director][:phone] %></p>
+    </div>
+  </div>
+</section>
+</main>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -16,3 +16,8 @@ crumb :anonymous_feedback_by_path do |path|
   link "Feedback for “#{path}”"
   parent :feedex
 end
+
+crumb :emergency_contact_details do
+  link "Emergency contact details", emergency_contact_details_path
+  parent :root
+end

--- a/config/emergency_contact_details.yml
+++ b/config/emergency_contact_details.yml
@@ -1,0 +1,19 @@
+primary_contacts:
+  national_emergencies:
+    phone: 05555 555555
+  major_technical_problems:
+    phone: 05555 555555
+  urgent_mainstream_content_change:
+    phone: 05555 555555
+  urgent_department_content_change:
+    phone: 05555 555555
+
+secondary_contacts:
+  deputy_director:
+    name: Billy Director
+    phone: 05555 555555
+    email: billy.director@email.uk
+  operations_manager:
+    name: Bob Manager
+    phone: 05555 555556
+    email: bob.manager@email.uk

--- a/config/initializers/emergency_contact_details.rb
+++ b/config/initializers/emergency_contact_details.rb
@@ -1,0 +1,2 @@
+config = File.join(Rails.root, "config", "emergency_contact_details.yml")
+EMERGENCY_CONTACT_DETAILS = ActiveSupport::HashWithIndifferentAccess.new(YAML.load(File.open(config)))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,11 @@ Support::Application.routes.draw do
     post :explore, to: "explore#create", format: false
   end
 
+  get "emergency-contact-details",
+    to: 'support#emergency_contact_details',
+    format: false,
+    as: "emergency_contact_details"
+
   resources :anonymous_feedback, only: :index, format: false
 
   match "acknowledge" => "support#acknowledge"

--- a/lib/support/navigation/emergency_contact_details_section.rb
+++ b/lib/support/navigation/emergency_contact_details_section.rb
@@ -1,0 +1,27 @@
+module Support
+  module Navigation
+    class EmergencyContactDetailsSection
+      include ActionView::Helpers::UrlHelper
+
+      def initialize(current_user)
+        @current_user = current_user
+      end
+
+      def label
+        "Emergency contact details"
+      end
+
+      def description
+        "Contact GOV.UK in an emergency"
+      end
+
+      def link
+        Rails.application.routes.url_helpers.emergency_contact_details_path
+      end
+
+      def accessible?
+        @current_user.can? :read, self.class
+      end
+    end
+  end
+end

--- a/lib/support/permissions/ability.rb
+++ b/lib/support/permissions/ability.rb
@@ -1,6 +1,7 @@
 require 'cancan/ability'
 require 'support/requests'
 require 'support/requests/anonymous/explore'
+require 'support/navigation/emergency_contact_details_section'
 
 module Support
   module Permissions
@@ -16,6 +17,7 @@ module Support
         can :create, [ FoiRequest, Anonymous::ProblemReport, Anonymous::LongFormContact, NamedContact ] if user.has_permission?('api_users')
 
         can :read, Anonymous::AnonymousContact
+        can :read, Support::Navigation::EmergencyContactDetailsSection
         can :create, Support::Requests::Anonymous::Explore
         can :create, [GeneralRequest, AnalyticsRequest, ContentAdviceRequest, TechnicalFaultReport, UnpublishContentRequest]
       end

--- a/spec/features/emergency_contact_details_spec.rb
+++ b/spec/features/emergency_contact_details_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+feature "Emergency contact details" do
+  # In order to recover from an emergency
+  # As a departmental user
+  # I want to phone somebody at GDS
+
+  background do
+    login_as create(:user)
+  end
+
+  scenario "access the emergency contact details" do
+    visit '/'
+
+    click_on "Emergency contact details"
+
+    expect(page).to have_content("05555 555555") # Billy Director
+    expect(page).to have_content("05555 555556") # Bob Manager
+  end
+end


### PR DESCRIPTION
**This must be merged first: https://github.gds/gds/alphagov-deployment/pull/698**

Emergency contact details for GOV.UK operations need to be added to the Support app behind Signon. These used to reside behind the Government Communications Network. However, this is being closed down. The information will also be held in the government Basecamp instance in case Signon goes down.

The new feature includes a navigation link on the Support app landing page, and a new page with the contact details.

The actual phone/email/names are held in a separate `.yml` file to be included elsewhere when deployed to production.

![home - gov uk support](https://cloud.githubusercontent.com/assets/1482862/3954274/9e8b9936-26f4-11e4-95cb-455eaada3eae.png)

Clicking the new link takes the user to the emergency-contact-details page

![emergency contact details - gov uk support 1](https://cloud.githubusercontent.com/assets/1482862/3954290/bd09c8f6-26f4-11e4-8269-114a025d35d5.png)

The page contains the required emergency contact routes for four primary emergency categories, and secondary contact details in case the primary ones are not contactable.

I paired with @benilovj on this.
