### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'govuk_admin_template', '2.3.1'
 if ENV['API_DEV']
   gem "gds-api-adapters", :path => '../gds-api-adapters'
 else
-  gem "gds-api-adapters", '~> 18.11.0'
+  gem "gds-api-adapters", '20.1.1'
 end
 gem 'gretel', '3.0.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     formtastic (3.1.3)
       actionpack (>= 3.2.13)
-    gds-api-adapters (18.11.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -177,7 +177,7 @@ GEM
     plek (1.10.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.2)
+    rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-cache (1.2)
@@ -314,7 +314,7 @@ DEPENDENCIES
   capybara (~> 2.4.0)
   factory_girl_rails (~> 4.5.0)
   formtastic-bootstrap!
-  gds-api-adapters (~> 18.11.0)
+  gds-api-adapters (= 20.1.1)
   gds-sso (= 11.0.0)
   gds_zendesk (= 1.0.5)
   govuk_admin_template (= 2.3.1)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information