### PR TITLE
DO NOT MERGE: Use support-api

### DIFF
--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -5,18 +5,11 @@ class AnonymousFeedbackController < RequestsController
     authorize! :read, Anonymous::AnonymousContact
 
     if params[:path].nil? or params[:path].empty?
-      respond_to do |format|
-        format.html { redirect_to anonymous_feedback_explore_url, status: 301 }
-        format.json { render json: {"errors" => ["Please set a valid 'path' parameter"] }, status: 400 }
-      end
+      redirect_to anonymous_feedback_explore_url, status: 301
     else
       @feedback = Anonymous::AnonymousContact.
         find_all_starting_with_path(params[:path]).
         page(params[:page])
-      respond_to do |format|
-        format.html
-        format.json
-      end
     end
   end
 

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -1,3 +1,5 @@
+require "gds_api/support_api"
+
 class AnonymousFeedbackController < RequestsController
   include Support::Requests
 
@@ -7,13 +9,29 @@ class AnonymousFeedbackController < RequestsController
     if params[:path].nil? or params[:path].empty?
       redirect_to anonymous_feedback_explore_url, status: 301
     else
-      @feedback = Anonymous::AnonymousContact.
-        find_all_starting_with_path(params[:path]).
-        page(params[:page])
+      @feedback = anonymous_feedback(index_params)
     end
   end
 
   def set_requester_on(request)
     # this is anonymous feedback, so requester doesn't need to be set
+  end
+
+private
+  def anonymous_feedback(options)
+    AnonymousFeedbackPresenter.new(
+      support_api.get_anonymous_feedback(options),
+    )
+  end
+
+  def index_params
+    {
+      starting_with_path: params[:path],
+      page: params[:page],
+    }
+  end
+
+  def support_api
+    GdsApi::SupportApi.new(Plek.find("support-api"))
   end
 end

--- a/app/presenters/anonymous_feedback_presenter.rb
+++ b/app/presenters/anonymous_feedback_presenter.rb
@@ -1,0 +1,38 @@
+require 'long_form_contact_presenter'
+require 'problem_report_presenter'
+require 'service_feedback_presenter'
+
+class AnonymousFeedbackPresenter < SimpleDelegator
+  attr_reader :current_page, :total_pages, :limit_value
+
+  def initialize(api_response)
+    # actually delegate to the API response's `results` array
+    super(present_results(api_response["results"]))
+
+    @current_page = api_response["current_page"]
+    @total_pages = api_response["pages"]
+    @limit_value = api_response["page_size"]
+  end
+
+private
+  def present_results(results)
+    results.map { |anonymous_contact|
+      present(anonymous_contact)
+    }
+  end
+
+  def present(anonymous_contact)
+    presenter_for(anonymous_contact).new(anonymous_contact)
+  end
+
+  def presenter_for(anonymous_contact)
+    case anonymous_contact["type"]
+    when "long_form_contact"
+      LongFormContactPresenter
+    when "problem_report"
+      ProblemReportPresenter
+    when "service_feedback"
+      ServiceFeedbackPresenter
+    end
+  end
+end

--- a/app/presenters/long_form_contact_presenter.rb
+++ b/app/presenters/long_form_contact_presenter.rb
@@ -1,0 +1,1 @@
+class LongFormContactPresenter < OpenStruct; end

--- a/app/presenters/problem_report_presenter.rb
+++ b/app/presenters/problem_report_presenter.rb
@@ -1,0 +1,1 @@
+class ProblemReportPresenter < OpenStruct; end

--- a/app/presenters/service_feedback_presenter.rb
+++ b/app/presenters/service_feedback_presenter.rb
@@ -1,0 +1,1 @@
+class ServiceFeedbackPresenter < OpenStruct; end

--- a/app/views/anonymous_feedback/_feedback.html.erb
+++ b/app/views/anonymous_feedback/_feedback.html.erb
@@ -1,8 +1,8 @@
-<% if anonymous_contact.is_a?(Support::Requests::Anonymous::ProblemReport) %>
+<% if anonymous_contact.type == "problem_report" %>
   <strong>action</strong>: <%= anonymous_contact.what_doing %>
   <br/>
   <strong>problem</strong>: <%= anonymous_contact.what_wrong %>
