### PR TITLE
Make the referrer column user friendly

### DIFF
--- a/app/helpers/referrer_helper.rb
+++ b/app/helpers/referrer_helper.rb
@@ -1,0 +1,27 @@
+require 'uri'
+
+module ReferrerHelper
+
+  def friendly_referrer(referrer)
+    uri = URI.parse(referrer)
+    if uri.host
+      if (uri.host.match(/www\.gov.uk/))
+        uri.path
+      else
+        uri.host.sub(/www\./,'')
+      end
+    else
+      referrer
+    end
+  rescue URI::InvalidURIError
+    referrer
+  end
+
+  def extract_search_term(referrer)
+    uri = URI.parse(referrer)
+    params = Rack::Utils.parse_query(uri.query)
+    params['q'] if params['q'].present?
+  rescue URI::InvalidURIError
+    nil
+  end
+end

--- a/app/views/anonymous_feedback/_anonymous-contact.html.erb
+++ b/app/views/anonymous_feedback/_anonymous-contact.html.erb
@@ -11,10 +11,12 @@
     <% end %>
   </td>
   <td>
-    <% if anonymous_contact.referrer %>
-      <%= link_to truncate(anonymous_contact.referrer), anonymous_contact.referrer, class: "breakable" %>
-    <% else %>
-      &ndash;
+    <% if anonymous_contact.referrer and anonymous_contact.referrer != "unknown" %>
+      <% search_term = extract_search_term(anonymous_contact.referrer) %>
+      <%= link_to friendly_referrer(anonymous_contact.referrer), anonymous_contact.referrer, class: "breakable" %>
+      <% if search_term %>
+        <span class="text-muted help" title="Search term">“<%= search_term %>”</span>
+      <% end %>
     <% end %>
   </td>
 </tr>

--- a/app/views/anonymous_feedback/_results.html.erb
+++ b/app/views/anonymous_feedback/_results.html.erb
@@ -6,7 +6,7 @@
       <th class="no-wrap">Date</th>
       <th class="col-md-5">Feedback</th>
       <th class="col-md-3">URL</th>
-      <th class="col-md-2">Referrer</th>
+      <th class="col-md-3">Referrer</th>
     </tr>
   </thead>
   <tbody>

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -11,7 +11,7 @@ feature "Exploring anonymous feedback" do
       created_at: DateTime.parse("2013-01-01"),
       what_doing: "logging in",
       what_wrong: "error",
-      referrer: "https://www.gov.uk",
+      referrer: "https://www.gov.uk/",
     )
 
     create(:problem_report,
@@ -27,7 +27,7 @@ feature "Exploring anonymous feedback" do
       created_at: DateTime.parse("2013-03-01"),
       what_doing: "looking at 3rd paragraph",
       what_wrong: "typo in 2rd word",
-      referrer: "https://www.gov.uk",
+      referrer: "https://www.gov.uk/",
     )
 
     feedback_reports = [
@@ -35,12 +35,12 @@ feature "Exploring anonymous feedback" do
         "Date" => "1 March 2013",
         "Feedback" => "action: looking at 3rd paragraph problem: typo in 2rd word",
         "URL" => "/vat-rates",
-        "Referrer" => "https://www.gov.uk"
+        "Referrer" => "/"
       }, {
         "Date" => "1 February 2013",
         "Feedback" => "action: looking at rates problem: standard rate is wrong",
         "URL" => "/vat-rates",
-        "Referrer" => "https://www.gov.uk/pay-vat"
+        "Referrer" => "/pay-vat"
       }
     ]
 

--- a/spec/features/user_satisfaction_survey_spec.rb
+++ b/spec/features/user_satisfaction_survey_spec.rb
@@ -27,7 +27,7 @@ feature "User satisfaction survey submissions" do
         "Date" => "28 February 2013",
         "Feedback" => "rating: 3 comment: Make service less 'meh'",
         "URL" => "/done/find-court-tribunal",
-        "Referrer" => "–"
+        "Referrer" => ""
       }
     ])
   end

--- a/spec/helpers/referrer_helper_spec.rb
+++ b/spec/helpers/referrer_helper_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe(ReferrerHelper) do
+  include ReferrerHelper
+
+  context('friendly_referrer') do
+    it('shows the hostname for external sites') do
+      expect(friendly_referrer('http://www.google.co.uk/search?q=public+holidays+in+uk&hl=en-GB&gbv=2&oq=&gs_l=')).to eq('google.co.uk')
+      expect(friendly_referrer('http://www.bing.com/search?q=4th+May+2015+Bank+Holiday&FORM=QSRE1')).to eq('bing.com')
+      expect(friendly_referrer('https://www.google.ie/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&ved=0CCEQFjAA&url=https%3A%2F%2Fwww.gov.uk%2Fbank-holidays')).to eq('google.ie')
+    end
+
+    it('can handle invalid URIs') do
+      expect(friendly_referrer('httttp:/123')).to eq('httttp:/123')
+    end
+
+    it('shows the path for internal referrers') do
+      expect(friendly_referrer('https://www.gov.uk/search?q=Bank+holidays')).to eq('/search')
+      expect(friendly_referrer('https://www.gov.uk/bank-holidays')).to eq('/bank-holidays')
+      expect(friendly_referrer('https://www.gov.uk/')).to eq('/')
+    end
+  end
+
+  it('can extract a search term from a referrer') do
+    expect(extract_search_term('https://www.gov.uk/search?q=Bank+holidays')).to eq('Bank holidays')
+    expect(extract_search_term('http://www.google.co.uk/search?q=public+holidays+in+uk&hl=en-GB&gbv=2&oq=&gs_l=')).to eq('public holidays in uk')
+    expect(extract_search_term('http://www.bing.com/search?q=4th+May+2015+Bank+Holiday&FORM=QSRE1')).to eq('4th May 2015 Bank Holiday')
+  end
+
+end


### PR DESCRIPTION
The long referrer URLs are often unreadable, squished onto multiple lines and unusable.

* For external sites show only the hostname (stripping out `www` as well)
* When a search has been performed (when there is a “q” parameter), extract and show the search term
* When referred internally, show only the gov.uk path
* All links continue to link through to the full referrer
* When referrer is unknown or blank, leave an empty cell