### PR TITLE
Bump gds-sso to 9.4.0, pick up User specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 gem 'mysql2', '0.3.14'
 gem "airbrake", "3.1.15"
 
-gem 'gds-sso', '9.3.0'
+gem 'gds-sso', '9.4.0'
 gem 'cancan', '1.6.9'
 gem 'jquery-ui-rails', '4.2.1'
 gem 'plek', '1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    gds-sso (9.3.0)
+    gds-sso (9.4.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -279,7 +279,7 @@ DEPENDENCIES
   factory_girl_rails (= 4.4.1)
   formtastic-bootstrap (= 3.0.0)
   gds-api-adapters (= 10.8.0)
-  gds-sso (= 9.3.0)
+  gds-sso (= 9.4.0)
   gds_zendesk (= 1.0.2)
   govuk_admin_template (= 1.0.1)
   gretel (= 3.0.7)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'redis_client'
 
+require 'gds-sso/lint/user_spec'
+
 describe User, :type => :model do
   before do
     RedisClient.instance.connection.del "support-test:users-12345"
@@ -36,4 +38,6 @@ describe User, :type => :model do
 
     expect(User.where(uid: "12345").first.name).to eq("Z")
   end
+
+  it_behaves_like "a gds-sso user class"
 end


### PR DESCRIPTION
This reduces the risk of refactorings breaking the GDS SSO integration
when the `User` class is refactored or `gds-sso` is bumped.
