### PR TITLE
Improve formatting of anonymous feedback

### DIFF
--- a/app/views/anonymous_feedback/_anonymous-contact.html.erb
+++ b/app/views/anonymous_feedback/_anonymous-contact.html.erb
@@ -1,5 +1,7 @@
 <tr class="anonymous-contact">
-  <th scope="row" class="no-wrap"><%= anonymous_contact.created_at.to_date.to_s(:govuk_date) %></th>
+  <th scope="row" class="table-header-secondary no-wrap">
+    <%= anonymous_contact.created_at.to_date.to_s(:govuk_date_short) %>
+  </th>
   <td>
     <%= render partial: "feedback", locals: { anonymous_contact: anonymous_contact } %>
   </td>

--- a/app/views/anonymous_feedback/_feedback.html.erb
+++ b/app/views/anonymous_feedback/_feedback.html.erb
@@ -1,7 +1,14 @@
 <% if anonymous_contact.is_a?(Support::Requests::Anonymous::ProblemReport) %>
-  <strong>action</strong>: <%= anonymous_contact.what_doing %>
-  <br/>
-  <strong>problem</strong>: <%= anonymous_contact.what_wrong %>
+  <% if anonymous_contact.what_doing.present? %>
+    <div class="bold">
+      <span class="rm">Action:</span>
+      <%= anonymous_contact.what_doing.capitalize %>
+    </div>
+  <% end %>
+  <% if anonymous_contact.what_wrong.present? %>
+    <span class="rm">Problem:</span>
+    <%= anonymous_contact.what_wrong.capitalize if anonymous_contact.what_wrong %>
+  <% end %>
 <% elsif anonymous_contact.is_a?(Support::Requests::Anonymous::ServiceFeedback) %>
   <strong>rating</strong>: <%= anonymous_contact.service_satisfaction_rating %>
   <% if anonymous_contact.details.present? %>

--- a/app/views/anonymous_feedback/_results.html.erb
+++ b/app/views/anonymous_feedback/_results.html.erb
@@ -1,6 +1,6 @@
 <%= paginate feedback, theme: 'twitter-bootstrap-3' %>
 
-<table id="results" class="table table-hover table-bordered">
+<table id="results" class="table table-bordered">
   <thead>
     <tr class="table-header">
       <th class="no-wrap">Date</th>

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -32,12 +32,12 @@ feature "Exploring anonymous feedback" do
 
     feedback_reports = [
       {
-        "Date" => "1 March 2013",
+        "Date" => "1 Mar 2013",
         "Feedback" => "Action: Looking at 3rd paragraph Problem: Typo in 2rd word",
         "URL" => "/vat-rates",
         "Referrer" => "/"
       }, {
-        "Date" => "1 February 2013",
+        "Date" => "1 Feb 2013",
         "Feedback" => "Action: Looking at rates Problem: Standard rate is wrong",
         "URL" => "/vat-rates",
         "Referrer" => "/pay-vat"

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -33,12 +33,12 @@ feature "Exploring anonymous feedback" do
     feedback_reports = [
       {
         "Date" => "1 March 2013",
-        "Feedback" => "action: looking at 3rd paragraph problem: typo in 2rd word",
+        "Feedback" => "Action: Looking at 3rd paragraph Problem: Typo in 2rd word",
         "URL" => "/vat-rates",
         "Referrer" => "/"
       }, {
         "Date" => "1 February 2013",
-        "Feedback" => "action: looking at rates problem: standard rate is wrong",
+        "Feedback" => "Action: Looking at rates Problem: Standard rate is wrong",
         "URL" => "/vat-rates",
         "Referrer" => "/pay-vat"
       }

--- a/spec/features/user_satisfaction_survey_spec.rb
+++ b/spec/features/user_satisfaction_survey_spec.rb
@@ -24,7 +24,7 @@ feature "User satisfaction survey submissions" do
 
     expect(feedex_results).to eq([
       {
-        "Date" => "28 February 2013",
+        "Date" => "28 Feb 2013",
         "Feedback" => "rating: 3 comment: Make service less 'meh'",
         "URL" => "/done/find-court-tribunal",
         "Referrer" => ""


### PR DESCRIPTION
Make the action/problem feedback more legible by
* removing visible labels
* capitalising the start of each action/problem
* visibly rendering the action as a heading for the problem

## Before
![screen shot 2015-05-10 at 10 34 50](https://cloud.githubusercontent.com/assets/319055/7553724/96f351e6-f700-11e4-9249-6093aefe4874.png)

## After
![screen shot 2015-05-10 at 10 34 28](https://cloud.githubusercontent.com/assets/319055/7553725/9909e53a-f700-11e4-8f21-19c9009eec98.png)

cc @benilovj @rivalee