### PR TITLE
Add training information to create or change user

### DIFF
--- a/app/controllers/create_or_change_user_requests_controller.rb
+++ b/app/controllers/create_or_change_user_requests_controller.rb
@@ -22,9 +22,9 @@ class CreateOrChangeUserRequestsController < RequestsController
   def create_or_change_user_request_params
     params.require(:support_requests_create_or_change_user_request).permit(
       :action, :additional_comments,
-      :user_needs,:mainstream_changes, :maslow, :other_details,
+      :user_needs, :mainstream_changes, :maslow, :other_details,
       requester_attributes: [:email, :name, :collaborator_emails],
-      requested_user_attributes: [:name, :email, :job, :phone],
+      requested_user_attributes: [:name, :email, :job, :phone, :training],
     )
   end
 

--- a/app/views/create_or_change_user_requests/_requested_user_details.html.erb
+++ b/app/views/create_or_change_user_requests/_requested_user_details.html.erb
@@ -4,5 +4,8 @@
     <%= r.input :email, label: "Email", as: :email, required: true, input_html: { :"aria-required" => true, :class => "input-md-6" } %>
     <%= r.input :job, label: "Job title", input_html: { class: "input-md-6" } %>
     <%= r.input :phone, label: "Phone number", as: :phone, required: false, input_html: { class: "input-md-6" } %>
+    <label for="support_requests_create_or_change_user_request_requested_user_attributes_training">Have you had any GOV.UK training?<sup>*</sup></label>
+    <p class="text-muted input-md-6"> If so, please give details of the course you attended, eg Writing for GOV.UK training in September 2015 with Christine Cawthorne. </p>
+    <%= r.input :training, label: false, as: :text, required: true, input_html: { class: "input-md-6", rows: 6, cols: 50 } %>
   <% end %>
 <% end %>

--- a/lib/support/gds/requested_user.rb
+++ b/lib/support/gds/requested_user.rb
@@ -4,9 +4,9 @@ module Support
   module GDS
     class RequestedUser
       include ActiveModel::Model
-      attr_accessor :name, :email, :job, :phone
+      attr_accessor :name, :email, :job, :phone, :training
 
-      validates_presence_of :name, :email
+      validates_presence_of :name, :email, :training
       validates :email, :format => {:with => /@/}
     end
   end

--- a/lib/zendesk/ticket/create_or_change_user_request_ticket.rb
+++ b/lib/zendesk/ticket/create_or_change_user_request_ticket.rb
@@ -27,6 +27,8 @@ module Zendesk
                                                            label: "Requested user's job title"),
           LabelledSnippet.new(on: @request.requested_user, field: :phone,
                                                            label: "Requested user's phone number"),
+          LabelledSnippet.new(on: @request.requested_user, field: :training,
+                                                           label: "Requested user's previous training"),
           LabelledSnippet.new(on: @request,                field: :additional_comments)
         ]
       end

--- a/spec/controllers/create_or_change_user_requests_controller_spec.rb
+++ b/spec/controllers/create_or_change_user_requests_controller_spec.rb
@@ -7,6 +7,7 @@ describe CreateOrChangeUserRequestsController, :type => :controller do
       "email"=>"subject@digital.cabinet-office.gov.uk",
       "job"=>"editor",
       "phone"=>"12345",
+      "training"=>"Attended publishing for GOV.UK training in September 2015 with Christine Cawthorne"
     }
   end
 
