### PR TITLE
Introduce strong params for all incoming POST requests

### DIFF
--- a/app/controllers/analytics_requests_controller.rb
+++ b/app/controllers/analytics_requests_controller.rb
@@ -14,6 +14,22 @@ class AnalyticsRequestsController <  RequestsController
   end
 
   def parse_request_from_params
-    AnalyticsRequest.new(params[:support_requests_analytics_request])
+    AnalyticsRequest.new(analytics_request_params)
+  end
+
+  def analytics_request_params
+    params.require(:support_requests_analytics_request).permit(
+      :justification_for_needing_report,
+      :request_context,
+      requester_attributes: [:email, :name, :collaborator_emails],
+      needed_report_attributes: [
+        :reporting_period_start,
+        :reporting_period_end,
+        :pages_or_sections,
+        :non_standard_requirements,
+        :frequency,
+        :format
+      ],
+    )
   end
 end

--- a/app/controllers/campaign_requests_controller.rb
+++ b/app/controllers/campaign_requests_controller.rb
@@ -14,6 +14,16 @@ class CampaignRequestsController <  RequestsController
   end
 
   def parse_request_from_params
-    CampaignRequest.new(params[:support_requests_campaign_request])
+    CampaignRequest.new(campaign_request_params)
+  end
+
+  def campaign_request_params
+    params.require(:support_requests_campaign_request).permit(
+      :additional_comments,
+      requester_attributes: [:email, :name, :collaborator_emails],
+      campaign_attributes: [
+        :title, :erg_reference_number, :start_date, :description, :affiliated_group_or_company, :info_url
+      ]
+    )
   end
 end

--- a/app/controllers/content_advice_requests_controller.rb
+++ b/app/controllers/content_advice_requests_controller.rb
@@ -14,6 +14,15 @@ class ContentAdviceRequestsController < RequestsController
   end
 
   def parse_request_from_params
-    ContentAdviceRequest.new(params[:support_requests_content_advice_request])
+    ContentAdviceRequest.new(content_advice_request_params)
+  end
+
+  def content_advice_request_params
+    params.require(:support_requests_content_advice_request).permit(
+      :title, :nature_of_request, :nature_of_request_details,
+      :details, :urls, :response_needed_by_date, :reason_for_deadline,
+      :contact_number,
+      requester_attributes: [:email, :name, :collaborator_emails],
+    )
   end
 end

--- a/app/controllers/content_change_requests_controller.rb
+++ b/app/controllers/content_change_requests_controller.rb
@@ -14,6 +14,15 @@ class ContentChangeRequestsController < RequestsController
   end
 
   def parse_request_from_params
-    ContentChangeRequest.new(params[:support_requests_content_change_request])
+    ContentChangeRequest.new(content_change_request_params)
+  end
+
+  def content_change_request_params
+    params.require(:support_requests_content_change_request).permit(
+      :title, :details_of_change, :url, :related_urls,
+      :request_context,
+      requester_attributes: [:email, :name, :collaborator_emails],
+      time_constraint_attributes: [:not_before_date, :needed_by_date, :time_constraint_reason],
+    )
   end
 end

--- a/app/controllers/create_or_change_user_requests_controller.rb
+++ b/app/controllers/create_or_change_user_requests_controller.rb
@@ -16,7 +16,16 @@ class CreateOrChangeUserRequestsController < RequestsController
   end
 
   def parse_request_from_params
-    CreateOrChangeUserRequest.new(params[:support_requests_create_or_change_user_request])
+    CreateOrChangeUserRequest.new(create_or_change_user_request_params)
+  end
+
+  def create_or_change_user_request_params
+    params.require(:support_requests_create_or_change_user_request).permit(
+      :action, :additional_comments,
+      user_needs: [],
+      requester_attributes: [:email, :name, :collaborator_emails],
+      requested_user_attributes: [:name, :email, :job, :phone],
+    )
   end
 
   def save_to_zendesk(submitted_request)

--- a/app/controllers/foi_requests_controller.rb
+++ b/app/controllers/foi_requests_controller.rb
@@ -14,10 +14,16 @@ class FoiRequestsController < RequestsController
   end
 
   def parse_request_from_params
-    FoiRequest.new(params[:foi_request])
+    FoiRequest.new(foi_request_params)
   end
 
   def set_requester_on(request)
-    request.requester = Support::Requests::Requester.new(params[:foi_request][:requester])
+    request.requester = Support::Requests::Requester.new(foi_request_params[:requester])
+  end
+
+  def foi_request_params
+    params.require(:foi_request).permit(
+      :details, { requester: [:email, :name] }
+    )
   end
 end

--- a/app/controllers/general_requests_controller.rb
+++ b/app/controllers/general_requests_controller.rb
@@ -14,8 +14,15 @@ class GeneralRequestsController < RequestsController
   end
 
   def parse_request_from_params