-<% elsif anonymous_contact.is_a?(Support::Requests::Anonymous::ServiceFeedback) %>
+<% elsif anonymous_contact.type == "service_feedback" %>
   <strong>rating</strong>: <%= anonymous_contact.service_satisfaction_rating %>
   <% if anonymous_contact.details.present? %>
     <br/>

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -6,19 +6,9 @@ describe AnonymousFeedbackController, :type => :controller do
   end
 
   context "invalid input" do
-    context "HTML representation" do
-      it "redirects to the explore endpoint when no path given" do
-        get :index
-        expect(response).to redirect_to(anonymous_feedback_explore_url)
-      end
-    end
-
-    context "JSON" do
-      it "returns an error when no path given" do
-        get :index, format: :json
-        expect(response).to have_http_status(400)
-        expect(json_response).to eq("errors" => ["Please set a valid 'path' parameter"])
-      end
+    it "redirects to the explore endpoint when no path given" do
+      get :index
+      expect(response).to redirect_to(anonymous_feedback_explore_url)
     end
   end
 
@@ -33,37 +23,15 @@ describe AnonymousFeedbackController, :type => :controller do
       )
     end
 
-    context "HTML representation" do
-      it "renders the results" do
-        get :index, path: "/tax-disc"
-        expect(response).to have_http_status(:success)
-      end
-
-      it "displays at most 50 results per page" do
-        create_list(:problem_report, 70, path: "/tax-disc")
-        get :index, path: "/tax-disc"
-        expect(assigns["feedback"]).to have(50).items
-      end
+    it "renders the results" do
+      get :index, path: "/tax-disc"
+      expect(response).to have_http_status(:success)
     end
 
-    context "JSON" do
-      render_views
-
-      it "returns the results for problem" do
-        get :index, { "path" => "/tax-disc", "format" => "json" }
-
-        expect(response).to have_http_status(:success)
-        expect(json_response).to have(1).item
-        expect(json_response.first).to include(
-          "id" => feedback.id,
-          "type" => "problem-report",
-          "what_wrong" => "A",
-          "what_doing" => "B",
-          "url" => "http://www.dev.gov.uk/tax-disc",
-          "referrer" => "https://www.gov.uk/browse",
-          "user_agent" => "Safari",
-        )
-      end
+    it "displays at most 50 results per page" do
+      create_list(:problem_report, 70, path: "/tax-disc")
+      get :index, path: "/tax-disc"
+      expect(assigns["feedback"]).to have(50).items
     end
   end
 
@@ -77,30 +45,9 @@ describe AnonymousFeedbackController, :type => :controller do
       )
     end
 
-    context "HTML representation" do
-      it "renders the results for an HTML request" do
-        get :index, path: "/tax-disc"
-        expect(response).to have_http_status(:success)
-      end
-    end
-
-    context "JSON representation" do
-      render_views
-
-      it "returns the results for problem" do
-        get :index, { "path" => "/tax-disc", "format" => "json" }
-
-        expect(response).to have_http_status(:success)
-        expect(json_response).to have(1).item
-        expect(json_response.first).to include(
-          "id" => feedback.id,
-          "type" => "long-form-contact",
-          "details" => "Abc def",
-          "url" => "http://www.dev.gov.uk/tax-disc",
-          "referrer" => "https://www.gov.uk/contact/govuk",
-          "user_agent" => "Safari",
-        )
-      end
+    it "renders the results for an HTML request" do
+      get :index, path: "/tax-disc"
+      expect(response).to have_http_status(:success)
     end
   end
 
@@ -115,31 +62,9 @@ describe AnonymousFeedbackController, :type => :controller do
       )
     end
 
-    context "HTML representation" do
-      it "renders the results" do
-        get :index, path: "/done/apply-carers-allowance"
-        expect(response).to have_http_status(:success)
-      end
-    end
-
-    context "JSON representation" do
-      render_views
-
-      it "returns the results" do
-        get :index, { "path" => "/done/apply-carers-allowance", "format" => "json" }
-
-        expect(response).to have_http_status(:success)
-        expect(json_response).to have(1).item
-        expect(json_response.first).to include(
-          "id" => feedback.id,
-          "type" => "service-feedback",
-          "slug" => "apply-carers-allowance",
-          "details" => "It's great",
-          "url" => "http://www.dev.gov.uk/done/apply-carers-allowance",
-          "service_satisfaction_rating" => 5,
-          "user_agent" => "Safari",
-        )
-      end
+    it "renders the results" do
+      get :index, path: "/done/apply-carers-allowance"
+      expect(response).to have_http_status(:success)
     end
   end
 end

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -1,33 +1,43 @@
 require 'rails_helper'
