### PR TITLE
Stub requests in specs

### DIFF
--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -130,7 +130,7 @@ describe AnonymousFeedbackController, :type => :controller do
 
     context "HTML representation" do
       it "renders the results for an HTML request" do
-        get :index, path: "/tax-disc"
+        get :index, path: "/contact/govuk"
         expect(response).to have_http_status(:success)
       end
     end

--- a/spec/features/redirects_spec.rb
+++ b/spec/features/redirects_spec.rb
@@ -16,7 +16,7 @@ describe "legacy feedex URL redirect" do
 
   it "redirects the old problem report deep-links to the current anon feedback links" do
     stub_anonymous_feedback(
-      { path_prefix: "/vat-rates" },
+      { path_prefix: "/vat-etc" },
       {
         "current_page" => 1,
         "pages" => 1,
@@ -24,7 +24,7 @@ describe "legacy feedex URL redirect" do
         "results" => [],
       }
     )
-    visit '/anonymous_feedback/problem_reports?path=/vat-rates'
-    expect(current_url).to eq(current_host + '/anonymous_feedback?path=%2Fvat-rates')
+    visit '/anonymous_feedback/problem_reports?path=/vat-etc'
+    expect(current_url).to eq(current_host + '/anonymous_feedback?path=%2Fvat-etc')
   end
 end

--- a/spec/features/redirects_spec.rb
+++ b/spec/features/redirects_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 require 'uri'
+require 'gds_api/test_helpers/support_api'
 
 describe "legacy feedex URL redirect" do
+  include GdsApi::TestHelpers::SupportApi
+
   before do
     login_as create(:user)
   end
@@ -12,6 +15,15 @@ describe "legacy feedex URL redirect" do
   end
 
   it "redirects the old problem report deep-links to the current anon feedback links" do
+    stub_anonymous_feedback(
+      { path_prefix: "/vat-rates" },
+      {
+        "current_page" => 1,
+        "pages" => 1,
+        "page_size" => 1,
+        "results" => [],
+      }
+    )
     visit '/anonymous_feedback/problem_reports?path=/vat-rates'
     expect(current_url).to eq(current_host + '/anonymous_feedback?path=%2Fvat-rates')
   end


### PR DESCRIPTION
A small clean up to some of the specs' use of GdsApi request stubs.

A couple of these issues are caused by WebMock's need to have stubs explicitly cleared after use - i.e. later specs were relying on API request stubs from earlier specs. (We could try to explicitly clear stubs after use in a few different ways, if it was agreed to be worthwhile. An alternative is running the specs in a random order, as I did to find these problems this time.)

I haven't managed to get to the bottom of one of these issues. It seemed as though an API request stub from an earlier spec was being triggered from a later spec that had already performed its own request stub with the same URI. For now I've just changed their URIs to be unique. That is clearly not a long-term solution.