### PR TITLE
Improve wrapping of date filter at small widths

### DIFF
--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -13,7 +13,7 @@
 </form>
 
 <div class="row">
-  <div class="col-md-8">
+  <div class="col-lg-8 col-md-9">
     <div class="panel <% if invalid_filter? %>panel-warning<% else %>panel-default<% end %>">
       <% if invalid_filter? %>
         <div class="panel-heading">
@@ -58,4 +58,3 @@
 <% else %>
   <%= render partial: "results", locals: { feedback: @feedback } %>
 <% end %>
-


### PR DESCRIPTION
At thin widths the container size wasn’t large enough to contain the form as well as the reset filter button.

* Give the form more space at medium page widths
* Keep the space the same at larger ones

Prevents:
![screen shot 2015-06-05 at 15 18 36](https://cloud.githubusercontent.com/assets/319055/8007822/38855992-0b96-11e5-9626-24f388c472dc.png)

cc @benilovj 