### PR TITLE
Be lenient in what the feedback explorer can receive in its URL field

### DIFF
--- a/app/views/anonymous_feedback/explore/new.html.erb
+++ b/app/views/anonymous_feedback/explore/new.html.erb
@@ -7,11 +7,15 @@
   <div class="col-md-6">
     <div class="panel panel-default">
       <div class="panel-heading">
-        Feedback for a specific URL
+        <h3 class="panel-title">
+          Feedback on a URL or path
+        </h3>
       </div>
       <div class="panel-body">
         <%= semantic_form_for @explore_by_url, url: { action: "create" } do |f| %>
           <%= f.input :url, label: "URL", required: true, input_html: { class: "input-md-6", :"aria-required" => true, type: "url"} %>
+          <p class="help-block">eg <code>/vat-rates</code> or <code>https://www.gov.uk/bank-holidays</code></p>
+          <hr />
           <%= f.action :submit, label: "Explore", button_html: { class: "btn btn-success" } %>
         <% end %>
       </div>

--- a/app/views/anonymous_feedback/explore/new.html.erb
+++ b/app/views/anonymous_feedback/explore/new.html.erb
@@ -10,7 +10,7 @@
         Feedback for a specific URL
       </div>
       <div class="panel-body">
-        <%= semantic_form_for @explore_by_url, url: { action: "create" }, html: { novalidate: false } do |f| %>
+        <%= semantic_form_for @explore_by_url, url: { action: "create" } do |f| %>
           <%= f.input :url, label: "URL", required: true, input_html: { class: "input-md-6", :"aria-required" => true, type: "url"} %>
           <%= f.action :submit, label: "Explore", button_html: { class: "btn btn-success" } %>
         <% end %>

--- a/lib/support/requests/anonymous/explore.rb
+++ b/lib/support/requests/anonymous/explore.rb
@@ -15,16 +15,21 @@ module Support
         validate :url_is_well_formed
 
         def redirect_path
-          Rails.application.routes.url_helpers.anonymous_feedback_index_path(path: URI(url).path)
+          Rails.application.routes.url_helpers.anonymous_feedback_index_path(path: path_from_url)
         end
 
         private
         def url_is_well_formed
           uri = URI.parse(url)
-          valid = (uri.kind_of?(URI::HTTP) or uri.kind_of?(URI::HTTPS)) && !uri.path.nil? && !uri.host.nil?
+          valid = !uri.path.nil?
           errors.add(:url, "must be a valid URL") unless valid
         rescue URI::InvalidURIError
           errors.add(:url, "must be a valid URL")
+        end
+
+        def path_from_url
+          path = URI(url).path
+          path.sub(/^(www.)?gov.uk/, '')
         end
       end
     end

--- a/lib/support/requests/anonymous/explore.rb
+++ b/lib/support/requests/anonymous/explore.rb
@@ -18,15 +18,6 @@ module Support
           Rails.application.routes.url_helpers.anonymous_feedback_index_path(path: path_from_url)
         end
 
-        private
-        def url_is_well_formed
-          uri = URI.parse(url)
-          valid = !uri.path.nil?
-          errors.add(:url, "must be a valid URL") unless valid
-        rescue URI::InvalidURIError
-          errors.add(:url, "must be a valid URL")
-        end
-
         # correct user's URL entries to give them what they're after
         # we only really care about the path they've entered
         # strip out
@@ -37,6 +28,15 @@ module Support
         def path_from_url
           path = URI(url).path.sub(/^(http(s)?(:)?(\/)+?(:)?)?((\/)?www.)?gov.uk/, '')
           path.start_with?('/') ? path : "/#{path}"
+        end
+
+        private
+        def url_is_well_formed
+          uri = URI.parse(url)
+          valid = !uri.path.nil?
+          errors.add(:url, "must be a valid URL") unless valid
+        rescue URI::InvalidURIError
+          errors.add(:url, "must be a valid URL")
         end
       end
     end

--- a/lib/support/requests/anonymous/explore.rb
+++ b/lib/support/requests/anonymous/explore.rb
@@ -27,9 +27,16 @@ module Support
           errors.add(:url, "must be a valid URL")
         end
 
+        # correct user's URL entries to give them what they're after
+        # we only really care about the path they've entered
+        # strip out
+        # - malformed http eg https:, http//:, http:/, http:///
+        # - www.gov.uk and gov.uk
+        # allow
+        # treat some-path as if it were /some-path
         def path_from_url
-          path = URI(url).path
-          path.sub(/^(www.)?gov.uk/, '')
+          path = URI(url).path.sub(/^(http(s)?(:)?(\/)+?(:)?)?((\/)?www.)?gov.uk/, '')
+          path.start_with?('/') ? path : "/#{path}"
         end
       end
     end

--- a/spec/controllers/anonymous_feedback/explore_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/explore_controller_spec.rb
@@ -6,7 +6,7 @@ describe AnonymousFeedback::ExploreController, :type => :controller do
   end
 
   it "shows the new form again for invalid requests" do
-    post :create, { support_requests_anonymous_explore_by_url: { url: "abc" } }
+    post :create, { support_requests_anonymous_explore_by_url: { url: "" } }
     expect(response).to have_http_status(422)
   end
 

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -44,25 +44,7 @@ feature "Exploring anonymous feedback" do
       }
     ]
 