+require 'gds_api/test_helpers/support_api'
 
 feature "Exploring anonymous feedback" do
+  include GdsApi::TestHelpers::SupportApi
+
   background do
     login_as create(:user)
   end
 
   scenario "exploring feedback by URL" do
-    create(:problem_report,
-      path: "/tax-disc",
-      created_at: DateTime.parse("2013-01-01"),
-      what_doing: "logging in",
-      what_wrong: "error",
-      referrer: "https://www.gov.uk/",
-    )
+    data = {
+      "current_page" => 1,
+      "pages" => 1,
+      "page_size" => 2,
+      "results" => [
+        {
+          type: :problem_report,
+          path: "/vat-rates",
+          created_at: DateTime.parse("2013-03-01"),
+          what_doing: "looking at 3rd paragraph",
+          what_wrong: "typo in 2rd word",
+          referrer: "https://www.gov.uk/",
+        },
+        {
+          type: :problem_report,
+          path: "/vat-rates",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "looking at rates",
+          what_wrong: "standard rate is wrong",
+          referrer: "https://www.gov.uk/pay-vat",
+        },
+      ]
+    }.to_json
 
-    create(:problem_report,
-      path: "/vat-rates",
-      created_at: DateTime.parse("2013-02-01"),
-      what_doing: "looking at rates",
-      what_wrong: "standard rate is wrong",
-      referrer: "https://www.gov.uk/pay-vat",
-    )
-
-    create(:problem_report,
-      path: "/vat-rates",
-      created_at: DateTime.parse("2013-03-01"),
-      what_doing: "looking at 3rd paragraph",
-      what_wrong: "typo in 2rd word",
-      referrer: "https://www.gov.uk/",
+    stub_get_anonymous_feedback(
+      {
+        starting_with_path: "/vat-rates",
+      },
+      response_body: data
     )
 
     feedback_reports = [
@@ -49,6 +59,15 @@ feature "Exploring anonymous feedback" do
   end
 
   scenario "no feedback found" do
+    stub_get_anonymous_feedback(
+      {
+        starting_with_path: "/non-existent-path",
+      },
+      response_body: {
+        "results" => []
+      }.to_json
+    )
+
     explore_anonymous_feedback_with(url: "https://www.gov.uk/non-existent-path")
 
     expect(page).to have_content("There is no feedback for this path.")

--- a/spec/features/redirects_spec.rb
+++ b/spec/features/redirects_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 require 'uri'
+require 'gds_api/test_helpers/support_api'
 
 describe "legacy feedex URL redirect" do
+  include GdsApi::TestHelpers::SupportApi
+
   before do
     login_as create(:user)
   end
@@ -12,6 +15,12 @@ describe "legacy feedex URL redirect" do
   end
 
   it "redirects the old problem report deep-links to the current anon feedback links" do
+    stub_get_anonymous_feedback(
+      {
+        starting_with_path: "/vat-rates",
+      }
+    )
+
     visit '/anonymous_feedback/problem_reports?path=/vat-rates'
     expect(current_url).to eq(current_host + '/anonymous_feedback?path=%2Fvat-rates')
   end

--- a/spec/features/user_satisfaction_survey_spec.rb
+++ b/spec/features/user_satisfaction_survey_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
+require 'gds_api/test_helpers/support_api'
 
 feature "User satisfaction survey submissions" do
+  include GdsApi::TestHelpers::SupportApi
+
   # In order to fix and improve my service (that's linked on GOV.UK)
   # As a service manager
   # I want to record and view bugs, gripes and improvement suggestions submitted by the service users
@@ -11,13 +14,30 @@ feature "User satisfaction survey submissions" do
   end
 
   scenario "submission with comment" do
-    create(:service_feedback,
-      slug: "find-court-tribunal",
-      path: "/done/find-court-tribunal",
-      service_satisfaction_rating: 3,
-      details: "Make service less 'meh'",
-      user_agent: "Safari",
-      javascript_enabled: true,
+    data = {
+      "current_page" => 1,
+      "pages" => 1,
+      "page_size" => 1,
+      "results" => [
+        {
+          type: :service_feedback,
+          slug: "find-court-tribunal",
+          path: "/done/find-court-tribunal",
+          service_satisfaction_rating: 3,
+          details: "Make service less 'meh'",
+          user_agent: "Safari",
+          javascript_enabled: true,
+          created_at: Time.now,
+          updated_at: Time.now,
+        }
+      ]
+    }.to_json
+
+    stub_get_anonymous_feedback(
+      {
+        starting_with_path: "/done/find-court-tribunal",
+      },
+      response_body: data
     )
 
     explore_anonymous_feedback_with(url: "https://www.gov.uk/done/find-court-tribunal")
@@ -33,12 +53,29 @@ feature "User satisfaction survey submissions" do
   end
 
   scenario "submission without a comment" do
-    create(:service_feedback,
-      slug: "apply-carers-allowance",
-      path: "/done/apply-carers-allowance",
-      service_satisfaction_rating: 3,
-      details: nil,
-      javascript_enabled: true,
+    data = {
+      "current_page" => 1,
+      "pages" => 1,
+      "page_size" => 1,
+      "results" => [
+        {
+          type: :service_feedback,
+          slug: "apply-carers-allowance",
+          path: "/done/apply-carers-allowance",
+          service_satisfaction_rating: 3,
+          details: nil,
+          javascript_enabled: true,
+          created_at: Time.now,
+          updated_at: Time.now,
+        },
+      ]
+    }.to_json
+
+    stub_get_anonymous_feedback(
+      {
+        starting_with_path: "/done/apply-carers-allowance",
+      },
+      response_body: data
     )
 
     explore_anonymous_feedback_with(url: "https://www.gov.uk/done/apply-carers-allowance")

--- a/spec/presenters/anonymous_feedback_presenter_spec.rb
+++ b/spec/presenters/anonymous_feedback_presenter_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+describe AnonymousFeedbackPresenter, type: :presenter do
+  context "when api_response has no `results`" do
+    let(:api_response) { {"results" => []} }
+    let(:presenter) { AnonymousFeedbackPresenter.new(api_response) }
+
+    describe "#empty?" do
+      it "should be empty" do
+        expect(presenter).to be_empty
+      end
+    end
+
+    describe "#size" do
+      it "should be zero" do
+        expect(presenter.size).to be_zero
+      end
+    end
+
+    describe "contents" do
+      it "should present api_response's `results`" do
+        expect(presenter).to eq([])
+      end
+    end
+  end
+
+  context "when api_response has `results`" do
+    let(:long_form_contact) { {"type" => "long_form_contact"} }
+    let(:problem_report) { { "type" => "problem_report" } }
+    let(:service_feedback) { { "type" => "service_feedback" } }
+    let(:current_page) { 2 }
+    let(:pages) { 9 }
+    let(:page_size) { 50 }
+    let(:api_response) {
+      {
+        "current_page" => current_page,
+        "pages" => pages,
+        "page_size" => page_size,
+        "results" => [
+          long_form_contact,
+          problem_report,
+          service_feedback,
+        ]
+      }
+    }
+    let(:presenter) { AnonymousFeedbackPresenter.new(api_response) }
+
+    describe "#size" do
+      it "should match api_response's `results`" do
+        expect(presenter.size).to eql(api_response["results"].size)
+      end
+    end
+
+    describe "contents" do
+      it "should present api_response's `results`" do
+        expect(presenter).to contain_exactly(
+          an_instance_of(LongFormContactPresenter),
+          an_instance_of(ProblemReportPresenter),
+          an_instance_of(ServiceFeedbackPresenter),
+        )
+      end
+    end
+
+    describe "pagination" do
+      it "should report `current_page`" do
+        expect(presenter.current_page).to eq(current_page)
+      end
+
+      it "should report `total_pages`" do
+        expect(presenter.total_pages).to eq(pages)
+      end
+
+      it "should report `limit_value`" do
+        expect(presenter.limit_value).to eq(page_size)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use an as-yet-to-be-implemented end-point of the `support-api` instead of connecting to a database.

Note: there is more work (contained in separate stories) to be done before we can completely remove the database, models, etc.

The commits here are fairly self-contained.