### PR TITLE
Clarify emergency phone number destination

### DIFF
--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -83,7 +83,7 @@
   </div>
   <div class="row">
     <div class="col-md-6">
-      <p>This number will put you in contact with the GOV.UK operations manager, who will establish your identity and put the GOV.UK site into ‘emergency’ mode.</p>
+      <p>This number will put you in contact with the Head of GOV.UK, who will establish your identity and put the GOV.UK site into ‘emergency’ mode.</p>
       <ul>
         <li><%= link_to "Further information and guidance", "https://www.gov.uk/guidance/contact-the-government-digital-service/gov-uk-support-requests-processes-and-response-times" %></li>
       </ul>


### PR DESCRIPTION
Make it clear that emergency number goes through to the Head of GOV.UK not the operations manager

This is not a change in policy, it's just a clarification of the existing policy.