### PR TITLE
Tweak feedback explorer table and page headings

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,3 +41,7 @@ thead {
   border-top-left-radius: 3px;
   border-bottom-left-radius: 3px;
 }
+
+.no-wrap {
+  white-space: nowrap;
+}

--- a/app/views/anonymous_feedback/_anonymous-contact.html.erb
+++ b/app/views/anonymous_feedback/_anonymous-contact.html.erb
@@ -1,5 +1,5 @@
 <tr class="anonymous-contact">
-  <th scope="row"><%= anonymous_contact.created_at.strftime("%d.%m.%Y") %></th>
+  <th scope="row" class="no-wrap"><%= anonymous_contact.created_at.to_date.to_s(:govuk_date) %></th>
   <td>
     <%= render partial: "feedback", locals: { anonymous_contact: anonymous_contact } %>
   </td>

--- a/app/views/anonymous_feedback/_results.html.erb
+++ b/app/views/anonymous_feedback/_results.html.erb
@@ -3,10 +3,10 @@
 <table id="results" class="table table-hover table-bordered">
   <thead>
     <tr class="table-header">
-      <th class="col-md-1">creation date</th>
-      <th class="col-md-6">feedback</th>
-      <th class="col-md-3">full path</th>
-      <th class="col-md-2">user came from</th>
+      <th class="no-wrap">Date</th>
+      <th class="col-md-5">Feedback</th>
+      <th class="col-md-3">URL</th>
+      <th class="col-md-2">Referrer</th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/anonymous_feedback/explore/new.html.erb
+++ b/app/views/anonymous_feedback/explore/new.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :page_title, "FeedEx" %>
-<%= content_for :header, "Explore GOV.UK anonymous feedback" %>
+<%= content_for :page_title, "Anonymous Feedback" %>
+<%= content_for :header, "GOV.UK Anonymous Feedback" %>
 
 <% breadcrumb :feedex %>
 

--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :page_title, "FeedEx" %>
-<%= content_for :header, "Anonymous feedback for “#{params[:path]}”" %>
+<%= content_for :page_title, "Feedback for “#{params[:path]}”" %>
+<%= content_for :header, "Feedback for “#{params[:path]}”" %>
 <% breadcrumb :anonymous_feedback_by_path, params[:path] %>
 
 <% if @feedback.empty? %>

--- a/lib/support/navigation/feedex_section.rb
+++ b/lib/support/navigation/feedex_section.rb
@@ -12,7 +12,7 @@ module Support
       end
 
       def description
-        "Explore GOV.UK anonymous feedback"
+        "GOV.UK Anonymous Feedback"
       end
 
       def link

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -34,15 +34,15 @@ feature "Exploring anonymous feedback" do
 
     expect(feedex_results).to eq([
       {
-        "creation date" => "01.03.2013",
-        "feedback" => "action: looking at 3rd paragraph problem: typo in 2rd word",
-        "full path" => "/vat-rates",
-        "user came from" => "https://www.gov.uk"
+        "Date" => "1 March 2013",
+        "Feedback" => "action: looking at 3rd paragraph problem: typo in 2rd word",
+        "URL" => "/vat-rates",
+        "Referrer" => "https://www.gov.uk"
       }, {
-        "creation date" => "01.02.2013",
-        "feedback" => "action: looking at rates problem: standard rate is wrong",
-        "full path" => "/vat-rates",
-        "user came from" => "https://www.gov.uk/pay-vat"
+        "Date" => "1 February 2013",
+        "Feedback" => "action: looking at rates problem: standard rate is wrong",
+        "URL" => "/vat-rates",
+        "Referrer" => "https://www.gov.uk/pay-vat"
       }
     ])
   end

--- a/spec/features/user_satisfaction_survey_spec.rb
+++ b/spec/features/user_satisfaction_survey_spec.rb
@@ -24,10 +24,10 @@ feature "User satisfaction survey submissions" do
 
     expect(feedex_results).to eq([
       {
-        "creation date" => "28.02.2013",
-        "feedback" => "rating: 3 comment: Make service less 'meh'",
-        "full path" => "/done/find-court-tribunal",
-        "user came from" => "–"
+        "Date" => "28 February 2013",
+        "Feedback" => "rating: 3 comment: Make service less 'meh'",
+        "URL" => "/done/find-court-tribunal",
+        "Referrer" => "–"
       }
     ])
   end
@@ -43,7 +43,7 @@ feature "User satisfaction survey submissions" do
 
     explore_anonymous_feedback_with(url: "https://www.gov.uk/done/apply-carers-allowance")
 
-    expect(feedex_results.first["feedback"]).to eq("rating: 3")
+    expect(feedex_results.first["Feedback"]).to eq("rating: 3")
   end
 
   private

--- a/spec/support/app_actions.rb
+++ b/spec/support/app_actions.rb
@@ -2,12 +2,12 @@ module AppActions
   def explore_anonymous_feedback_with(options)
     visit "/"
     click_on "Feedback explorer"
-    assert page.has_title?("FeedEx"), page.html
+    assert page.has_title?("Anonymous Feedback"), page.html
     fill_in 'URL', with: options[:url]
 
     click_on "Explore"
 
-    expect(page).to have_content("Anonymous feedback for")
+    expect(page).to have_content("Feedback for")
   end
 
   def feedex_results


### PR DESCRIPTION
* Use readable date formats
* Prevent dates from wrapping to new lines
* Use better column headings
* Use shorter, more legible page titles

cc @rivalee @benilovj 

## Explorer
Before
![screen shot 2015-04-28 at 16 43 14](https://cloud.githubusercontent.com/assets/319055/7373722/0a9c9376-edc6-11e4-9747-a4bcb03c005c.png)

After
![screen shot 2015-04-28 at 16 41 10](https://cloud.githubusercontent.com/assets/319055/7373633/9a090de2-edc5-11e4-9819-9cdd41436f61.png)

## Index
Before
![screen shot 2015-04-28 at 16 43 49](https://cloud.githubusercontent.com/assets/319055/7373696/e5814a3c-edc5-11e4-9c3c-56fffa86f269.png)

After
![screen shot 2015-04-28 at 16 41 26](https://cloud.githubusercontent.com/assets/319055/7373634/9a0c2996-edc5-11e4-8e5c-391f31c9d7b3.png)