### PR TITLE
Bump gds-zendesk gem to 1.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'jc-validates_timeliness', '3.1.1'
 if ENV['GDS_ZENDESK_DEV']
   gem "gds_zendesk", :path => '../gds_zendesk'
 else
-  gem "gds_zendesk", '1.0.4'
+  gem "gds_zendesk", '1.0.5'
 end
 gem 'redis', '3.2.1'
 gem "sidekiq", "3.3.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,9 +102,9 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    gds_zendesk (1.0.4)
+    gds_zendesk (1.0.5)
       null_logger (= 0.0.1)
-      zendesk_api (= 1.6.3)
+      zendesk_api (= 1.8.0)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
     govuk_admin_template (2.2.0)
@@ -296,9 +296,9 @@ GEM
       crack (>= 0.3.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    zendesk_api (1.6.3)
+    zendesk_api (1.8.0)
       faraday (~> 0.9)
-      hashie (>= 1.2, < 4.0)
+      hashie (>= 1.2, < 4.0, != 3.3.0)
       inflection
       mime-types
       multi_json
@@ -316,7 +316,7 @@ DEPENDENCIES
   formtastic-bootstrap!
   gds-api-adapters (~> 18.11.0)
   gds-sso (= 11.0.0)
-  gds_zendesk (= 1.0.4)
+  gds_zendesk (= 1.0.5)
   govuk_admin_template (= 2.2.0)
   gretel (= 3.0.8)
   jasmine (= 2.3.0)


### PR DESCRIPTION
This picks up a fix for a bug that meant Zendesk ticket creation
failed silently if the Zendesk API suddenly started returning redirects.