### PR TITLE
Update the 'create or change a user account' form in Support app

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,3 +48,7 @@ thead {
 .remove-filter {
   margin-top: 6px;
 }
+
+.managing_editor_note {
+  margin-left: 20px;
+}

--- a/app/controllers/create_or_change_user_requests_controller.rb
+++ b/app/controllers/create_or_change_user_requests_controller.rb
@@ -22,7 +22,7 @@ class CreateOrChangeUserRequestsController < RequestsController
   def create_or_change_user_request_params
     params.require(:support_requests_create_or_change_user_request).permit(
       :action, :additional_comments,
-      user_needs: [],
+      :user_needs,
       requester_attributes: [:email, :name, :collaborator_emails],
       requested_user_attributes: [:name, :email, :job, :phone],
     )

--- a/app/controllers/create_or_change_user_requests_controller.rb
+++ b/app/controllers/create_or_change_user_requests_controller.rb
@@ -22,7 +22,7 @@ class CreateOrChangeUserRequestsController < RequestsController
   def create_or_change_user_request_params
     params.require(:support_requests_create_or_change_user_request).permit(
       :action, :additional_comments,
-      :user_needs,
+      :user_needs,:mainstream_changes, :maslow, :other_details,
       requester_attributes: [:email, :name, :collaborator_emails],
       requested_user_attributes: [:name, :email, :job, :phone],
     )

--- a/app/views/create_or_change_user_requests/_request_details.html.erb
+++ b/app/views/create_or_change_user_requests/_request_details.html.erb
@@ -1,5 +1,5 @@
 <div id="action">
-   <%= f.input :action, as: :radio, required: true, label: "What would you like to request?", collection: f.object.action_options, input_html: { :"aria-required" => true } %>
+   <%= f.input :action, as: :radio, required: true, label: "What would you like to do?", collection: f.object.action_options, input_html: { :"aria-required" => true } %>
 </div>
 
 <br/>
@@ -7,7 +7,7 @@
 <%= render partial: 'support/user_needs', locals: { f: f } %>
 
 <div id="user_details" %>
-  <%= render partial: 'requested_user_details', locals: { f: f } %>  
+  <%= render partial: 'requested_user_details', locals: { f: f } %>
 </div>
 
 <%= f.input :additional_comments, as: :text, label: "Additional comments", input_html: { class: "input-md-6", rows: 6, cols: 50 } %>

--- a/app/views/support/_user_needs.html.erb
+++ b/app/views/support/_user_needs.html.erb
@@ -1,12 +1,20 @@
 <div id="user-needs"<%= ' class="has-error"'.html_safe if f.object.errors[:formatted_user_needs].any? %>>
   <div id="whitehall">
-     <%= f.input :user_needs, as: :radio, label: "Select Whitehall user account", collection: f.object.whitehall_account_options %>
+    <%= f.input :user_needs, as: :radio, label: "Select type of Whitehall user account (optional)", collection: f.object.whitehall_account_options %>
+    <div class="managing_editor_note">
+      A managing editor can also:
+      <ul>
+        <li>unpublish and withdraw your organisation’s content</li>
+        <li>request changes to user accounts</li>
+        <li>request new campaigns, organisations and groups</li>
+      </ul>
+    </div>
   </div>
   <div id="other_permissions">
      <%= f.label "Other permissions", class: "control-label" %>
-     <%= f.input :mainstream_changes, as: :boolean, label: "request changes to your organisation’s mainstream content" %>
-     <%= f.input :maslow, as: :boolean, label: "access to Maslow database of user needs" %>
-     <%= f.input :other_details, label: "other, please give details", input_html: { class: "input-md-6" } %>
+     <%= f.input :mainstream_changes, as: :boolean, label: "Request changes to your organisation’s mainstream content" %>
+     <%= f.input :maslow, as: :boolean, label: "Access to Maslow database of user needs" %>
+     <%= f.input :other_details, label: "Other, please give details", input_html: { class: "input-md-6" } %>
   </div>
   <% if f.object.errors[:formatted_user_needs].any? %>
     <span class="help-block">

--- a/app/views/support/_user_needs.html.erb
+++ b/app/views/support/_user_needs.html.erb
@@ -1,3 +1,3 @@
 <div id="user-needs">
-   <%= f.input :user_needs, as: :check_boxes, required: true, label: "What does the user need?", collection: f.object.user_need_options, input_html: { :"aria-required" => true } %>
+   <%= f.input :user_needs, as: :radio, required: true, label: "Select Whitehall user account", collection: f.object.whitehall_account_options, input_html: { :"aria-required" => true } %>
 </div>

--- a/app/views/support/_user_needs.html.erb
+++ b/app/views/support/_user_needs.html.erb
@@ -1,3 +1,17 @@
-<div id="user-needs">
-   <%= f.input :user_needs, as: :radio, required: true, label: "Select Whitehall user account", collection: f.object.whitehall_account_options, input_html: { :"aria-required" => true } %>
+<div id="user-needs"<%= ' class="has-error"'.html_safe if f.object.errors[:formatted_user_needs].any? %>>
+  <div id="whitehall">
+     <%= f.input :user_needs, as: :radio, label: "Select Whitehall user account", collection: f.object.whitehall_account_options %>
+  </div>
+  <div id="other_permissions">
+     <%= f.label "Other permissions", class: "control-label" %>
+     <%= f.input :mainstream_changes, as: :boolean, label: "request changes to your organisation’s mainstream content" %>
+     <%= f.input :maslow, as: :boolean, label: "access to Maslow database of user needs" %>
+     <%= f.input :other_details, label: "other, please give details", input_html: { class: "input-md-6" } %>
+  </div>
+  <% if f.object.errors[:formatted_user_needs].any? %>
+    <span class="help-block">
+      <%= f.object.errors[:formatted_user_needs].to_sentence %>
+    </span>
+  <% end %>
 </div>
+

--- a/lib/support/gds/with_user_needs.rb
+++ b/lib/support/gds/with_user_needs.rb
@@ -4,47 +4,34 @@ module Support
       attr_accessor :user_needs
 
       def self.included(base)
-        base.validates_presence_of :user_needs
-        base.validate :allowed_user_needs, :at_least_one_user_need
+        base.validates :user_needs, presence: true, inclusion: { in: %w{writer editor managing_editor other} }
+        base.validate :allowed_user_needs
       end
 
       def formatted_user_needs
-        filtered_user_needs.map {|user_need| Hash[user_need_options].key(user_need) }.sort.join(", ")
+        Hash[whitehall_account_options].key(user_needs)
       end
 
       def inside_government_related?
-        not (%w{inside_government_editor inside_government_writer} & filtered_user_needs).empty?
+        %w{editor writer managing_editor}.include?(user_needs)
       end
 
-      def user_need_options
+      def whitehall_account_options
         [
-          ["Departments and policy writer permissions", "inside_government_writer"],
-          ["Departments and policy editor permissions", "inside_government_editor"],
-          ["to request new content and content changes", "content_change"],
-          ["to request creation, deletion and changes to user permissions", "user_manager"],
-          ["to request new campaigns", "campaign_requester"],
-          ["Other/Not sure", "other"]
+          ["writer - can create content", "writer"],
+          ["editor - can create, review and publish content", "editor"],
+          ["managing editor - can create, review and publish content, and additional rights", "managing_editor"],
+          ["other", "other"]
         ]
       end
 
       protected
-      def filtered_user_needs
-        (user_needs || []).reject(&:empty?)
-      end
-
-      def at_least_one_user_need
-        if filtered_user_needs.empty?
-          errors.add(:user_needs, "please choose at least one option")
-        end
-      end
 
       def allowed_user_needs
-        permitted_user_needs = user_need_options.map(&:last)
-        disallowed_needs = filtered_user_needs - permitted_user_needs
-        unless disallowed_needs.empty?
-          errors.add(:user_needs, disallowed_needs.join(", ") + " not valid user needs")
-        end
+        return user_needs if user_needs.class == String
+        errors.add(:user_needs, " not valid user needs")
       end
+
     end
   end
 end

--- a/lib/support/requests/create_or_change_user_request.rb
+++ b/lib/support/requests/create_or_change_user_request.rb
@@ -37,8 +37,8 @@ module Support
 
       def action_options
         [
-          ["New user account", "create_new_user"],
-          ["Change an existing user's permissions", "change_user"],
+          ["Create a new user account", "create_new_user"],
+          ["Change an existing user's account", "change_user"],
         ]
       end
 

--- a/lib/zendesk/ticket/create_or_change_user_request_ticket.rb
+++ b/lib/zendesk/ticket/create_or_change_user_request_ticket.rb
@@ -14,7 +14,7 @@ module Zendesk
 
       protected
       def comment_snippets
-        [ 
+        [
           LabelledSnippet.new(on: @request,                field: :formatted_action,
                                                            label: "Action"),
           LabelledSnippet.new(on: @request,                field: :formatted_user_needs,

--- a/spec/controllers/create_or_change_user_requests_controller_spec.rb
+++ b/spec/controllers/create_or_change_user_requests_controller_spec.rb
@@ -15,8 +15,9 @@ describe CreateOrChangeUserRequestsController, :type => :controller do
       { "requester_attributes" => valid_requester_params,
         "requested_user_attributes" => valid_requested_user_params,
         "action" => "create_new_user",
-        "user_needs" => ["", "other"],
-        "additional_comments"=>"" }
+        "user_needs" => "editor",
+        "additional_comments"=>""
+      }
     }
   end
 
@@ -25,11 +26,12 @@ describe CreateOrChangeUserRequestsController, :type => :controller do
       { "requester_attributes" => valid_requester_params,
         "requested_user_attributes" => {
           "name"=>"subject",
-          "email"=>"subject@digital.cabinet-office.gov.uk",
+          "email"=>"subject@digital.cabinet-office.gov.uk"
         },
         "action" => "change_user",
-        "user_needs" => ["", "other"],
-        "additional_comments"=>"" }
+        "user_needs" => "other",
+        "additional_comments"=>""
+      }
     }
   end
 
