### PR TITLE
Using sidekiq-statsd gem to plot sidekiq activity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ else
 end
 gem 'redis', '3.2.1'
 gem "sidekiq", "3.3.4"
+gem "sidekiq-statsd", "0.1.5"
 gem "statsd-ruby", "1.2.1", require: "statsd"
 gem 'logstasher', '0.4.8'
 gem 'kaminari', '0.16.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,9 +273,13 @@ GEM
       json
       redis (>= 3.0.6)
       redis-namespace (>= 1.3.1)
+    sidekiq-statsd (0.1.5)
+      activesupport
+      rack (> 1, < 3)
+      sidekiq (>= 2.6)
+      statsd-ruby (>= 1.1.0)
     slop (3.6.0)
     sprockets (3.4.0)
-      rack (> 1, < 3)
     sprockets-rails (2.3.3)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
@@ -349,6 +353,7 @@ DEPENDENCIES
   select2-rails (= 3.5.9.3)
   shoulda (~> 3.5.0)
   sidekiq (= 3.3.4)
+  sidekiq-statsd (= 0.1.5)
   statsd-ruby (= 1.2.1)
   timecop (~> 0.7.1)
   uglifier (= 2.7.1)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -14,6 +14,10 @@ redis_config = {
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config
+
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: 'govuk.app.support', prefix: 'workers'
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
In order to improve tracking of what's going on with Sidekiq workers, add `sidekiq-statsd` gem and configuration.

Part of https://trello.com/c/z2aHqwS8/48-add-sidekiq-statsd-to-apps-that-use-sidekiq