### PR TITLE
Explicitly set log level to info in prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,8 +32,7 @@ Support::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # See everything in the log (default is :info)
-  # config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
This is the default configuration in new Rails 4 apps. Without this
setting, Rails throws deprecation warnings that in Rails 5, the log
level is set to :debug in production if left unset.