### PR TITLE
UI changes to support feedex result limiting.

### DIFF
--- a/app/helpers/feedex_helper.rb
+++ b/app/helpers/feedex_helper.rb
@@ -1,6 +1,8 @@
 module FeedexHelper
-  def total_responses_header(total_count:, from:, to:)
+  def total_responses_header(total_count:, from:, to:, results_limited:)
     response_total = pluralize(number_with_delimiter(total_count), "response")
+
+    response_total = "Over #{response_total}" if results_limited
 
     if from.present? && to.present?
       "#{response_total} between #{from} and #{to}"
@@ -8,7 +10,7 @@ module FeedexHelper
       "#{response_total} since #{from}"
     elsif to.present?
       "#{response_total} before #{to}"
-    elsif total_count && total_count > 1
+    elsif total_count && total_count > 1 && !results_limited
       "All #{response_total}"
     else
       response_total

--- a/app/presenters/anonymous_feedback_presenter.rb
+++ b/app/presenters/anonymous_feedback_presenter.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 
 class AnonymousFeedbackPresenter < SimpleDelegator
-  attr_reader :current_page, :total_pages, :limit_value, :total_count
+  attr_reader :current_page, :total_pages, :limit_value, :total_count, :results_limited
 
   def initialize(api_response)
     # actually delegate to the API response's `results` array
@@ -11,6 +11,7 @@ class AnonymousFeedbackPresenter < SimpleDelegator
     @total_pages = api_response.pages
     @limit_value = api_response.page_size
     @total_count = api_response.total_count
+    @results_limited = api_response.results_limited if api_response.respond_to?(:results_limited)
   end
 
 private

--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -4,7 +4,10 @@
 
 <%= form_tag anonymous_feedback_export_requests_path, class: "form-inline" %>
   <p class="feedback-response-count text-muted">
-    <%= total_responses_header(total_count: @feedback.total_count, from: @dates.from, to: @dates.to) %>
+    <%= total_responses_header(total_count: @feedback.total_count,
+                               from: @dates.from,
+                               to: @dates.to,
+                               results_limited: @feedback.results_limited) %>
     <% %i(from to path organisation).each do |attr| %>
       <% next if params[attr].blank? %>
       <input type="hidden" name="<%= attr%>" value="<%= params[attr]%>" />
@@ -58,5 +61,15 @@
     <% end %>
   </div>
 <% else %>
+  <% if @feedback.results_limited && @feedback.current_page == @feedback.total_pages %>
+    <div class="callout callout-info">
+      <div class="callout-title">
+        More responses are available.
+      </div>
+      <div class="callout-body">
+        You can change the date range to see more results, or export the whole range as a CSV.
+      </div>
+    </div>
+  <% end %>
   <%= render partial: "results", locals: { feedback: @feedback } %>
 <% end %>

--- a/spec/helpers/feedex_helper_spec.rb
+++ b/spec/helpers/feedex_helper_spec.rb
@@ -9,8 +9,11 @@ describe FeedexHelper, type: :helper do
         total_count: total_count,
         from: from,
         to: to,
+        results_limited: results_limited
       )
     }
+
+    let(:results_limited) { false }
 
     context "with no dates and a total_count of 1" do
       let(:total_count) { 1 }
@@ -59,6 +62,28 @@ describe FeedexHelper, type: :helper do
 
       it "outputs total_count and both dates" do
         expect(header).to eq("1,000 responses between 10 May 2015 and 11 May 2015")
+      end
+    end
+
+    context "with limited results" do
+      let(:total_count) { 10000 }
+      let(:from) { nil }
+      let(:to) { nil }
+      let(:results_limited) { true }
+
+      it "outputs total_count" do
+        expect(header).to eq("Over 10,000 responses")
+      end
+    end
+
+    context "with limited results and dates" do
+      let(:total_count) { 10000 }
+      let(:from) { "10 May 2015" }
+      let(:to) { "11 May 2015" }
+      let(:results_limited) { true }
+
+      it "outputs total_count" do
+        expect(header).to eq("Over 10,000 responses between 10 May 2015 and 11 May 2015")
       end
     end
   end

--- a/spec/presenters/anonymous_feedback_presenter_spec.rb
+++ b/spec/presenters/anonymous_feedback_presenter_spec.rb
@@ -24,6 +24,10 @@ describe AnonymousFeedbackPresenter, type: :presenter do
     it "should present api_response's `results` as an empty array" do
       expect(presenter).to eq([])
     end
+
+    it "should return false for results_limited" do
+      expect(presenter.results_limited).to be_falsey
+    end
   end
 
   context "when api_response has `results`" do
@@ -34,6 +38,7 @@ describe AnonymousFeedbackPresenter, type: :presenter do
         page_size: 50,
         results: [ {}, {}, {} ],
         total_count: 444,
+        results_limited: true
       )
     }
     subject(:presenter) { AnonymousFeedbackPresenter.new(api_response) }
@@ -53,6 +58,10 @@ describe AnonymousFeedbackPresenter, type: :presenter do
 
       it "should report `limit_value`" do
         expect(presenter.limit_value).to eq(50)
+      end
+
+      it "should return false for results_limited" do
+        expect(presenter.results_limited).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Uses the `results_limited` flag from support-api to display more
accurate response counts if the user’s query has been truncated due to
too many results. Also displays useful information on the last
available page.

Before:

![screen shot 2015-11-06 at 14 35 16](https://cloud.githubusercontent.com/assets/18276/10999404/a32d3122-8493-11e5-8dd0-67a152a20daf.png)

After:

![screen shot 2015-11-06 at 16 01 34](https://cloud.githubusercontent.com/assets/18276/11001574/b34b475e-849f-11e5-8fe5-6c9d35977af3.png)

Needs pointers from @fofr and Gavan on layout and copy.