### PR TITLE
Move dates to comment body

### DIFF
--- a/app/controllers/content_advice_requests_controller.rb
+++ b/app/controllers/content_advice_requests_controller.rb
@@ -20,9 +20,9 @@ class ContentAdviceRequestsController < RequestsController
   def content_advice_request_params
     params.require(:support_requests_content_advice_request).permit(
       :title, :nature_of_request, :nature_of_request_details,
-      :details, :urls, :response_needed_by_date, :reason_for_deadline,
-      :contact_number,
+      :details, :urls, :contact_number,
       requester_attributes: [:email, :name, :collaborator_emails],
+      time_constraint_attributes: [:needed_by_date, :time_constraint_reason],
     )
   end
 end

--- a/app/views/content_advice_requests/_request_details.html.erb
+++ b/app/views/content_advice_requests/_request_details.html.erb
@@ -22,10 +22,12 @@
               input_html: { class: "input-md-6" } %>
 <% end %>
 
-<%= f.inputs name: "Time constraints" do %>
-  <%= f.input :response_needed_by_date,
-              label: "Is there a date you need to have a response by?",
-              input_html: { class: "input-md-2", :"data-module" => 'calendar', :"data-format" => 'dd-mm-yy', :"data-min-date" => 0, :placeholder => "dd-mm-yyyy", :value => f.object.response_needed_by_date } %>
+<%= f.semantic_fields_for :time_constraint do |r| %>
+  <%= r.inputs name: "Time constraints" do %>
+    <%= r.input :needed_by_date,
+                label: "Is there a date you need to have a response by?",
+                input_html: { class: "input-md-2", :"data-module" => 'calendar', :"data-format" => 'dd-mm-yy', :"data-min-date" => 0, :placeholder => "dd-mm-yyyy", :value => r.object.needed_by_date } %>
 
-  <%= f.input :reason_for_deadline, label: "Reason for deadline", input_html: { class: "input-md-6" } %>
+    <%= r.input :time_constraint_reason, label: "Reason for deadline", input_html: { class: "input-md-6" } %>
+  <% end %>
 <% end %>

--- a/lib/support/requests/content_advice_request.rb
+++ b/lib/support/requests/content_advice_request.rb
@@ -1,12 +1,14 @@
 require 'support/requests/request'
+require 'support/requests/with_time_constraint'
 require 'active_support/core_ext'
 
 module Support
   module Requests
     class ContentAdviceRequest < Request
+      include WithTimeConstraint
+
       attr_accessor :title, :nature_of_request, :nature_of_request_details,
-                    :details, :urls, :response_needed_by_date, :reason_for_deadline,
-                    :contact_number
+                    :details, :urls, :contact_number
 
       validates_presence_of :nature_of_request
       validates_presence_of :details
@@ -18,8 +20,11 @@ module Support
       validates_presence_of :nature_of_request_details,
         if: Proc.new { |r| r.nature_of_request == 'other' }
 
-      validates_date :response_needed_by_date,
-        allow_nil: true, allow_blank: true, on_or_after: :today
+      def initialize(attrs = {})
+        self.time_constraint = TimeConstraint.new
+
+        super
+      end
 
       def nature_of_request_options
         [

--- a/lib/zendesk/ticket/content_advice_request_ticket.rb
+++ b/lib/zendesk/ticket/content_advice_request_ticket.rb
@@ -26,16 +26,13 @@ module Zendesk
           request_label(field: :details),
           request_label(field: :urls,
                         label: "Relevant URLs"),
-          request_label(field: :response_needed_by_date,
-                        label: "Date needed by"),
-          request_label(field: :reason_for_deadline),
           request_label(field: :contact_number),
         ]
       end
 
       def deadline_date
-        if @request.response_needed_by_date && !@request.response_needed_by_date.empty?
-          Date.parse(@request.response_needed_by_date).strftime("%-d %b")
+        if needed_by_date && !needed_by_date.empty?
+          Date.parse(needed_by_date).strftime("%-d %b")
         end
       end
     end

--- a/lib/zendesk/ticket/content_change_request_ticket.rb
+++ b/lib/zendesk/ticket/content_change_request_ticket.rb
@@ -27,7 +27,6 @@ module Zendesk
                                                             label: "Related URLs"),
           LabelledSnippet.new(on: @request,                 field: :details_of_change,
                                                             label: "Details of what should be added, amended or removed"),
-          LabelledSnippet.new(on: @request.time_constraint, field: :time_constraint_reason)
         ]
       end
     end

