### PR TITLE
Anonymous feedback: use 'path' instead of 'url' everywhere

### DIFF
--- a/lib/support/requests/anonymous/anonymous_contact.rb
+++ b/lib/support/requests/anonymous/anonymous_contact.rb
@@ -9,15 +9,18 @@ module Support
         include WithPersonalInformationChecking
         include AnonymousContactValidations
 
-        attr_accessible :url, :path, :referrer, :javascript_enabled, :user_agent, :personal_information_status
+        attr_accessible :path, :referrer, :javascript_enabled, :user_agent, :personal_information_status
         attr_accessible :is_actionable, :reason_why_not_actionable
 
-        before_save :set_path_from_url
         before_save do |feedback|
           detect_personal_information_in(feedback.details, feedback.what_wrong, feedback.what_doing)
         end
 
         paginates_per 50
+
+        def url
+          path.present? ? Plek.new.website_root + path : nil
+        end
 
         def requester
           Requester.anonymous
@@ -30,11 +33,6 @@ module Support
             only_actionable.
             order("created_at desc")
         }
-
-        private
-        def set_path_from_url
-          self.path = URI.parse(url).path unless url.nil?
-        end
       end
     end
   end

--- a/lib/support/requests/anonymous/corporate_content_problem_report_aggregated_metrics.rb
+++ b/lib/support/requests/anonymous/corporate_content_problem_report_aggregated_metrics.rb
@@ -41,7 +41,7 @@ module Support
       end
 
       class TopUrls
-        NUMBER_OF_URLS_PER_ORG = 5
+        NUMBER_OF_PATHS_PER_ORG = 5
 
         def initialize(first_day_of_period, period_in_question)
           @first_day_of_period = first_day_of_period
@@ -50,7 +50,7 @@ module Support
 
         def to_a
           top_urls = distinct_org_acronyms.inject([]) do |list, org_acronym|
-            list + top_urls_for(org_acronym).zip(1..NUMBER_OF_URLS_PER_ORG)
+            list + top_urls_for(org_acronym).zip(1..NUMBER_OF_PATHS_PER_ORG)
           end
           top_urls.map do |top_url, rank|
             {
@@ -58,7 +58,7 @@ module Support
               "_timestamp" => @first_day_of_period.to_time.iso8601,
               "period" => "month",
               "organisation_acronym" => top_url.page_owner,
-              "comment_count" => top_url.number_of_urls,
+              "comment_count" => top_url.number_of_paths,
               "url" => top_url.url
             }
           end
@@ -70,10 +70,10 @@ module Support
             only_actionable.
             where(created_at: @period_in_question).
             where(page_owner: org_acronym).
-            select("page_owner, url, count(*) as number_of_urls").
-            group(:url).
-            order("number_of_urls desc, url asc").
-            limit(NUMBER_OF_URLS_PER_ORG)
+            select("page_owner, path, count(*) as number_of_paths").
+            group(:path).
+            order("number_of_paths desc, path asc").
+            limit(NUMBER_OF_PATHS_PER_ORG)
         end
 
         def distinct_org_acronyms

--- a/lib/support/requests/anonymous/problem_report.rb
+++ b/lib/support/requests/anonymous/problem_report.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'plek'
 require 'support/requests/anonymous/anonymous_contact'
 
 module Support

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -27,7 +27,7 @@ describe AnonymousFeedbackController, :type => :controller do
       create(:problem_report,
         what_wrong: "A",
         what_doing: "B",
-        url: "https://www.gov.uk/tax-disc",
+        path: "/tax-disc",
         referrer: "https://www.gov.uk/browse",
         user_agent: "Safari",
       )
@@ -40,7 +40,7 @@ describe AnonymousFeedbackController, :type => :controller do
       end
 
       it "displays at most 50 results per page" do
-        create_list(:problem_report, 70, url: "https://www.gov.uk/tax-disc")
+        create_list(:problem_report, 70, path: "/tax-disc")
         get :index, path: "/tax-disc"
         expect(assigns["feedback"]).to have(50).items
       end
@@ -59,7 +59,7 @@ describe AnonymousFeedbackController, :type => :controller do
           "type" => "problem-report",
           "what_wrong" => "A",
           "what_doing" => "B",
-          "url" => "https://www.gov.uk/tax-disc",
+          "url" => "http://www.dev.gov.uk/tax-disc",
           "referrer" => "https://www.gov.uk/browse",
           "user_agent" => "Safari",
         )
