### PR TITLE
Change text regarding emergency contact.

### DIFF
--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -83,7 +83,7 @@
   </div>
   <div class="row">
     <div class="col-md-6">
-      <p>This number will put you in contact with the Head of GOV.UK, who will establish your identity and put the GOV.UK site into ‘emergency’ mode.</p>
+      <p>This number will put you in contact with GOV.UK, who will establish your identity and put the GOV.UK site into ‘emergency’ mode.</p>
       <ul>
         <li><%= link_to "Further information and guidance", "https://www.gov.uk/guidance/contact-the-government-digital-service/gov-uk-support-requests-processes-and-response-times" %></li>
       </ul>


### PR DESCRIPTION
The person answering the phone won't necessarily
be the head of gov.uk.