--- a/lib/zendesk/ticket/new_feature_request_ticket.rb
+++ b/lib/zendesk/ticket/new_feature_request_ticket.rb
@@ -24,7 +24,6 @@ module Zendesk
                                                             label: "Which part of GOV.UK is this about?"),
           LabelledSnippet.new(on: @request,                 field: :user_need),
           LabelledSnippet.new(on: @request,                 field: :url_of_example),
-          LabelledSnippet.new(on: @request.time_constraint, field: :time_constraint_reason)
         ]
       end
     end

--- a/lib/zendesk/zendesk_ticket.rb
+++ b/lib/zendesk/zendesk_ticket.rb
@@ -16,7 +16,7 @@ module Zendesk
     def_delegators :@requester, :email, :name, :collaborator_emails
 
     def comment
-      SnippetCollection.new(comment_snippets).to_s
+      SnippetCollection.new(base_comment_snippets + comment_snippets).to_s
     end
 
     def not_before_date
@@ -44,11 +44,22 @@ module Zendesk
     end
 
     def to_s
-      SnippetCollection.new(base_attribute_snippets + comment_snippets).to_s
+      SnippetCollection.new(base_attribute_snippets + base_comment_snippets + comment_snippets).to_s
     end
 
     def priority
       "normal"
+    end
+
+    def base_comment_snippets
+      if has_value?(:time_constraint)
+        [
+          LabelledSnippet.new(on: self, field: :needed_by_date, label: "Needed by date"),
+          LabelledSnippet.new(on: self, field: :not_before_date, label: "Not before date"),
+        ]
+      else
+        []
+      end
     end
 
     def comment_snippets

--- a/lib/zendesk/zendesk_ticket.rb
+++ b/lib/zendesk/zendesk_ticket.rb
@@ -56,6 +56,7 @@ module Zendesk
         [
           LabelledSnippet.new(on: self, field: :needed_by_date, label: "Needed by date"),
           LabelledSnippet.new(on: self, field: :not_before_date, label: "Not before date"),
+          LabelledSnippet.new(on: @request.time_constraint, field: :time_constraint_reason, label: "Reason for time constraint")
         ]
       else
         []

--- a/lib/zendesk/zendesk_tickets.rb
+++ b/lib/zendesk/zendesk_tickets.rb
@@ -7,8 +7,6 @@ class ZendeskTickets
       :priority => ticket_to_raise.priority,
       :requester => {"locale_id" => 1, "email" => ticket_to_raise.email, "name" => ticket_to_raise.name},
       :collaborators => ticket_to_raise.collaborator_emails,
-      :fields => [{"id" => GDSZendesk::FIELD_MAPPINGS[:needed_by_date],  "value" => ticket_to_raise.needed_by_date},
-                  {"id" => GDSZendesk::FIELD_MAPPINGS[:not_before_date], "value" => ticket_to_raise.not_before_date}],
       :tags => ticket_to_raise.tags,
       :comment => { "body" => ticket_to_raise.comment }
     })

