### PR TITLE
Prevent invalid query strings in referrers from erroring

### DIFF
--- a/app/helpers/referrer_helper.rb
+++ b/app/helpers/referrer_helper.rb
@@ -21,7 +21,7 @@ module ReferrerHelper
     uri = URI.parse(referrer)
     params = Rack::Utils.parse_query(uri.query)
     params['q'] if params['q'].present?
-  rescue URI::InvalidURIError
+  rescue URI::InvalidURIError, ArgumentError
     nil
   end
 end

--- a/spec/helpers/referrer_helper_spec.rb
+++ b/spec/helpers/referrer_helper_spec.rb
@@ -19,12 +19,22 @@ describe(ReferrerHelper) do
       expect(friendly_referrer('https://www.gov.uk/bank-holidays')).to eq('/bank-holidays')
       expect(friendly_referrer('https://www.gov.uk/')).to eq('/')
     end
+
+    it('can handle incorrectly encoded query strings') do
+      expect(friendly_referrer('https://www.gov.uk/search?q=Taxed%20to%2')).to eq('/search')
+    end
   end
 
-  it('can extract a search term from a referrer') do
-    expect(extract_search_term('https://www.gov.uk/search?q=Bank+holidays')).to eq('Bank holidays')
-    expect(extract_search_term('http://www.google.co.uk/search?q=public+holidays+in+uk&hl=en-GB&gbv=2&oq=&gs_l=')).to eq('public holidays in uk')
-    expect(extract_search_term('http://www.bing.com/search?q=4th+May+2015+Bank+Holiday&FORM=QSRE1')).to eq('4th May 2015 Bank Holiday')
+  context('extract_search_term') do
+    it('can extract a search term from a referrer') do
+      expect(extract_search_term('https://www.gov.uk/search?q=Bank+holidays')).to eq('Bank holidays')
+      expect(extract_search_term('http://www.google.co.uk/search?q=public+holidays+in+uk&hl=en-GB&gbv=2&oq=&gs_l=')).to eq('public holidays in uk')
+      expect(extract_search_term('http://www.bing.com/search?q=4th+May+2015+Bank+Holiday&FORM=QSRE1')).to eq('4th May 2015 Bank Holiday')
+    end
+
+    it('can handle incorrectly encoded query strings') do
+      expect(extract_search_term('https://www.gov.uk/search?q=Taxed%20to%2')).to eq(nil)
+    end
   end
 
 end


### PR DESCRIPTION
For certain referrer URLs  eg `Taxed%20to%2`, `Rack::Utils.parse_query(uri.query)` throws an ArgumentError: `invalid %-encoding`.

Because this is mostly an enhancement to the table, rather than attempt to decode the query correctly, return a nil search term.

Interestingly, before Ruby 2.1 this URL would have thrown `URI::InvalidURIError` and the error would have been caught.

A discussion on the nuances of this issue can be found here:
https://github.com/rack/rack/issues/337

cc @benilovj @boffbowsh 