### PR TITLE
Keep items columns readable

### DIFF
--- a/app/assets/stylesheets/sortable_table.scss
+++ b/app/assets/stylesheets/sortable_table.scss
@@ -24,3 +24,7 @@
     margin-left: 5px;
   }
 }
+
+.item-count-column {
+  min-width: 100px;
+}

--- a/app/views/anonymous_feedback/organisations/show.html.erb
+++ b/app/views/anonymous_feedback/organisations/show.html.erb
@@ -14,7 +14,7 @@
           last_90_days: '90 days',
         }.each do |param, name| %>
         <% sorted = @ordering == param.to_s %>
-        <th class="sortable-column<% if sorted %> sorted-column<% end %>">
+        <th class="<% unless param == :path %>item-count-column <% end %>sortable-column<% if sorted %> sorted-column<% end %>">
           <% if sorted %>
             <div>
               <%= name %><span class="glyphicon glyphicon-arrow-down"></span>


### PR DESCRIPTION
On pages with long URLs the path column was stretching out and squishing the “X items” columns.

* Add a minimum width to prevent this

![screen shot 2015-05-26 at 13 57 21](https://cloud.githubusercontent.com/assets/319055/7813016/2a573d0c-03af-11e5-959c-612f1b731c14.png)