### PR TITLE
Upgrade gds_zendesk to 1.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'jc-validates_timeliness', '3.1.1'
 if ENV['GDS_ZENDESK_DEV']
   gem "gds_zendesk", :path => '../gds_zendesk'
 else
-  gem "gds_zendesk", '1.0.2'
+  gem "gds_zendesk", '1.0.4'
 end
 gem 'redis', '3.0.6'
 gem "sidekiq", "2.17.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,8 +75,6 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.9.1)
-      faraday (>= 0.7.4, < 0.10)
     formtastic (3.1.3)
       actionpack (>= 3.2.13)
     formtastic-bootstrap (3.1.0)
@@ -96,9 +94,9 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    gds_zendesk (1.0.2)
+    gds_zendesk (1.0.4)
       null_logger (= 0.0.1)
-      zendesk_api (= 1.0.2)
+      zendesk_api (= 1.6.3)
     globalid (0.3.3)
       activesupport (>= 4.1.0)
     govuk_admin_template (2.1.0)
@@ -287,14 +285,13 @@ GEM
       chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    zendesk_api (1.0.2)
-      faraday (>= 0.8.0)
-      faraday_middleware (>= 0.8.7)
-      hashie (>= 1.2)
+    zendesk_api (1.6.3)
+      faraday (~> 0.9)
+      hashie (>= 1.2, < 4.0)
       inflection
       mime-types
       multi_json
-      multipart-post
+      multipart-post (~> 2.0)
 
 PLATFORMS
   ruby
@@ -308,7 +305,7 @@ DEPENDENCIES
   formtastic-bootstrap (= 3.1.0)
   gds-api-adapters (= 10.8.0)
   gds-sso (= 9.4.0)
-  gds_zendesk (= 1.0.2)
+  gds_zendesk (= 1.0.4)
   govuk_admin_template (= 2.1.0)
   gretel (= 3.0.7)
   jbuilder (= 2.1.1)


### PR DESCRIPTION
This picks up the latest 'zendesk_api' gem, which fixes
https://errbit.preview.alphagov.co.uk/apps/5319f4d40da115d7a90004fe/problems/5526b2990da1157bfa0008be

/cc @issyl0 