-    explore_anonymous_feedback_with(url: "https://www.gov.uk/vat-rates")
-    expect(feedex_results).to eq(feedback_reports)
-
-    explore_anonymous_feedback_with(url: "http:/www.gov.uk/vat-rates")
-    expect(feedex_results).to eq(feedback_reports)
-
-    explore_anonymous_feedback_with(url: "https//www.gov.uk/vat-rates")
-    expect(feedex_results).to eq(feedback_reports)
-
     explore_anonymous_feedback_with(url: "www.gov.uk/vat-rates")
-    expect(feedex_results).to eq(feedback_reports)
-
-    explore_anonymous_feedback_with(url: "gov.uk/vat-rates")
-    expect(feedex_results).to eq(feedback_reports)
-
-    explore_anonymous_feedback_with(url: "/vat-rates")
-    expect(feedex_results).to eq(feedback_reports)
-
-    explore_anonymous_feedback_with(url: "vat-rates")
     expect(feedex_results).to eq(feedback_reports)
   end
 

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -47,6 +47,12 @@ feature "Exploring anonymous feedback" do
     explore_anonymous_feedback_with(url: "https://www.gov.uk/vat-rates")
     expect(feedex_results).to eq(feedback_reports)
 
+    explore_anonymous_feedback_with(url: "http:/www.gov.uk/vat-rates")
+    expect(feedex_results).to eq(feedback_reports)
+
+    explore_anonymous_feedback_with(url: "https//www.gov.uk/vat-rates")
+    expect(feedex_results).to eq(feedback_reports)
+
     explore_anonymous_feedback_with(url: "www.gov.uk/vat-rates")
     expect(feedex_results).to eq(feedback_reports)
 
@@ -54,6 +60,9 @@ feature "Exploring anonymous feedback" do
     expect(feedex_results).to eq(feedback_reports)
 
     explore_anonymous_feedback_with(url: "/vat-rates")
+    expect(feedex_results).to eq(feedback_reports)
+
+    explore_anonymous_feedback_with(url: "vat-rates")
     expect(feedex_results).to eq(feedback_reports)
   end
 

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -30,9 +30,7 @@ feature "Exploring anonymous feedback" do
       referrer: "https://www.gov.uk",
     )
 
-    explore_anonymous_feedback_with(url: "https://www.gov.uk/vat-rates")
-
-    expect(feedex_results).to eq([
+    feedback_reports = [
       {
         "Date" => "1 March 2013",
         "Feedback" => "action: looking at 3rd paragraph problem: typo in 2rd word",
@@ -44,7 +42,19 @@ feature "Exploring anonymous feedback" do
         "URL" => "/vat-rates",
         "Referrer" => "https://www.gov.uk/pay-vat"
       }
-    ])
+    ]
+
+    explore_anonymous_feedback_with(url: "https://www.gov.uk/vat-rates")
+    expect(feedex_results).to eq(feedback_reports)
+
+    explore_anonymous_feedback_with(url: "www.gov.uk/vat-rates")
+    expect(feedex_results).to eq(feedback_reports)
+
+    explore_anonymous_feedback_with(url: "gov.uk/vat-rates")
+    expect(feedex_results).to eq(feedback_reports)
+
+    explore_anonymous_feedback_with(url: "/vat-rates")
+    expect(feedex_results).to eq(feedback_reports)
   end
 
   scenario "no feedback found" do

--- a/spec/models/support/requests/anonymous/explore_by_url_spec.rb
+++ b/spec/models/support/requests/anonymous/explore_by_url_spec.rb
@@ -14,6 +14,35 @@ module Support
           expect(ExploreByUrl.new(url: "https://www.gov.uk/some-path").redirect_path).
             to eq("/anonymous_feedback?path=%2Fsome-path")
         end
+
+        it "can extract the path from a valid URL" do
+          [
+            "https://www.gov.uk/abc",
+            "http://www.gov.uk/abc",
+          ].each {|url| expect(extracted_path_from(url)).to eq("/abc")}
+        end
+
+        it "can extract the path from a URL with a malformed protocol" do
+          [
+            "http:///www.gov.uk/abc",
+            "http//:www.gov.uk/abc",
+            "http/:www.gov.uk/abc",
+            "http:/www.gov.uk/abc",
+          ].each {|url| expect(extracted_path_from(url)).to eq("/abc")}
+        end
+
+        it "can extract the path from short hand URLs" do
+          [
+            "www.gov.uk/abc",
+            "gov.uk/abc",
+            "/abc",
+            "abc",
+          ].each {|url| expect(extracted_path_from(url)).to eq("/abc")}
+        end
+
+        def extracted_path_from(url)
+          ExploreByUrl.new(url: url).path_from_url
+        end
       end
     end
   end


### PR DESCRIPTION
Allow full URLs with http and https, as well as partial URLs beginning with gov.uk or www.gov.uk, URLs users have entered with a bad protocol, or simply the plain path itself – with or without leading slash.

The following inputs all give the same results page:
```
Valid
https://www.gov.uk/vat-rates
http://www.gov.uk/vat-rates

Invalid
http//www.gov.uk/vat-rates
https//:www.gov.uk/vat-rates

Short hand
www.gov.uk/vat-rates
gov.uk/vat-rates
/vat-rates
vat-rates
```
Also
* removes inline form validation – what the browser validation defines as a URL is too strict.
* adds examples to the form

![screen shot 2015-04-29 at 16 06 54](https://cloud.githubusercontent.com/assets/319055/7394174/e9c5269e-ee89-11e4-9188-8dd98db67790.png)

cc @rivalee @benilovj 