### PR TITLE
Add support for filtering orgs by acronym

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'govuk_admin_template', '2.2.0'
 if ENV['API_DEV']
   gem "gds-api-adapters", :path => '../gds-api-adapters'
 else
-  gem "gds-api-adapters", '~> 18.9.0'
+  gem "gds-api-adapters", '~> 18.9.1'
 end
 gem 'gretel', '3.0.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     formtastic (3.1.3)
       actionpack (>= 3.2.13)
-    gds-api-adapters (18.9.0)
+    gds-api-adapters (18.9.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -314,7 +314,7 @@ DEPENDENCIES
   capybara (~> 2.4.0)
   factory_girl_rails (~> 4.5.0)
   formtastic-bootstrap!
-  gds-api-adapters (~> 18.9.0)
+  gds-api-adapters (~> 18.9.1)
   gds-sso (= 11.0.0)
   gds_zendesk (= 1.0.4)
   govuk_admin_template (= 2.2.0)

--- a/app/controllers/anonymous_feedback/explore_controller.rb
+++ b/app/controllers/anonymous_feedback/explore_controller.rb
@@ -8,10 +8,7 @@ class AnonymousFeedback::ExploreController < AuthorisationController
     @explore_by_url = Support::Requests::Anonymous::ExploreByUrl.new
     @explore_by_organisation = Support::Requests::Anonymous::ExploreByOrganisation.new(organisation: current_user.organisation_slug)
     @organisations_list = support_api.organisations_list.map do |org|
-      title = org["title"]
-      title << " (#{org["acronym"]})" if org["acronym"].present?
-      title << " [#{org["govuk_status"].titleize}]" if org["govuk_status"] && org["govuk_status"] != "live"
-      [title, org["slug"]]
+      [organisation_title(org), org["slug"]]
     end
   end
 
@@ -36,5 +33,12 @@ class AnonymousFeedback::ExploreController < AuthorisationController
 private
   def support_api
     GdsApi::SupportApi.new(Plek.find("support-api"))
+  end
+
+  def organisation_title(organisation)
+    title = organisation["title"]
+    title << " (#{organisation["acronym"]})" if organisation["acronym"].present?
+    title << " [#{organisation["govuk_status"].titleize}]" if organisation["govuk_status"] && organisation["govuk_status"] != "live"
+    title
   end
 end

--- a/spec/features/redirects_spec.rb
+++ b/spec/features/redirects_spec.rb
@@ -1,23 +1,16 @@
 require 'rails_helper'
 require 'uri'
 require 'gds_api/test_helpers/support_api'
-require 'gds_api/test_helpers/organisations'
 
 describe "legacy feedex URL redirect" do
   include GdsApi::TestHelpers::SupportApi
-  include GdsApi::TestHelpers::Organisations
-
-  def stub_organisations_api
-    organisations_slugs = %w(department-of-fair-dos)
-    organisations_api_has_organisations(organisations_slugs)
-  end
 
   before do
     login_as create(:user)
   end
 
   it "redirects the legacy feedex landing page to the current feedex landing page" do
-    stub_organisations_api
+    stub_anonymous_feedback_organisations_list
 
     visit '/anonymous_feedback/problem_reports/explore'
     expect(page.current_path).to eq('/anonymous_feedback/explore')

--- a/spec/support/app_actions.rb
+++ b/spec/support/app_actions.rb
@@ -1,12 +1,12 @@
-require 'gds_api/test_helpers/organisations'
+require 'gds_api/test_helpers/support_api'
 
 module AppActions
-  include GdsApi::TestHelpers::Organisations
+  include GdsApi::TestHelpers::SupportApi
 
   def explore_anonymous_feedback_with(options)
     visit "/"
 
-    stub_organisations_api
+    stub_anonymous_feedback_organisations_list
 
     click_on "Feedback explorer"
     assert page.has_title?("Anonymous Feedback"), page.html
@@ -15,11 +15,6 @@ module AppActions
     click_on "Explore by URL"
 
     expect(page).to have_content("Feedback for")
-  end
-
-  def stub_organisations_api
-    organisations_slugs = %w(department-of-fair-dos)
-    organisations_api_has_organisations(organisations_slugs)
   end
 
   def feedex_results


### PR DESCRIPTION
Break link to Whitehall organisations API, preferring support api organisations list
Add the status of the organisation to the list if it’s not live
Default the selected organisation to the currently logged-in user's organisation