### PR TITLE
[DO NOT MERGE] Added Universal Analytics tracking for date picker

### DIFF
--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -14,8 +14,8 @@ class AnonymousFeedbackController < RequestsController
         redirect_to anonymous_feedback_index_path(index_params.merge(page: 1))
       else
         @feedback = AnonymousFeedbackPresenter.new(api_response)
-        @from_date = Date.parse(api_response["from_date"]).to_s(:govuk_date_short) if api_response["from_date"]
-        @to_date = Date.parse(api_response["to_date"]).to_s(:govuk_date_short) if api_response["to_date"]
+        @from_date = Date.parse(api_response["from_date"]) if api_response["from_date"]
+        @to_date = Date.parse(api_response["to_date"]) if api_response["to_date"]
 
         respond_to do |format|
           format.html

--- a/app/helpers/date_filter_helper.rb
+++ b/app/helpers/date_filter_helper.rb
@@ -12,7 +12,10 @@ module DateFilterHelper
     attempted_to_filter? && !date_filtered?
   end
 
-  def total_responses_header(total_count, from, to)
+  def total_responses_header(total_count, from_date, to_date)
+    from = from_date.to_s(:govuk_date_short) if from_date
+    to = to_date.to_s(:govuk_date_short) if to_date
+
     response_total = pluralize(number_with_delimiter(total_count), 'response')
 
     if from.present? and to.present?
@@ -26,5 +29,26 @@ module DateFilterHelper
     else
       response_total
     end
+  end
+
+  def date_range_track_action(from_date=nil, to_date=nil)
+    if from_date && to_date
+      "filtering between two dates"
+    elsif from_date
+      "filtering everything since date"
+    elsif to_date
+      "filtering everying before date"
+    else
+      "no filtering"
+    end
+  end
+
+  def date_range_track_label(from_date, to_date)
+    from_date ||= Date.new(1970,1,1)
+    to_date ||= Date.current
+    date_range = distance_of_time_in_words(from_date, to_date)
+    date_ago = time_ago_in_words(to_date)
+    date_ago = 0 if to_date.at_middle_of_day() == Date.current.at_middle_of_day()
+    return "selected date range: #{date_range}, time between search and 'to' date provided: #{date_ago}"
   end
 end

--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -16,19 +16,27 @@
           </h3>
         </div>
       <% end %>
-      <form action="<% anonymous_feedback_index_path%>" class="form-inline date-filter-form panel-body">
+      <form action="<% anonymous_feedback_index_path%>" class="form-inline date-filter-form panel-body"
+        <% if date_filtered? %>
+          data-module="auto-track-event"
+          data-track-action="<%= date_range_track_action(@from_date, @to_date) %>"
+          data-track-label="<%= date_range_track_label(@from_date, @to_date) %>"
+        <% end %>
+      >
         <input type="hidden" name="path" value="<%= params[:path]%>" />
         <fieldset>
           <legend class="rm">Filter feedback by date</legend>
           <label class="add-right-margin" for="start-date">
             Show feedback between <span class="rm">starting date</span>
           </label>
+
           <input type="text" name="from" id="start-date" class="input-sm form-control add-right-margin" data-module="calendar" data-max-date="0" value="<%= params[:from]%>"/>
 
           <label class="add-right-margin" for="end-date">and <span class="rm">end date</span></label>
           <input type="text" name="to" id="end-date" class="form-control input-sm" data-module="calendar" data-max-date="0" value="<%= params[:to]%>"/>
 
           <input type="submit" value="Filter" class="btn-sm btn btn-default add-left-margin" />
+
           <% if attempted_to_filter? %>
             <%= link_to anonymous_feedback_index_path(path:params[:path]), class: "inherit remove-filter pull-right" do %>
               <span class="glyphicon glyphicon-remove"></span>
@@ -52,4 +60,3 @@
 <% else %>
   <%= render partial: "results", locals: { feedback: @feedback } %>
 <% end %>
-

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,13 @@
   </div>
 
   <%= yield %>
+    <% if Rails.env.development? %>
+      <script>
+        window.ga = function() {
+          console.log(arguments);
+        }
+      </script>
+    <% end %>
 <% end %>
 
 <% content_for(:footer_version) { CURRENT_RELEASE_SHA } %>

--- a/spec/helpers/date_filter_helper_spec.rb
+++ b/spec/helpers/date_filter_helper_spec.rb
@@ -14,9 +14,9 @@ describe(DateFilterHelper) do
 
   context('total_responses_header') do
     it('gives details about responses and date filter') do
-      expect(total_responses_header(1000, '10 May', '11 May')).to eq('1,000 responses between 10 May and 11 May')
-      expect(total_responses_header(1000, '10 May',  nil)).to eq('1,000 responses since 10 May')
-      expect(total_responses_header(1000, nil, '11 May')).to eq('1,000 responses before 11 May')
+      expect(total_responses_header(1000, Date.new(2015, 05, 10), Date.new(2015, 05, 11))).to eq('1,000 responses between 10 May 2015 and 11 May 2015')
+      expect(total_responses_header(1000, Date.new(2015, 05, 10),  nil)).to eq('1,000 responses since 10 May 2015')
+      expect(total_responses_header(1000, nil, Date.new(2015, 05, 11))).to eq('1,000 responses before 11 May 2015')
       expect(total_responses_header(1000, nil, nil)).to eq('All 1,000 responses')
       expect(total_responses_header(1, nil, nil)).to eq('1 response')
     end


### PR DESCRIPTION
[DO NOT MERGE] - in the process of implementing oral feedback from Jake Benilov!

eventAction is tracking: whether date ranges provided 'to' date, 'from' date, neither or both.
eventLabel is tracking:
1) length of date range chosen by users, which will later help decide on preset time filters to add to feedex.
2) time between search and 'to' date provided. If the user does a search of all anonymous contacts  until today, it will return 0.

Added script that will run in development to display the values sent to Google Analytics. In production, this will be performed by the [gov_uk_admin_template](https://github.com/alphagov/govuk_admin_template) gem.

![screen shot 2015-05-27 at 14 41 42](https://cloud.githubusercontent.com/assets/8225167/7837503/428cbe3a-047f-11e5-982c-f004e506f02d.png)

cc @fofr @benilovj @boffbowsh 