### PR TITLE
Add sorting to organisation summary table

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import "select2";
 @import "select2-bootstrap";
 @import "breadcrumbs";
+@import "sortable_table";
 
 thead {
   background-color: $gray-lighter;

--- a/app/assets/stylesheets/sortable_table.scss
+++ b/app/assets/stylesheets/sortable_table.scss
@@ -1,0 +1,26 @@
+.table-sortable {
+  .sortable-column {
+    padding: 0;
+  }
+
+  .sortable-column div {
+    padding: $table-cell-padding;
+  }
+
+  .sortable-column a:hover,
+  .sortable-column a:focus {
+    text-decoration: none;
+
+    div {
+      background-color: #ccc;
+    }
+  }
+
+  .sorted-column div {
+    background-color: #ddd;
+  }
+
+  .sorted-column .glyphicon {
+    margin-left: 5px;
+  }
+}

--- a/app/controllers/anonymous_feedback/organisations_controller.rb
+++ b/app/controllers/anonymous_feedback/organisations_controller.rb
@@ -4,15 +4,21 @@ class AnonymousFeedback::OrganisationsController < AuthorisationController
   def show
     authorize! :read, :anonymous_feedback
 
-    api_response = fetch_organisation_summary_from_support_api
+    if %w(path last_7_days last_30_days last_90_days).include? params[:ordering]
+      @ordering = params[:ordering]
+    else
+      @ordering = 'last_7_days'
+    end
+
+    api_response = fetch_organisation_summary_from_support_api(@ordering)
 
     @organisation_title = api_response["title"]
     @content_items = OrganisationSummaryPresenter.new(api_response)
   end
 
 private
-  def fetch_organisation_summary_from_support_api
-    support_api.organisation_summary(params[:slug])
+  def fetch_organisation_summary_from_support_api(ordering)
+    support_api.organisation_summary(params[:slug], ordering: ordering)
   end
 
   def support_api

--- a/app/presenters/organisation_summary_presenter.rb
+++ b/app/presenters/organisation_summary_presenter.rb
@@ -8,10 +8,6 @@ class OrganisationSummaryPresenter < SimpleDelegator
 
 private
   def present_results(results)
-    sort_results(results).map { |entry| OpenStruct.new(entry) }
-  end
-
-  def sort_results(results)
-    results.sort_by { |content_item| content_item["path"] }
+    results.map { |entry| OpenStruct.new(entry) }
   end
 end

--- a/app/views/anonymous_feedback/organisations/show.html.erb
+++ b/app/views/anonymous_feedback/organisations/show.html.erb
@@ -4,13 +4,30 @@
 
 <% breadcrumb :feedex %>
 
-<table class="table table-bordered" data-module="filterable-table">
+<table class="table table-bordered table-sortable" data-module="filterable-table">
   <thead>
     <tr class="table-header">
-      <th style="width: 800px">Page</th>
-      <th>7 days</th>
-      <th>30 days</th>
-      <th>90 days</th>
+      <% {
+          path: 'Page',
+          last_7_days: '7 days',
+          last_30_days: '30 days',
+          last_90_days: '90 days',
+        }.each do |param, name| %>
+        <% sorted = @ordering == param.to_s %>
+        <th class="sortable-column<% if sorted %> sorted-column<% end %>">
+          <% if sorted %>
+            <div>
+              <%= name %><span class="glyphicon glyphicon-arrow-down"></span>
+            </div>
+          <% else %>
+            <a href="?ordering=<%= param %>" class="link-inherit" title="Sort table by this column">
+              <div>
+                <%= name %>
+              </div>
+            </a>
+          <% end %>
+        </th>
+      <% end %>
     </tr>
     <tr class="if-no-js-hide table-header-secondary">
       <td colspan="4">

--- a/spec/features/feedex_organisation_summary_spec.rb
+++ b/spec/features/feedex_organisation_summary_spec.rb
@@ -9,11 +9,11 @@ feature "Summary of Organisation feedback" do
 
   before do
     stub_summary_sorted_by('last_7_days')
-    explore_anonymous_feedback_with(organisation: "Department Of Fair Dos")
+    explore_anonymous_feedback_with(organisation: "Cabinet Office")
   end
 
   scenario "defaults to sorting feedback by last 7 days" do
-    expect(page).to have_content("Feedback for Department of Fair Dos")
+    expect(page).to have_content("Feedback for Cabinet Office")
     expect(organisation_summary_results).to eq(organisation_summary)
     expect(page).to have_selector('th.sorted-column', text: "7 days")
   end
@@ -36,8 +36,8 @@ feature "Summary of Organisation feedback" do
   end
 
   def stub_summary_sorted_by(ordering)
-    stub_anonymous_feedback_organisation_summary('department-of-fair-dos', ordering, {
-      "title" => "Department of Fair Dos",
+    stub_anonymous_feedback_organisation_summary('cabinet-office', ordering, {
+      "title" => "Cabinet Office",
       "anonymous_feedback_counts" => [
         { path: '/done-well', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
         { path: '/not-bad-my-friend' },

--- a/spec/features/feedex_organisation_summary_spec.rb
+++ b/spec/features/feedex_organisation_summary_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/support_api'
+
+feature "Summary of Organisation feedback" do
+  include GdsApi::TestHelpers::SupportApi
+  background do
+    login_as create(:user)
+  end
+
+  before do
+    stub_summary_sorted_by('last_7_days')
+    explore_anonymous_feedback_with(organisation: "Department Of Fair Dos")
+  end
+
+  scenario "defaults to sorting feedback by last 7 days" do
+    expect(page).to have_content("Feedback for Department of Fair Dos")
+    expect(organisation_summary_results).to eq(organisation_summary)
+    expect(page).to have_selector('th.sorted-column', text: "7 days")
+  end
+
+  scenario "organisation feedback table can be sorted by path, 7, 30 and 90 days" do
+    {
+      path: 'Page',
+      last_7_days: '7 days',
+      last_30_days: '30 days',
+      last_90_days: '90 days',
+    }.each do |param, name|
+      stub_summary_sorted_by(param.to_s)
+      within '.table-sortable thead' do
+        click_on name
+      end
+      expect(organisation_summary_results).to eq(organisation_summary)
+      expect(page).to have_selector('th.sorted-column', text: name)
+      expect(page).to have_no_selector('th a', text: name)
+    end
+  end
+
+  def stub_summary_sorted_by(ordering)
+    stub_anonymous_feedback_organisation_summary('department-of-fair-dos', ordering, {
+      "title" => "Department of Fair Dos",
+      "anonymous_feedback_counts" => [
+        { path: '/done-well', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
+        { path: '/not-bad-my-friend' },
+        { path: '/fair-enough' },
+      ],
+    })
+  end
+
+  def organisation_summary
+    [
+      {
+        "Page" => "/done-well",
+        "7 days" => "5 items",
+        "30 days" => "10 items",
+        "90 days" => "20 items",
+      }, {
+        "Page" => "/not-bad-my-friend",
+        "7 days" => "0 items",
+        "30 days" => "0 items",
+        "90 days" => "0 items",
+      }, {
+        "Page" => "/fair-enough",
+        "7 days" => "0 items",
+        "30 days" => "0 items",
+        "90 days" => "0 items",
+      }
+    ]
+  end
+end

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -67,8 +67,8 @@ feature "Exploring anonymous feedback" do
   end
 
   scenario "exploring feedback by organisation" do
-    stub_anonymous_feedback_organisation_summary('department-of-fair-dos', 'last_7_days', {
-      "title" => "Department of Fair Dos",
+    stub_anonymous_feedback_organisation_summary('cabinet-office', 'last_7_days', {
+      "title" => "Cabinet Office",
       "anonymous_feedback_counts" => [
         { path: '/done-well', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
         { path: '/not-bad-my-friend' },
@@ -95,8 +95,8 @@ feature "Exploring anonymous feedback" do
       }
     ]
 
-    explore_anonymous_feedback_with(organisation: "Department Of Fair Dos")
-    expect(page).to have_content("Feedback for Department of Fair Dos")
+    explore_anonymous_feedback_with(organisation: "Cabinet Office")
+    expect(page).to have_content("Feedback for Cabinet Office")
     expect(organisation_summary_results).to eq(organisation_summary)
   end
 end

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -65,4 +65,38 @@ feature "Exploring anonymous feedback" do
 
     expect(page).to have_content("There’s no feedback for this URL.")
   end
+
+  scenario "exploring feedback by organisation" do
+    stub_anonymous_feedback_organisation_summary('department-of-fair-dos', 'last_7_days', {
+      "title" => "Department of Fair Dos",
+      "anonymous_feedback_counts" => [
+        { path: '/done-well', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
+        { path: '/not-bad-my-friend' },
+        { path: '/fair-enough' },
+      ],
+    })
+
+    organisation_summary = [
+      {
+        "Page" => "/done-well",
+        "7 days" => "5 items",
+        "30 days" => "10 items",
+        "90 days" => "20 items",
+      }, {
+        "Page" => "/not-bad-my-friend",
+        "7 days" => "0 items",
+        "30 days" => "0 items",
+        "90 days" => "0 items",
+      }, {
+        "Page" => "/fair-enough",
+        "7 days" => "0 items",
+        "30 days" => "0 items",
+        "90 days" => "0 items",
+      }
+    ]
+
+    explore_anonymous_feedback_with(organisation: "Department Of Fair Dos")
+    expect(page).to have_content("Feedback for Department of Fair Dos")
+    expect(organisation_summary_results).to eq(organisation_summary)
+  end
 end

--- a/spec/presenters/organisation_summary_presenter_spec.rb
+++ b/spec/presenters/organisation_summary_presenter_spec.rb
@@ -42,11 +42,5 @@ describe OrganisationSummaryPresenter, type: :presenter do
     it "should match api_response's `anonymous_feedback_counts`" do
       expect(presenter.size).to eql(3)
     end
-
-    it "should sort `anonymous_feedback_counts` by `path`" do
-      expect(presenter[0].path).to eql(path_a)
-      expect(presenter[1].path).to eql(path_b)
-      expect(presenter[2].path).to eql(path_c)
-    end
   end
 end

--- a/spec/support/app_actions.rb
+++ b/spec/support/app_actions.rb
@@ -10,9 +10,14 @@ module AppActions
 
     click_on "Feedback explorer"
     assert page.has_title?("Anonymous Feedback"), page.html
-    fill_in 'URL', with: options[:url]
 
-    click_on "Explore by URL"
+    if options[:url].present?
+      fill_in 'URL', with: options[:url]
+      click_on "Explore by URL"
+    else
+      select options[:organisation], from: 'Organisation'
+      click_on "Explore by organisation"
+    end
 
     expect(page).to have_content("Feedback for")
   end
@@ -20,6 +25,12 @@ module AppActions
   def feedex_results
     all_cells = find('table#results').all('tr').map { |row| row.all('th, td').map { |cell| cell.text.strip } }
     first_row, results = all_cells[0], all_cells[1..-1]
+    results.collect { |row| Hash[first_row.zip(row)] }
+  end
+
+  def organisation_summary_results
+    all_cells = find('table').all('tr').map { |row| row.all('th, td').map { |cell| cell.text.strip } }
+    first_row, results = all_cells[0], all_cells[2..-1]
     results.collect { |row| Hash[first_row.zip(row)] }
   end
 


### PR DESCRIPTION
* Make table header cells clickable and use them to sort the table by those columns
* Default to last 7 days sorting
* Add spec for browsing by organisation

![support-table-sorting](https://cloud.githubusercontent.com/assets/319055/7808314/355d90e0-038a-11e5-87b3-de9d11511bf8.gif)

Part of https://tree.taiga.io/project/core-improvement-theme/us/12?kanban-status=211675

cc @boffbowsh @benilovj