-    user_request = GeneralRequest.new(params[:support_requests_general_request])
+    user_request = GeneralRequest.new(general_request_params)
     user_request.user_agent = request.user_agent
     user_request
+  end
+
+  def general_request_params
+    params.require(:support_requests_general_request).permit(
+      :title, :url, :details,
+      requester_attributes: [:email, :name, :collaborator_emails],
+    )
   end
 end

--- a/app/controllers/named_contacts_controller.rb
+++ b/app/controllers/named_contacts_controller.rb
@@ -14,10 +14,17 @@ class NamedContactsController < RequestsController
   end
 
   def parse_request_from_params
-    NamedContact.new(params[:named_contact])
+    NamedContact.new(named_contact_params)
   end
 
   def set_requester_on(request)
-    request.requester = Support::Requests::Requester.new(params[:named_contact][:requester])
+    request.requester = Support::Requests::Requester.new(named_contact_params[:requester])
+  end
+
+  def named_contact_params
+    params.require(:named_contact).permit(
+      :details, :link, :referrer, :javascript_enabled, :user_agent,
+      requester: [:email, :name],
+    )
   end
 end

--- a/app/controllers/new_feature_requests_controller.rb
+++ b/app/controllers/new_feature_requests_controller.rb
@@ -14,6 +14,14 @@ class NewFeatureRequestsController < RequestsController
   end
 
   def parse_request_from_params
-    NewFeatureRequest.new(params[:support_requests_new_feature_request])
+    NewFeatureRequest.new(new_feature_request_params)
+  end
+
+  def new_feature_request_params
+    params.require(:support_requests_new_feature_request).permit(
+      :request_context, :title, :user_need, :url_of_example,
+      requester_attributes: [:email, :name, :collaborator_emails],
+      time_constraint_attributes: [:not_before_date, :needed_by_date, :time_constraint_reason],
+    )
   end
 end

--- a/app/controllers/remove_user_requests_controller.rb
+++ b/app/controllers/remove_user_requests_controller.rb
@@ -14,6 +14,14 @@ class RemoveUserRequestsController < RequestsController
   end
 
   def parse_request_from_params
-    RemoveUserRequest.new(params[:support_requests_remove_user_request])
+    RemoveUserRequest.new(remove_user_request_params)
+  end
+
+  def remove_user_request_params
+    params.require(:support_requests_remove_user_request).permit(
+      :user_name, :user_email, :reason_for_removal,
+      requester_attributes: [:email, :name, :collaborator_emails],
+      time_constraint_attributes: [:not_before_date, :needed_by_date, :time_constraint_reason],
+    )
   end
 end

--- a/app/controllers/technical_fault_reports_controller.rb
+++ b/app/controllers/technical_fault_reports_controller.rb
@@ -14,6 +14,15 @@ class TechnicalFaultReportsController <  RequestsController
   end
 
   def parse_request_from_params
-    TechnicalFaultReport.new(params[:support_requests_technical_fault_report])
+    TechnicalFaultReport.new(technical_fault_report_params)
+  end
+
+  def technical_fault_report_params
+    params.require(:support_requests_technical_fault_report).permit(
+      :fault_context, :fault_specifics, :actions_leading_to_problem,
+      :what_happened, :what_should_have_happened,
+      requester_attributes: [:email, :name, :collaborator_emails],
+      fault_context_attributes: [:name, :id, :inside_government_related],
+    )
   end
 end

--- a/app/controllers/unpublish_content_requests_controller.rb
+++ b/app/controllers/unpublish_content_requests_controller.rb
@@ -14,6 +14,14 @@ class UnpublishContentRequestsController < RequestsController
   end
 
   def parse_request_from_params
-    UnpublishContentRequest.new(params[:support_requests_unpublish_content_request])
+    UnpublishContentRequest.new(unpublish_content_request_params)
+  end
+
+  def unpublish_content_request_params
+    params.require(:support_requests_unpublish_content_request).permit(
+      :urls, :reason_for_unpublishing, :further_explanation, :redirect_url,
+      :automatic_redirect,
+      requester_attributes: [:email, :name, :collaborator_emails],
+    )
   end
 end


### PR DESCRIPTION
Commit 83fab62 (which was included in #219) inadvertently
introduced a bug whereby any unexpected parameter in a POST submission
would result in a 500 error.

This was a serious problem because the 'feedback' app is submitting
requests with extra (unnecessary) fields for certain requests, including
the public support form requests and the FOI requests.

This change introduces strong params into all controller actions that
receive form submissions. Acceptable parameters are now explicitly whitelisted,
meaning that unexpected parameters are thrown away. The next step after this
is to stop the 'feedback' app from submitting unexpected params.