--- a/spec/features/content_advice_requests_spec.rb
+++ b/spec/features/content_advice_requests_spec.rb
@@ -17,7 +17,13 @@ feature "Request for content advice" do
       "subject" => "Needed by 12 Jan: Which format - Advice on content",
       "tags" => [ "govt_form", "dept_content_advice" ],
       "comment" => { "body" =>
-"[Nature of the request]
+"[Needed by date]
+12-01-2020
+
+[Reason for time constraint]
+Ministerial announcement Z
+
+[Nature of the request]
 Initial guidance from GOV.UK on content you are working on
 
 [Details]
@@ -25,12 +31,6 @@ I need help to choose a format, here's my content...
 
 [Relevant URLs]
 https://www.gov.uk/x, https://www.gov.uk/y
-
-[Date needed by]
-12-01-2020
-
-[Reason for deadline]
-Ministerial announcement Z
 
 [Contact number]
 0121 111111"})

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -24,6 +24,9 @@ feature "Content change requests" do
 [Not before date]
 01-12-2020
 
+[Reason for time constraint]
+New law
+
 [Which part of GOV.UK is this about?]
 Services and information
 
@@ -34,10 +37,7 @@ http://gov.uk/X
 XXXXX
 
 [Details of what should be added, amended or removed]
-Out of date XX YY
-
-[Time constraint reason]
-New law"})
+Out of date XX YY"})
 
     user_makes_a_content_change_request(
       title: "Update X",

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -17,12 +17,14 @@ feature "Content change requests" do
       "subject" => "Update X - Content change request",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => [ "govt_form", "content_amend" ],
-      "fields" => [
-        { "id" => GDSZendesk::FIELD_MAPPINGS[:needed_by_date], "value" => "31-12-2020" },
-        { "id" => GDSZendesk::FIELD_MAPPINGS[:not_before_date], "value" => "01-12-2020" }
-      ],
       "comment" => { "body" =>
-"[Which part of GOV.UK is this about?]
+"[Needed by date]
+31-12-2020
+
+[Not before date]
+01-12-2020
+
+[Which part of GOV.UK is this about?]
 Services and information
 
 [URL of content to be changed]

--- a/spec/features/new_feature_requests_spec.rb
+++ b/spec/features/new_feature_requests_spec.rb
@@ -17,12 +17,14 @@ feature "New feature requests" do
       "subject" => "Abc - New Feature Request",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => [ "govt_form", "new_feature_request", "inside_government" ],
-      "fields" => [
-        { "id" => GDSZendesk::FIELD_MAPPINGS[:needed_by_date], "value" => "31-12-2020" },
-        { "id" => GDSZendesk::FIELD_MAPPINGS[:not_before_date], "value" => "01-12-2020" }
-      ],
       "comment" => { "body" =>
-"[Which part of GOV.UK is this about?]
+"[Needed by date]
+31-12-2020
+
+[Not before date]
+01-12-2020
+
+[Which part of GOV.UK is this about?]
 Departments and policy
 
 [User need]

--- a/spec/features/new_feature_requests_spec.rb
+++ b/spec/features/new_feature_requests_spec.rb
@@ -24,6 +24,9 @@ feature "New feature requests" do
 [Not before date]
 01-12-2020
 
+[Reason for time constraint]
+Legal requirement
+
 [Which part of GOV.UK is this about?]
 Departments and policy
 
@@ -31,10 +34,7 @@ Departments and policy
 Information on XYZ
 
 [Url of example]
-http://www.example.com
-
-[Time constraint reason]
-Legal requirement"})
+http://www.example.com"})
 
     user_makes_a_new_feature_request(
       title: "Abc",

--- a/spec/features/remove_user_requests_spec.rb
+++ b/spec/features/remove_user_requests_spec.rb
@@ -16,10 +16,12 @@ feature "Remove user requests" do
     request = expect_zendesk_to_receive_ticket(
       "subject" => "Remove user",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
-      "fields" => array_including("id" => GDSZendesk::FIELD_MAPPINGS[:not_before_date], "value" => "31-12-2020"),
       "tags" => [ "govt_form", "remove_user" ],
       "comment" => { "body" =>
-"[User name]
+"[Not before date]
+31-12-2020
+
+[User name]
 Bob
 
 [User email]

--- a/spec/models/support/requests/content_advice_request_spec.rb
+++ b/spec/models/support/requests/content_advice_request_spec.rb
@@ -10,12 +10,7 @@ module Support
       it { should allow_value("xxx").for(:nature_of_request_details) }
       it { should allow_value("xxx").for(:urls) }
 
-      it { should allow_value(nil).for(:response_needed_by_date) }
-      it { should allow_value(as_str(Date.today + 1)).for(:response_needed_by_date) }
-      it { should_not allow_value("x").for(:response_needed_by_date) }
-
       it { should validate_presence_of(:nature_of_request) }
-      it { should allow_value("xxx").for(:reason_for_deadline) }
       it { should allow_value("xxx").for(:contact_number) }
 
       its(:nature_of_request_options) { is_expected.to have_exactly(3).items }

--- a/spec/models/zendesk/ticket/content_advice_request_ticket_spec.rb
+++ b/spec/models/zendesk/ticket/content_advice_request_ticket_spec.rb
@@ -5,7 +5,7 @@ module Zendesk
   module Ticket
     describe ContentAdviceRequestTicket do
       def ticket(opts = {})
-        defaults = { requester: nil, title: nil, response_needed_by_date: nil }
+        defaults = { requester: nil, title: nil, time_constraint: double(needed_by_date: nil) }
         ContentAdviceRequestTicket.new(double(defaults.merge(opts)))
       end
 
@@ -18,7 +18,7 @@ module Zendesk
       end
 
       it "contains the deadline in the subject, if one is provided" do
-        t = ticket(title: "Abc", response_needed_by_date: "12-04-2020")
+        t = ticket(title: "Abc", time_constraint: double(needed_by_date: "12-04-2020"))
         expect(t.subject).to eq("Needed by 12 Apr: Abc - Advice on content")
       end
     end


### PR DESCRIPTION
By moving the dates to the comment body, they're always displayed. At the moment, they're only displayed if the user turns on "Show all events".

This also includes a refactoring to use the TimeConstraint code for ContentAdviceRequests, which builds on the first commit. This second bit could be split off if needed.