@@ -26,7 +27,8 @@ describe CreateOrChangeUserRequestsController, :type => :controller do
       { "requester_attributes" => valid_requester_params,
         "requested_user_attributes" => {
           "name"=>"subject",
-          "email"=>"subject@digital.cabinet-office.gov.uk"
+          "email"=>"subject@digital.cabinet-office.gov.uk",
+          "training"=>"Attended publishing for GOV.UK training in September 2015 with Christine Cawthorne"
         },
         "action" => "change_user",
         "user_needs" => "writer",

--- a/spec/features/create_or_change_user_requests_spec.rb
+++ b/spec/features/create_or_change_user_requests_spec.rb
@@ -39,6 +39,9 @@ Editor
 [Requested user's phone number]
 12345
 
+[Requested user's previous training]
+Attended publishing for GOV.UK training in September 2015 with Christine Cawthorne
+
 [Additional comments]
 XXXX"})
 
@@ -57,6 +60,7 @@ XXXX"})
         user_email: "bob@gov.uk",
         user_job_title: "Editor",
         user_phone: "12345",
+        training: "Attended publishing for GOV.UK training in September 2015 with Christine Cawthorne",
         additional_comments: "XXXX",
       )
 
@@ -84,6 +88,9 @@ Bob Fields
 [Requested user's email]
 bob@gov.uk
 
+[Requested user's previous training]
+Attended publishing for GOV.UK training in September 2015 with Christine Cawthorne
+
 [Additional comments]
 XXXX"})
 
@@ -92,6 +99,7 @@ XXXX"})
         user_needs: "Writer - can create content",
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
+        training: "Attended publishing for GOV.UK training in September 2015 with Christine Cawthorne",
         additional_comments: "XXXX",
       )
 
@@ -126,6 +134,9 @@ Editor
 [Requested user's phone number]
 12345
 
+[Requested user's previous training]
+Attended publishing for GOV.UK training in September 2015 with Christine Cawthorne
+
 [Additional comments]
 XXXX"})
 
@@ -144,6 +155,7 @@ XXXX"})
         user_email: "bob@gov.uk",
         user_job_title: "Editor",
         user_phone: "12345",
+        training: "Attended publishing for GOV.UK training in September 2015 with Christine Cawthorne",
         additional_comments: "XXXX",
       )
 
@@ -171,6 +183,9 @@ Bob Fields
 [Requested user's email]
 bob@gov.uk
 
+[Requested user's previous training]
+Attended publishing for GOV.UK training in September 2015 with Christine Cawthorne
+
 [Additional comments]
 XXXX"})
 
@@ -179,6 +194,7 @@ XXXX"})
         user_needs: ["Request changes to your organisation’s mainstream content", "Access to Maslow database of user needs"],
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
+        training: "Attended publishing for GOV.UK training in September 2015 with Christine Cawthorne",
         additional_comments: "XXXX",
       )
 
@@ -207,6 +223,7 @@ XXXX"})
       fill_in "Email", with: details[:user_email]
       fill_in "Job title", with: details[:user_job_title] if details[:user_job_title]
       fill_in "Phone number", with: details[:user_phone] if details[:user_phone]
+      fill_in "training", with: details[:training]
     end
 
     fill_in "Additional comments", with: details[:additional_comments]
@@ -236,6 +253,7 @@ XXXX"})
       fill_in "Email", with: details[:user_email]
       fill_in "Job title", with: details[:user_job_title] if details[:user_job_title]
       fill_in "Phone number", with: details[:user_phone] if details[:user_phone]
+      fill_in "support_requests_create_or_change_user_request_requested_user_attributes_training", with: details[:training]
     end
 
     fill_in "Additional comments", with: details[:additional_comments]

--- a/spec/models/support/gds/requested_user_spec.rb
+++ b/spec/models/support/gds/requested_user_spec.rb
@@ -6,11 +6,13 @@ module Support
     describe RequestedUser do
       it { should validate_presence_of(:name) }
       it { should validate_presence_of(:email) }
+      it { should validate_presence_of(:training) }
 
       it { should allow_value('director').for(:job) }
       it { should allow_value("07911111").for(:phone) }
       it { should allow_value("ab@c.com").for(:email) }
       it { should_not allow_value("ab").for(:email) }
+      it { should allow_value("attended writing for GOV.UK training").for(:training) }
     end
   end
 end


### PR DESCRIPTION
When deciding on granting user permissions, people need to know what previous training requesters have had.

Discussed design and copy with @fofr and Nick Cammel from the content team.

before
![screen shot 2015-10-14 at 16 31 54](https://cloud.githubusercontent.com/assets/8225167/10488719/eeff33f2-7291-11e5-95d6-fbb68c18d307.png)

after
![screen shot 2015-10-14 at 16 31 22](https://cloud.githubusercontent.com/assets/8225167/10488750/135fbd70-7292-11e5-99b0-f176d06d6ac6.png)

cc @fofr @boffbowsh 

[Trello](https://trello.com/c/pi5NbNsj/119-update-the-create-or-change-a-user-account-form-in-support-app-small)