@@ -70,7 +70,7 @@ describe AnonymousFeedbackController, :type => :controller do
   context "valid input, long-form feedback" do
     let!(:feedback) do
       create(:long_form_contact,
-        url: "https://www.gov.uk/tax-disc",
+        path: "/tax-disc",
         referrer: "https://www.gov.uk/contact/govuk",
         details: "Abc def",
         user_agent: "Safari",
@@ -96,7 +96,7 @@ describe AnonymousFeedbackController, :type => :controller do
           "id" => feedback.id,
           "type" => "long-form-contact",
           "details" => "Abc def",
-          "url" => "https://www.gov.uk/tax-disc",
+          "url" => "http://www.dev.gov.uk/tax-disc",
           "referrer" => "https://www.gov.uk/contact/govuk",
           "user_agent" => "Safari",
         )
@@ -108,7 +108,7 @@ describe AnonymousFeedbackController, :type => :controller do
     let!(:feedback) do
       create(:service_feedback,
         slug: "apply-carers-allowance",
-        url: "https://www.gov.uk/done/apply-carers-allowance",
+        path: "/done/apply-carers-allowance",
         details: "It's great",
         service_satisfaction_rating: 5,
         user_agent: "Safari",
@@ -135,7 +135,7 @@ describe AnonymousFeedbackController, :type => :controller do
           "type" => "service-feedback",
           "slug" => "apply-carers-allowance",
           "details" => "It's great",
-          "url" => "https://www.gov.uk/done/apply-carers-allowance",
+          "url" => "http://www.dev.gov.uk/done/apply-carers-allowance",
           "service_satisfaction_rating" => 5,
           "user_agent" => "Safari",
         )

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -7,7 +7,7 @@ feature "Exploring anonymous feedback" do
 
   scenario "exploring feedback by URL" do
     create(:problem_report,
-      url: "https://www.gov.uk/tax-disc",
+      path: "/tax-disc",
       created_at: DateTime.parse("2013-01-01"),
       what_doing: "logging in",
       what_wrong: "error",
@@ -15,7 +15,7 @@ feature "Exploring anonymous feedback" do
     )
 
     create(:problem_report,
-      url: "https://www.gov.uk/vat-rates",
+      path: "/vat-rates",
       created_at: DateTime.parse("2013-02-01"),
       what_doing: "looking at rates",
       what_wrong: "standard rate is wrong",
@@ -23,7 +23,7 @@ feature "Exploring anonymous feedback" do
     )
 
     create(:problem_report,
-      url: "https://www.gov.uk/vat-rates",
+      path: "/vat-rates",
       created_at: DateTime.parse("2013-03-01"),
       what_doing: "looking at 3rd paragraph",
       what_wrong: "typo in 2rd word",

--- a/spec/integration/corporate_content_problem_report_stats_spec.rb
+++ b/spec/integration/corporate_content_problem_report_stats_spec.rb
@@ -24,7 +24,7 @@ describe "corporate content problem report stats" do
         "period" => "month",
         "organisation_acronym" => "dft",
         "comment_count" => 1,
-        "url" => "https://www.gov.uk/abc"
+        "url" => "http://www.dev.gov.uk/abc"
       }
     ])
 
@@ -32,7 +32,7 @@ describe "corporate content problem report stats" do
 
     create(:problem_report,
       what_wrong: "this service is great",
-      url: "https://www.gov.uk/abc",
+      path: "/abc",
       page_owner: "dft"
     )
 

--- a/spec/models/support/requests/anonymous/anonymous_contact_spec.rb
+++ b/spec/models/support/requests/anonymous/anonymous_contact_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 require 'support/requests/anonymous/anonymous_contact'
 
 class TestContact < Support::Requests::Anonymous::AnonymousContact
-  attr_accessible :details, :what_wrong, :what_doing, :url
+  attr_accessible :details, :what_wrong, :what_doing, :path
 end
 
 module Support
   module Requests
     module Anonymous
       describe AnonymousContact, :type => :model do
-        DEFAULTS = { javascript_enabled: true, url: "https://www.gov.uk/tax-disc", path: "/tax-disc" }
+        DEFAULTS = { javascript_enabled: true, path: "/tax-disc" }
 
         def new_contact(options = {})
           TestContact.new(DEFAULTS.merge(options))
