### PR TITLE
Remove responses count for done pages

### DIFF
--- a/app/helpers/feedex_helper.rb
+++ b/app/helpers/feedex_helper.rb
@@ -1,8 +1,7 @@
 module FeedexHelper
-  def total_responses_header(total_count:, from:, to:, results_limited:)
-    response_total = pluralize(number_with_delimiter(total_count), "response")
+  def total_responses_header(total_count:, from:, to:, results_limited:, path:)
 
-    response_total = "Over #{response_total}" if results_limited
+    response_total = get_response_total(total_count, results_limited, path)
 
     if from.present? && to.present?
       "#{response_total} between #{from} and #{to}"
@@ -12,8 +11,21 @@ module FeedexHelper
       "#{response_total} before #{to}"
     elsif total_count && total_count > 1 && !results_limited
       "All #{response_total}"
+    elsif is_done_page?(path)
+      "All responses"
     else
       response_total
     end
+  end
+
+  def is_done_page?(path)
+    path.start_with?("done", "/done")
+  end
+
+  def get_response_total(total_count, results_limited, path)
+    return "Responses" if is_done_page?(path)
+    response_total = pluralize(number_with_delimiter(total_count), "response")
+    response_total = "Over #{response_total}" if results_limited
+    response_total
   end
 end

--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -7,7 +7,8 @@
     <%= total_responses_header(total_count: @feedback.total_count,
                                from: @dates.from,
                                to: @dates.to,
-                               results_limited: @feedback.results_limited) %>
+                               results_limited: @feedback.results_limited,
+                               path: @filtered_by) %>
     <% %i(from to path organisation).each do |attr| %>
       <% next if params[attr].blank? %>
       <input type="hidden" name="<%= attr%>" value="<%= params[attr]%>" />

--- a/spec/helpers/feedex_helper_spec.rb
+++ b/spec/helpers/feedex_helper_spec.rb
@@ -9,19 +9,45 @@ describe FeedexHelper, type: :helper do
         total_count: total_count,
         from: from,
         to: to,
-        results_limited: results_limited
+        results_limited: results_limited,
+        path: path
       )
     }
 
     let(:results_limited) { false }
+    let(:path) {"/vat-rates"}
 
-    context "with no dates and a total_count of 1" do
+    context "when the page has no ratings" do
+      context "with no dates and a total_count of 1" do
+        let(:total_count) { 1 }
+        let(:from) { nil }
+        let(:to) { nil }
+
+        it "outputs total_count" do
+          expect(header).to eq("1 response")
+        end
+      end
+    end
+    context "when the page has ratings" do
       let(:total_count) { 1 }
       let(:from) { nil }
       let(:to) { nil }
+      let(:path) {"/done/register-to-vote"}
 
-      it "outputs total_count" do
-        expect(header).to eq("1 response")
+      context "with no dates and a total_count of 1" do
+        it "doesn't output the responses" do
+          expect(header).to eq "All responses"
+        end
+      end
+
+      context "with dates and a total_count of 1" do
+        let(:total_count) { 1 }
+        let(:from) { "10 May 2015" }
+        let(:to) { "11 May 2015" }
+
+        it "outputs the dates only" do
+          expect(header).to eq "Responses between 10 May 2015 and 11 May 2015"
+        end
       end
     end
 


### PR DESCRIPTION
Pages with a path starting with "/done/" have another type of anonymous contact, in addition of comments, called service satisfaction ratings. Due to high volume, the latter are rolled up each evening into service rating aggregates that show the count of each rating. Each service rating aggregate is added as a line in the feedex table, and service satisfaction ratings that have no comments are erased from the table. 

This means that the number of "responses" displayed at the top of the table is misleading for these /done/pages, as they are in fact the number of lines in the table, which for /done/ pages is not relevant. For the feedback of the present day, there is no aggregation, so the number of lines in the table is the number of service satisfaction ratings. For the feedback of previous days, the number of lines in the table is the number of service satisfaction ratings with comments + number of service rating aggregates (zero to five lines). So it's not a very useful number.

Some users have found it confusing and misunderstood it, so this change removes the responses count altogether for paths starting with "/done".

Before
![screen shot 2016-07-13 at 16 57 27](https://cloud.githubusercontent.com/assets/8225167/16810426/b213fe9e-491b-11e6-88c5-4d799b8eead5.png)

After
![screen shot 2016-07-13 at 17 02 36](https://cloud.githubusercontent.com/assets/8225167/16810432/b76f4a42-491b-11e6-8c24-a5e5cb5e8e31.png)

Paired on this with @mgrassotti .

[Trello](https://trello.com/c/TVlBgbol/425-feedex-aggregation-not-adding-up-correctly)