### PR TITLE
Move cc field to the bottom of requests

### DIFF
--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -10,9 +10,9 @@
 
 <%= semantic_form_for @request, url: { action: "create" }, html: { novalidate: false } do |f| %>
 
-  <%= render partial: "support/collaborators", locals: { f: f } %>
-
   <%= render partial: "request_details", locals: { f: f } %>
+
+  <%= render partial: "support/collaborators", locals: { f: f } %>
 
   <%= f.action :submit, label: "Submit", button_html: { class: "btn btn-success" } %>
 <% end %>


### PR DESCRIPTION
Cc field should not be the first field on support requests, but should be at the end of the form.

This was feedback from the content team on [this story](https://trello.com/c/pi5NbNsj/119-update-the-create-or-change-a-user-account-form-in-support-app-small).
Before
![screen shot 2015-10-13 at 16 06 15](https://cloud.githubusercontent.com/assets/8225167/10458797/84b259ca-71c4-11e5-8232-ce9489f4a184.png)

After
![screen shot 2015-10-13 at 16 09 53](https://cloud.githubusercontent.com/assets/8225167/10458879/e55bdc6a-71c4-11e5-8393-379b97854552.png)


cc @benilovj 