@@ -42,7 +44,7 @@ describe CreateOrChangeUserRequestsController, :type => :controller do
     it "submits the request to Zendesk and creates a Zendesk user with the requested user details" do
       zendesk_has_no_user_with_email(valid_requested_user_params["email"])
       stub_ticket_creation = stub_zendesk_ticket_creation(
-        hash_including("tags" => ['govt_form', 'create_new_user'])
+        hash_including("tags" => ['govt_form', 'create_new_user', "inside_government"])
       )
       stub_user_creation = stub_zendesk_user_creation(
         email: "subject@digital.cabinet-office.gov.uk",
@@ -86,7 +88,8 @@ describe CreateOrChangeUserRequestsController, :type => :controller do
         stub_request = stub_zendesk_ticket_creation(
           hash_including("tags" => ['govt_form', 'change_user', 'inside_government'])
         )
-        params = valid_change_user_request_params.tap {|p| p["support_requests_create_or_change_user_request"].merge!("user_needs" => ["inside_government_editor"])}
+
+        params = valid_change_user_request_params.tap {|p| p["support_requests_create_or_change_user_request"].merge!("user_needs" => "editor")}
 
         post :create, params
 

--- a/spec/controllers/create_or_change_user_requests_controller_spec.rb
+++ b/spec/controllers/create_or_change_user_requests_controller_spec.rb
@@ -29,7 +29,7 @@ describe CreateOrChangeUserRequestsController, :type => :controller do
           "email"=>"subject@digital.cabinet-office.gov.uk"
         },
         "action" => "change_user",
