### PR TITLE
Update the 'gds_zendesk' gem to 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'jc-validates_timeliness', '3.1.1'
 if ENV['GDS_ZENDESK_DEV']
   gem "gds_zendesk", :path => '../gds_zendesk'
 else
-  gem "gds_zendesk", '1.0.5'
+  gem "gds_zendesk", '2.0.0'
 end
 gem 'redis', '3.2.1'
 gem "sidekiq", "3.3.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    gds_zendesk (1.0.5)
+    gds_zendesk (2.0.0)
       null_logger (= 0.0.1)
       zendesk_api (= 1.8.0)
     globalid (0.3.6)
@@ -316,7 +316,7 @@ DEPENDENCIES
   formtastic-bootstrap!
   gds-api-adapters (= 20.1.1)
   gds-sso (= 11.0.0)
-  gds_zendesk (= 1.0.5)
+  gds_zendesk (= 2.0.0)
   govuk_admin_template (= 3.0.0)
   gretel (= 3.0.8)
   jasmine (= 2.3.0)

--- a/lib/zendesk/zendesk_tickets.rb
+++ b/lib/zendesk/zendesk_tickets.rb
@@ -1,5 +1,3 @@
-require 'gds_zendesk/field_mappings'
-
 class ZendeskTickets
   def raise_ticket(ticket_to_raise)
     ZendeskTicketWorker.perform_async({


### PR DESCRIPTION
This picks up the fix to the "Create or update user request"
form (the form submission broke in development).

This commit also involves removing the unused field mappings
refernce, as field mappings have been removed from `gds_zendesk`.

/cc @binaryberry 