@@ -41,20 +41,6 @@ module Support
           expect(contact(what_wrong: "my NI number is QQ 12 34 56 A thanks").personal_information_status).to eq("suspected")
         end
 
-        it "stores the relative path of the page from which the feedback was lodged" do
-          contact = new_contact(url: "https://www.gov.uk/vat-rates")
-          contact.save!
-          expect(contact.path).to eq("/vat-rates")
-        end
-
-        context "URLs" do
-          it { should allow_value("https://www.gov.uk/something").for(:url) }
-          it { should allow_value(nil).for(:url) }
-          it { should allow_value("http://" + ("a" * 2040)).for(:url) }
-          it { should_not allow_value("http://" + ("a" * 2050)).for(:url) }
-          it { should_not allow_value("http://bla.example.org:9292/méh/fào?bar").for(:url) }
-        end
-
         context "path" do
           it { should allow_value("/something").for(:path) }
           it { should allow_value(nil).for(:path) }
@@ -73,9 +59,9 @@ module Support
 
         context "#find_all_starting_with_path" do
           it "finds urls beginning with the given path" do
-            a = contact(url: "https://www.gov.uk/some-calculator/y/abc")
-            b = contact(url: "https://www.gov.uk/some-calculator/y/abc/x")
-            c = contact(url: "https://www.gov.uk/tax-disc")
+            a = contact(path: "/some-calculator/y/abc")
+            b = contact(path: "/some-calculator/y/abc/x")
+            c = contact(path: "/tax-disc")
 
             result = TestContact.find_all_starting_with_path("/some-calculator")
 

--- a/spec/models/support/requests/anonymous/corporate_content_problem_report_aggregated_metrics_spec.rb
+++ b/spec/models/support/requests/anonymous/corporate_content_problem_report_aggregated_metrics_spec.rb
@@ -16,13 +16,13 @@ module Support
         before do
           { 7 => ["a"], 5 => ["b", "c", "d"], 3 => ["e", "f"], 1 => ["g"] }.each do |count, slugs|
             slugs.each do |slug|
-              count.times { create_report(page_owner: "co", created_at: Date.new(2013,2,10), url: "https://www.gov.uk/#{slug}") }
+              count.times { create_report(page_owner: "co", created_at: Date.new(2013,2,10), path: "/#{slug}") }
             end
           end
 
-          create_report(page_owner: "dft", created_at: Date.new(2013,2,10), url: "https://www.gov.uk/h")
-          create_report(page_owner: "hmrc", created_at: Date.new(2013,2,10), url: "https://www.gov.uk/i")
-          create_report(page_owner: "co", created_at: Date.new(2013,1,1), url: "https://www.gov.uk/a")
+          create_report(page_owner: "dft", created_at: Date.new(2013,2,10), path: "/h")
+          create_report(page_owner: "hmrc", created_at: Date.new(2013,2,10), path: "/i")
+          create_report(page_owner: "co", created_at: Date.new(2013,1,1), path: "/a")
         end
 
         after do
@@ -89,13 +89,13 @@ module Support
             it "includes urls, comment counts, grouped by page owner" do
               aggregates = top_urls.map {|entry| [ entry["organisation_acronym"], entry["url"], entry["comment_count"] ] }
               expect(aggregates).to eq([
-                ["co", "https://www.gov.uk/a", 7],
-                ["co", "https://www.gov.uk/b", 5],
-                ["co", "https://www.gov.uk/c", 5],
-                ["co", "https://www.gov.uk/d", 5],
-                ["co", "https://www.gov.uk/e", 3],
-                ["dft", "https://www.gov.uk/h", 1],
-                ["hmrc", "https://www.gov.uk/i", 1],
+                ["co", "http://www.dev.gov.uk/a", 7],
+                ["co", "http://www.dev.gov.uk/b", 5],
+                ["co", "http://www.dev.gov.uk/c", 5],
+                ["co", "http://www.dev.gov.uk/d", 5],
+                ["co", "http://www.dev.gov.uk/e", 3],
+                ["dft", "http://www.dev.gov.uk/h", 1],
+                ["hmrc", "http://www.dev.gov.uk/i", 1],
               ])
             end
           end


### PR DESCRIPTION
All anonymous feedback is now being created through the 'support-api'.
When persisting the feedback, the 'url' is no longer being set and this app
shouldn't be relying on it being set.

This fixes the issue with broken links in Feedex and missing URLs in the Feedex API.