-        "user_needs" => "other",
+        "user_needs" => "writer",
         "additional_comments"=>""
       }
     }

--- a/spec/features/create_or_change_user_requests_spec.rb
+++ b/spec/features/create_or_change_user_requests_spec.rb
@@ -12,14 +12,15 @@ feature "Create or change user requests" do
     zendesk_has_no_user_with_email(user.email)
   end
 
-  scenario "user creation request" do
-    zendesk_has_no_user_with_email("bob@gov.uk")
+  context "Whitehall user permissions" do
+    scenario "user creation request" do
+      zendesk_has_no_user_with_email("bob@gov.uk")
 
-    ticket_request = expect_zendesk_to_receive_ticket(
-      "subject" => "Create a new user account",
-      "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
-      "tags" => %w{govt_form create_new_user inside_government},
-      "comment" => { "body" =>
+      ticket_request = expect_zendesk_to_receive_ticket(
+        "subject" => "Create a new user account",
+        "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
+        "tags" => %w{govt_form create_new_user inside_government},
+        "comment" => { "body" =>
 "[Action]
 Create a new user account
 
@@ -41,36 +42,36 @@ Editor
 [Additional comments]
 XXXX"})
 
-    user_creation_request = stub_zendesk_user_creation(
-      email: "bob@gov.uk",
-      name: "Bob Fields",
-      details: "Job title: Editor",
-      phone: "12345",
-      verified: true,
-    )
+      user_creation_request = stub_zendesk_user_creation(
+        email: "bob@gov.uk",
+        name: "Bob Fields",
+        details: "Job title: Editor",
+        phone: "12345",
+        verified: true,
+      )
 
-    user_requests_a_change_to_user_accounts(
-      action: "Create a new user account",
-      user_needs: "editor - can create, review and publish content",
-      user_name: "Bob Fields",
-      user_email: "bob@gov.uk",
-      user_job_title: "Editor",
-      user_phone: "12345",
-      additional_comments: "XXXX",
-    )
+      user_requests_a_change_to_whitehall_user_accounts(
+        action: "Create a new user account",
+        user_needs: "editor - can create, review and publish content",
+        user_name: "Bob Fields",
+        user_email: "bob@gov.uk",
+        user_job_title: "Editor",
+        user_phone: "12345",
+        additional_comments: "XXXX",
+      )
 
-    expect(ticket_request).to have_been_made
-    expect(user_creation_request).to have_been_made
-  end
+      expect(ticket_request).to have_been_made
+      expect(user_creation_request).to have_been_made
+    end
 
-  scenario "changing user permissions" do
-    zendesk_has_user(email: "bob@gov.uk", name: "Bob Fields")
+    scenario "changing user permissions" do
+      zendesk_has_user(email: "bob@gov.uk", name: "Bob Fields")
 
-    ticket_request = expect_zendesk_to_receive_ticket(
-      "subject" => "Change an existing user's account",
-      "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
-      "tags" => %w{govt_form change_user inside_government},
-      "comment" => { "body" =>
+      ticket_request = expect_zendesk_to_receive_ticket(
+        "subject" => "Change an existing user's account",
+        "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
+        "tags" => %w{govt_form change_user inside_government},
+        "comment" => { "body" =>
 "[Action]
 Change an existing user's account
 
@@ -86,19 +87,107 @@ bob@gov.uk
 [Additional comments]
 XXXX"})
 
-    user_requests_a_change_to_user_accounts(
-      action: "Change an existing user's account",
-      user_needs: "writer - can create content",
-      user_name: "Bob Fields",
-      user_email: "bob@gov.uk",
-      additional_comments: "XXXX",
-    )
+      user_requests_a_change_to_whitehall_user_accounts(
+        action: "Change an existing user's account",
+        user_needs: "writer - can create content",
+        user_name: "Bob Fields",
+        user_email: "bob@gov.uk",
+        additional_comments: "XXXX",
+      )
 
-    expect(ticket_request).to have_been_made
+      expect(ticket_request).to have_been_made
+    end
+  end
+
+  context "Other permissions" do
+    scenario "user creation request" do
+      zendesk_has_no_user_with_email("bob@gov.uk")
+
+      ticket_request = expect_zendesk_to_receive_ticket(
+        "subject" => "Create a new user account",
+        "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
+        "tags" => %w{govt_form create_new_user},
+        "comment" => { "body" =>
+"[Action]
+Create a new user account
+
+[User needs]
+request changes to your organisation’s mainstream content
+
+[Requested user's name]
+Bob Fields
+
+[Requested user's email]
+bob@gov.uk
+
+[Requested user's job title]
+Editor
+
+[Requested user's phone number]
+12345
+
+[Additional comments]
+XXXX"})
+
+      user_creation_request = stub_zendesk_user_creation(
+        email: "bob@gov.uk",
+        name: "Bob Fields",
+        details: "Job title: Editor",
+        phone: "12345",
+        verified: true,
+      )
+
+      user_requests_a_change_to_other_user_accounts(
+        action: "Create a new user account",
+        user_needs: ["request changes to your organisation’s mainstream content"],
+        user_name: "Bob Fields",
+        user_email: "bob@gov.uk",
+        user_job_title: "Editor",
+        user_phone: "12345",
+        additional_comments: "XXXX",
+      )
+
+      expect(ticket_request).to have_been_made
+      expect(user_creation_request).to have_been_made
+    end
+
+    scenario "changing user permissions" do
+      zendesk_has_user(email: "bob@gov.uk", name: "Bob Fields")
+
+      ticket_request = expect_zendesk_to_receive_ticket(
+        "subject" => "Change an existing user's account",
+        "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
+        "tags" => %w{govt_form change_user},
+        "comment" => { "body" =>
+"[Action]
+Change an existing user's account
+
+[User needs]
+request changes to your organisation’s mainstream content\naccess to Maslow database of user needs
+
+[Requested user's name]
+Bob Fields
+
+[Requested user's email]
+bob@gov.uk
+
+[Additional comments]
+XXXX"})
+
+      user_requests_a_change_to_other_user_accounts(
+        action: "Change an existing user's account",
+        user_needs: ["request changes to your organisation’s mainstream content", "access to Maslow database of user needs"],
+        user_name: "Bob Fields",
+        user_email: "bob@gov.uk",
+        additional_comments: "XXXX",
+      )
+
+      expect(ticket_request).to have_been_made
+    end
   end
 
   private
-  def user_requests_a_change_to_user_accounts(details)
+  def user_requests_a_change_to_whitehall_user_accounts(details)
     visit '/'
 
     click_on "Create or change user"
@@ -111,6 +200,35 @@ XXXX"})
 
     within "#user-needs" do
       choose details[:user_needs]
+    end
+
+    within("#user_details") do
+      fill_in "Name", with: details[:user_name]
+      fill_in "Email", with: details[:user_email]
+      fill_in "Job title", with: details[:user_job_title] if details[:user_job_title]
+      fill_in "Phone number", with: details[:user_phone] if details[:user_phone]
+    end
+
+    fill_in "Additional comments", with: details[:additional_comments]
+
+    user_submits_the_request_successfully
+  end
+
+  def user_requests_a_change_to_other_user_accounts(details)
+    visit '/'
+
+    click_on "Create or change user"
+
+    expect(page).to have_content("Create or change a user account")
+
+    within "#action" do
+      choose details[:action]
+    end
+
+    within "#other_permissions" do
+      details[:user_needs].each do |user_need|
+        check user_need
+      end
     end
 
     within("#user_details") do

--- a/spec/features/create_or_change_user_requests_spec.rb
+++ b/spec/features/create_or_change_user_requests_spec.rb
@@ -16,12 +16,12 @@ feature "Create or change user requests" do
     zendesk_has_no_user_with_email("bob@gov.uk")
 
     ticket_request = expect_zendesk_to_receive_ticket(
-      "subject" => "New user account",
+      "subject" => "Create a new user account",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w{govt_form create_new_user inside_government},
       "comment" => { "body" =>
 "[Action]
-New user account
+Create a new user account
 
 [User needs]
 Departments and policy editor permissions, Departments and policy writer permissions
@@ -50,7 +50,7 @@ XXXX"})
     )
 
     user_requests_a_change_to_user_accounts(
-      action: "New user account",
+      action: "Create a new user account",
       user_needs: [ "Departments and policy writer permissions", "Departments and policy editor permissions" ],
       user_name: "Bob Fields",
       user_email: "bob@gov.uk",
@@ -67,12 +67,12 @@ XXXX"})
     zendesk_has_user(email: "bob@gov.uk", name: "Bob Fields")
 
     ticket_request = expect_zendesk_to_receive_ticket(
-      "subject" => "Change an existing user's permissions",
+      "subject" => "Change an existing user's account",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w{govt_form change_user},
       "comment" => { "body" =>
 "[Action]
-Change an existing user's permissions
+Change an existing user's account
 
 [User needs]
 Other/Not sure
@@ -87,7 +87,7 @@ bob@gov.uk
 XXXX"})
 
     user_requests_a_change_to_user_accounts(
-      action: "Change an existing user's permissions",
+      action: "Change an existing user's account",
       user_needs: [ "Other/Not sure" ],
       user_name: "Bob Fields",
       user_email: "bob@gov.uk",

--- a/spec/features/create_or_change_user_requests_spec.rb
+++ b/spec/features/create_or_change_user_requests_spec.rb
@@ -24,7 +24,7 @@ feature "Create or change user requests" do
 Create a new user account
 
 [User needs]
-Departments and policy editor permissions, Departments and policy writer permissions
+editor - can create, review and publish content
 
 [Requested user's name]
 Bob Fields
@@ -51,7 +51,7 @@ XXXX"})
 
     user_requests_a_change_to_user_accounts(
       action: "Create a new user account",
-      user_needs: [ "Departments and policy writer permissions", "Departments and policy editor permissions" ],
+      user_needs: "editor - can create, review and publish content",
       user_name: "Bob Fields",
       user_email: "bob@gov.uk",
       user_job_title: "Editor",
@@ -69,13 +69,13 @@ XXXX"})
     ticket_request = expect_zendesk_to_receive_ticket(
       "subject" => "Change an existing user's account",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
-      "tags" => %w{govt_form change_user},
+      "tags" => %w{govt_form change_user inside_government},
       "comment" => { "body" =>
 "[Action]
 Change an existing user's account
 
 [User needs]
-Other/Not sure
+writer - can create content
 
 [Requested user's name]
 Bob Fields
@@ -88,7 +88,7 @@ XXXX"})
 
     user_requests_a_change_to_user_accounts(
       action: "Change an existing user's account",
-      user_needs: [ "Other/Not sure" ],
+      user_needs: "writer - can create content",
       user_name: "Bob Fields",
       user_email: "bob@gov.uk",
       additional_comments: "XXXX",
@@ -110,7 +110,7 @@ XXXX"})
     end
 
     within "#user-needs" do
-      details[:user_needs].each { |user_need| check user_need }
+      choose details[:user_needs]
     end
 
     within("#user_details") do

--- a/spec/features/create_or_change_user_requests_spec.rb
+++ b/spec/features/create_or_change_user_requests_spec.rb
@@ -25,7 +25,7 @@ feature "Create or change user requests" do
 Create a new user account
 
 [User needs]
-editor - can create, review and publish content
+Editor - can create, review and publish content
 
 [Requested user's name]
 Bob Fields
@@ -52,7 +52,7 @@ XXXX"})
 
       user_requests_a_change_to_whitehall_user_accounts(
         action: "Create a new user account",
-        user_needs: "editor - can create, review and publish content",
+        user_needs: "Editor - can create, review and publish content",
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
         user_job_title: "Editor",
@@ -76,7 +76,7 @@ XXXX"})
 Change an existing user's account
 
 [User needs]
-writer - can create content
+Writer - can create content
 
 [Requested user's name]
 Bob Fields
@@ -89,7 +89,7 @@ XXXX"})
 
       user_requests_a_change_to_whitehall_user_accounts(
         action: "Change an existing user's account",
-        user_needs: "writer - can create content",
+        user_needs: "Writer - can create content",
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
         additional_comments: "XXXX",
@@ -112,7 +112,7 @@ XXXX"})
 Create a new user account
 
 [User needs]
-request changes to your organisation’s mainstream content
+Request changes to your organisation’s mainstream content
 
 [Requested user's name]
 Bob Fields
@@ -139,7 +139,7 @@ XXXX"})
 
       user_requests_a_change_to_other_user_accounts(
         action: "Create a new user account",
-        user_needs: ["request changes to your organisation’s mainstream content"],
+        user_needs: ["Request changes to your organisation’s mainstream content"],
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
         user_job_title: "Editor",
@@ -163,7 +163,7 @@ XXXX"})
 Change an existing user's account
 
 [User needs]
-request changes to your organisation’s mainstream content\naccess to Maslow database of user needs
+Request changes to your organisation’s mainstream content\nAccess to Maslow database of user needs
 
 [Requested user's name]
 Bob Fields
@@ -176,7 +176,7 @@ XXXX"})
 
       user_requests_a_change_to_other_user_accounts(
         action: "Change an existing user's account",
-        user_needs: ["request changes to your organisation’s mainstream content", "access to Maslow database of user needs"],
+        user_needs: ["Request changes to your organisation’s mainstream content", "Access to Maslow database of user needs"],
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
         additional_comments: "XXXX",

--- a/spec/models/support/gds/with_user_needs_spec.rb
+++ b/spec/models/support/gds/with_user_needs_spec.rb
@@ -15,30 +15,26 @@ module Support
       end
 
       it { should validate_presence_of(:user_needs) }
-      it { should allow_value(["", "other"]).for(:user_needs) }
-      it { should allow_value(["inside_government_editor"]).for(:user_needs) }
-      it { should allow_value(["inside_government_writer"]).for(:user_needs) }
-      it { should allow_value(["other"]).for(:user_needs) }
-      it { should_not allow_value(["xxx"]).for(:user_needs) }
-      it { should_not allow_value([]).for(:user_needs) }
+      it { should allow_value("other").for(:user_needs) }
+      it { should allow_value("editor").for(:user_needs) }
+      it { should allow_value("writer").for(:user_needs) }
+      it { should allow_value("other").for(:user_needs) }
+      it { should_not allow_value("xxx").for(:user_needs) }
+      it { should_not allow_value(["other", "editor"]).for(:user_needs) }
       it { should_not allow_value([""]).for(:user_needs) }
 
       it "knows if it's related to inside government or not" do
-        expect(request(user_needs: ["inside_government_editor"])).to be_inside_government_related
-        expect(request(user_needs: ["inside_government_editor"])).to be_inside_government_related
-        expect(request(user_needs: ["user_manager"])).to_not be_inside_government_related
-        expect(request(user_needs: ["other"])).to_not be_inside_government_related
-      end
-
-      it "filters out empty choices for user needs (apparently it's a rails things with tickboxes)" do
-        expect(request(user_needs: ["", "other"]).formatted_user_needs).to eq("Other/Not sure")
+        expect(request(user_needs: "writer")).to be_inside_government_related
+        expect(request(user_needs: "editor")).to be_inside_government_related
+        expect(request(user_needs: "managing_editor")).to be_inside_government_related
+        expect(request(user_needs: "other")).to_not be_inside_government_related
       end
 
       it "defines the formatted version" do
-        expect(request(user_needs: ["inside_government_writer"]).formatted_user_needs).
-          to eq("Departments and policy writer permissions")
-        expect(request(user_needs: ["inside_government_writer", "inside_government_editor"]).formatted_user_needs).
-          to eq("Departments and policy editor permissions, Departments and policy writer permissions")
+        expect(request(user_needs: "writer").formatted_user_needs).
+          to eq("writer - can create content")
+        expect(request(user_needs: "editor").formatted_user_needs).
+          to eq("editor - can create, review and publish content")
       end
     end
   end

--- a/spec/models/support/gds/with_user_needs_spec.rb
+++ b/spec/models/support/gds/with_user_needs_spec.rb
@@ -24,7 +24,7 @@ module Support
         context "for a Whitehall user account" do
           it "returns the long text of the user need" do
             expect(request(user_needs: "writer").formatted_user_needs).
-              to eq("writer - can create content")
+              to eq("Writer - can create content")
           end
         end
 
@@ -43,14 +43,14 @@ module Support
           context "when one is ticked" do
             it "returns the long text of the permission" do
               expect(request(maslow: "1").formatted_user_needs).
-                to eq("access to Maslow database of user needs")
+                to eq("Access to Maslow database of user needs")
             end
           end
 
           context "when several are ticked" do
             it "returns the long text of the permissions, with one permission per line" do
               expect(request(mainstream_changes:"1", maslow: "1").formatted_user_needs).
-                to eq("request changes to your organisation’s mainstream content\naccess to Maslow database of user needs")
+                to eq("Request changes to your organisation’s mainstream content\nAccess to Maslow database of user needs")
             end
           end
 
@@ -62,7 +62,7 @@ module Support
             context "and when another permission is ticked" do
               it "returns long text of the permissions and the text of the other field" do
                 expect(request(mainstream_changes:"1", other_details:"special permission request").formatted_user_needs).
-                  to eq("request changes to your organisation’s mainstream content\nOther: special permission request")
+                  to eq("Request changes to your organisation’s mainstream content\nOther: special permission request")
               end
             end
           end

--- a/spec/models/support/requests/create_or_change_user_request_spec.rb
+++ b/spec/models/support/requests/create_or_change_user_request_spec.rb
@@ -10,7 +10,6 @@ module Support
 
       it { should validate_presence_of(:requester) }
       it { should validate_presence_of(:requested_user) }
-      it { should validate_presence_of(:user_needs) }
       it { should validate_presence_of(:action) }
 
       it { should allow_value("create_new_user").for(:action) }

--- a/spec/models/support/requests/create_or_change_user_request_spec.rb
+++ b/spec/models/support/requests/create_or_change_user_request_spec.rb
@@ -24,7 +24,7 @@ module Support
       end
 
       it "provides formatted action" do
-        expect(request(action: "create_new_user").formatted_action).to eq("New user account")
+        expect(request(action: "create_new_user").formatted_action).to eq("Create a new user account")
 
         expect(request(action: "create_new_user").for_new_user?).to be_truthy
         expect(request(action: "change_user").for_new_user?).to be_falsey


### PR DESCRIPTION
Change the copy and options for creating or changing a user account in the support app.
Users can now select either a type of Whitehall account, other permissions or both. This was reviewed and approved by Nick Cammel in the content team

Before
![screen shot 2015-10-13 at 15 43 18](https://cloud.githubusercontent.com/assets/8225167/10458132/3f4936b8-71c1-11e5-99ae-17eb8ecac352.png)

After
![screen shot 2015-10-13 at 15 42 45](https://cloud.githubusercontent.com/assets/8225167/10458138/41d85ecc-71c1-11e5-81f2-fa0607850a19.png)

cc @benilovj @boffbowsh 

[Trello](https://trello.com/c/pi5NbNsj/119-update-the-create-or-change-a-user-account-form-in-support-app-small)