### PR TITLE
Radio button changes

### DIFF
--- a/app/controllers/analytics_requests_controller.rb
+++ b/app/controllers/analytics_requests_controller.rb
@@ -20,7 +20,6 @@ class AnalyticsRequestsController <  RequestsController
   def analytics_request_params
     params.require(:support_requests_analytics_request).permit(
       :justification_for_needing_report,
-      :request_context,
       requester_attributes: [:email, :name, :collaborator_emails],
       needed_report_attributes: [
         :reporting_period_start,

--- a/app/controllers/changes_to_publishing_apps_requests_controller.rb
+++ b/app/controllers/changes_to_publishing_apps_requests_controller.rb
@@ -19,7 +19,7 @@ class ChangesToPublishingAppsRequestsController < RequestsController
 
   def new_changes_to_publishing_apps_request_params
     params.require(:support_requests_changes_to_publishing_apps_request).permit(
-      :request_context, :title, :user_need, :url_of_example,
+      :title, :user_need, :url_of_example,
       requester_attributes: [:email, :name, :collaborator_emails],
       time_constraint_attributes: [:not_before_date, :needed_by_date, :time_constraint_reason],
     )

--- a/app/controllers/content_advice_requests_controller.rb
+++ b/app/controllers/content_advice_requests_controller.rb
@@ -19,8 +19,7 @@ class ContentAdviceRequestsController < RequestsController
 
   def content_advice_request_params
     params.require(:support_requests_content_advice_request).permit(
-      :title, :nature_of_request, :nature_of_request_details,
-      :details, :urls, :contact_number,
+      :title, :details, :urls, :contact_number,
       requester_attributes: [:email, :name, :collaborator_emails],
       time_constraint_attributes: [:needed_by_date, :time_constraint_reason],
     )

--- a/app/controllers/content_change_requests_controller.rb
+++ b/app/controllers/content_change_requests_controller.rb
@@ -20,7 +20,6 @@ class ContentChangeRequestsController < RequestsController
   def content_change_request_params
     params.require(:support_requests_content_change_request).permit(
       :title, :details_of_change, :url, :related_urls,
-      :request_context,
       requester_attributes: [:email, :name, :collaborator_emails],
       time_constraint_attributes: [:not_before_date, :needed_by_date, :time_constraint_reason],
     )

--- a/app/views/analytics_requests/_request_details.html.erb
+++ b/app/views/analytics_requests/_request_details.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "support/request_context", locals: { f: f } %>
-
 <%= f.semantic_fields_for :needed_report do |r| %>
   <%= r.inputs name: "What reporting period are you interested in?" do %>
     <%= r.input :reporting_period_start, label: "From", required: true, input_html: {:class => "input-md-6", :"aria-required" => true} %>

--- a/app/views/changes_to_publishing_apps_requests/_request_details.html.erb
+++ b/app/views/changes_to_publishing_apps_requests/_request_details.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "support/request_context", locals: { f: f } %>
-
 <%= f.input :title, label: "Title of request", input_html: { class: "input-md-6", placeholder: "New need request" } %>
 
 <%= f.inputs name: "Details of the new feature/need" do %>

--- a/app/views/content_advice_requests/_request_details.html.erb
+++ b/app/views/content_advice_requests/_request_details.html.erb
@@ -1,9 +1,5 @@
 <%= f.input :title, label: "Title of request", input_html: { class: "input-md-6", placeholder: "Advice on content" } %>
 
-<%= f.input :nature_of_request, as: :radio, required: true, label: "What is the nature of this request?", collection: f.object.nature_of_request_options, input_html: { :"aria-required" => true } %>
-
-<%= f.input :nature_of_request_details, label: false, input_html: { class: "input-md-6" } %>
-
 <%= f.inputs name: "Details of your request" do %>
   <%= f.input :details, as: :text, required: true,
               label: "Please explain what you would like help with",

--- a/app/views/content_change_requests/_request_details.html.erb
+++ b/app/views/content_change_requests/_request_details.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "support/request_context", locals: { f: f } %>
-
 <%= f.input :title, label: "Title of request", input_html: { class: "input-md-6", placeholder: "Content change request" } %>
 
 <%= f.inputs name: "URL affected" do %>

--- a/lib/support/gds/user_facing_components.rb
+++ b/lib/support/gds/user_facing_components.rb
@@ -17,8 +17,7 @@ module Support
         protected
         def component_options
           [
-            { name: "GOV.UK: Services and information content", id: "gov_uk_mainstream" },
-            { name: "GOV.UK: Departments and policy content", id: "gov_uk_inside_government", inside_government_related: true },
+            { name: "GOV.UK: content", id: "gov_uk_content" },
             { name: "Whitehall Publisher", id: "inside_government_publisher", inside_government_related: true },
             { name: "Mainstream Publisher", id: "mainstream_publisher" },
             { name: "Travel Advice Publisher", id: "travel_advice_publisher" },

--- a/lib/support/requests/analytics_request.rb
+++ b/lib/support/requests/analytics_request.rb
@@ -1,12 +1,9 @@
-require 'support/gds/with_request_context'
 require 'support/gds/needed_report'
 require 'support/requests/request'
 
 module Support
   module Requests
     class AnalyticsRequest < Request
-      include Support::GDS::WithRequestContext
-
       attr_accessor :needed_report, :justification_for_needing_report
 
       validates_presence_of :needed_report, :justification_for_needing_report

--- a/lib/support/requests/changes_to_publishing_apps_request.rb
+++ b/lib/support/requests/changes_to_publishing_apps_request.rb
@@ -1,12 +1,10 @@
 require 'support/requests/request'
 require 'support/requests/with_time_constraint'
-require 'support/gds/with_request_context'
 
 module Support
   module Requests
     class ChangesToPublishingAppsRequest < Request
       include WithTimeConstraint
-      include Support::GDS::WithRequestContext
 
       attr_accessor :title, :user_need, :url_of_example
       validates_presence_of :user_need

--- a/lib/support/requests/content_advice_request.rb
+++ b/lib/support/requests/content_advice_request.rb
@@ -7,39 +7,14 @@ module Support
     class ContentAdviceRequest < Request
       include WithTimeConstraint
 
-      attr_accessor :title, :nature_of_request, :nature_of_request_details,
-                    :details, :urls, :contact_number
+      attr_accessor :title, :details, :urls, :contact_number
 
-      validates_presence_of :nature_of_request
       validates_presence_of :details
-      validates :nature_of_request, inclusion: {
-        in: %w(initial_guidance formal_response other),
-        message: "%{value} is not a valid option"
-      }
-
-      validates_presence_of :nature_of_request_details,
-        if: Proc.new { |r| r.nature_of_request == 'other' }
 
       def initialize(attrs = {})
         self.time_constraint = TimeConstraint.new
 
         super
-      end
-
-      def nature_of_request_options
-        [
-          ["Initial guidance from GOV.UK on content you are working on", "initial_guidance"],
-          ["A formal response that you would like to pass onto other teams in your department or organisation", "formal_response"],
-          ["Other - please give information", "other"],
-        ]
-      end
-
-      def formatted_nature_of_request
-        if nature_of_request == "other"
-          nature_of_request_details
-        else
-          Hash[nature_of_request_options].key(nature_of_request)
-        end
       end
 
       def self.label

--- a/lib/support/requests/content_change_request.rb
+++ b/lib/support/requests/content_change_request.rb
@@ -1,12 +1,10 @@
 require 'support/requests/request'
 require 'support/requests/with_time_constraint'
-require 'support/gds/with_request_context'
 
 module Support
   module Requests
     class ContentChangeRequest < Request
       include WithTimeConstraint
-      include Support::GDS::WithRequestContext
 
       attr_accessor :title, :details_of_change, :url, :related_urls
       validates_presence_of :details_of_change

--- a/lib/zendesk/ticket/analytics_request_ticket.rb
+++ b/lib/zendesk/ticket/analytics_request_ticket.rb
@@ -15,8 +15,6 @@ module Zendesk
       protected
       def comment_snippets
         [
-          LabelledSnippet.new(on: @request,               field: :formatted_request_context,
-                                                          label: "Which part of GOV.UK is this about?"),
           LabelledSnippet.new(on: @request.needed_report, field: :reporting_period),
           LabelledSnippet.new(on: @request.needed_report, field: :pages_or_sections,
                                                           label: "Requested pages/sections"),

--- a/lib/zendesk/ticket/changes_to_publishing_apps_request_ticket.rb
+++ b/lib/zendesk/ticket/changes_to_publishing_apps_request_ticket.rb
@@ -7,21 +7,16 @@ module Zendesk
       attr_reader :time_constraint
 
       def subject
-        subject_prefix = (@request.title.nil? or @request.title.empty?) ? "" : "#{@request.title} - "
-        subject_suffix = @request.inside_government_related? ? "New Feature Request" : "New Need Request"
-        subject_prefix + subject_suffix
+        (@request.title.nil? or @request.title.empty?) ? "" : "#{@request.title}"
       end
 
       def tags
-        specific_tag = @request.inside_government_related? ? ["new_feature_request"] : ["new_need_request"]
-        super + specific_tag + inside_government_tag_if_needed
+        super + ["new_feature_request"]
       end
 
       protected
       def comment_snippets
         [
-          LabelledSnippet.new(on: @request,                 field: :formatted_request_context,
-                                                            label: "Which part of GOV.UK is this about?"),
           LabelledSnippet.new(on: @request,                 field: :user_need),
           LabelledSnippet.new(on: @request,                 field: :url_of_example),
         ]

--- a/lib/zendesk/ticket/content_advice_request_ticket.rb
+++ b/lib/zendesk/ticket/content_advice_request_ticket.rb
@@ -21,8 +21,6 @@ module Zendesk
       protected
       def comment_snippets
         [
-          request_label(field: :formatted_nature_of_request,
-                        label: "Nature of the request"),
           request_label(field: :details),
           request_label(field: :urls,
                         label: "Relevant URLs"),

--- a/lib/zendesk/ticket/content_change_request_ticket.rb
+++ b/lib/zendesk/ticket/content_change_request_ticket.rb
@@ -13,14 +13,12 @@ module Zendesk
       end
 
       def tags
-        super + ["content_amend"] + inside_government_tag_if_needed
+        super + ["content_amend"]
       end
 
       protected
       def comment_snippets
-        [ 
-          LabelledSnippet.new(on: @request,                 field: :formatted_request_context,
-                                                            label: "Which part of GOV.UK is this about?"),
+        [
           LabelledSnippet.new(on: @request,                 field: :url,
                                                             label: "URL of content to be changed"),
           LabelledSnippet.new(on: @request,                 field: :related_urls,

--- a/spec/features/analytics_requests_spec.rb
+++ b/spec/features/analytics_requests_spec.rb
@@ -18,10 +18,7 @@ feature "Analytics requests" do
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => [ "govt_form", "analytics" ],
       "comment" => { "body" =>
-"[Which part of GOV.UK is this about?]
-Services and information
-
-[Reporting period]
+"[Reporting period]
 From Start Q4 2012 to End 2012
 
 [Requested pages/sections]
@@ -40,7 +37,6 @@ One-off
 PDF"})
 
     user_makes_an_analytics_request(
-      context: "Services and information",
       from: "Start Q4 2012",
       to: "End 2012",
       which_part_of_govuk: "https://gov.uk/X",
@@ -60,10 +56,6 @@ PDF"})
     click_on "Analytics access, reports and help"
 
     expect(page).to have_content("Request access to Google Analytics or help with analytics or reports")
-
-    within "#request-context" do
-      choose details[:context]
-    end
 
     fill_in "From", :with => details[:from]
     fill_in "To", :with => details[:to]

--- a/spec/features/changes_to_publishing_apps_requests_spec.rb
+++ b/spec/features/changes_to_publishing_apps_requests_spec.rb
@@ -14,9 +14,9 @@ feature "New feature requests" do
 
   scenario "successful request" do
     request = expect_zendesk_to_receive_ticket(
-      "subject" => "Abc - New Feature Request",
+      "subject" => "Abc",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
-      "tags" => [ "govt_form", "new_feature_request", "inside_government" ],
+      "tags" => [ "govt_form", "new_feature_request" ],
       "comment" => { "body" =>
 "[Needed by date]
 31-12-2020
@@ -27,9 +27,6 @@ feature "New feature requests" do
 [Reason for time constraint]
 Legal requirement
 
-[Which part of GOV.UK is this about?]
-Departments and policy
-
 [User need]
 Information on XYZ
 
@@ -38,7 +35,6 @@ http://www.example.com"})
 
     user_makes_a_new_feature_request(
       title: "Abc",
-      context: "Departments and policy",
       user_need: "Information on XYZ",
       url_of_example: "http://www.example.com",
       needed_by_date: "31-12-2020",
@@ -58,10 +54,6 @@ http://www.example.com"})
     expect(page).to have_content("Request for changes or new features for any publishing applications or ask for technical advice. Also used for transitioning new sites to GOV.UK")
 
     fill_in "Title of request", with: details[:title]
-
-    within "#request-context" do
-      choose details[:context]
-    end
 
     fill_in "What is the user need/feature request?", with: details[:user_need]
     fill_in "Can you provide a link to an example of this feature?", with: details[:url_of_example]

--- a/spec/features/content_advice_requests_spec.rb
+++ b/spec/features/content_advice_requests_spec.rb
@@ -23,9 +23,6 @@ feature "Request for content advice" do
 [Reason for time constraint]
 Ministerial announcement Z
 
-[Nature of the request]
-Initial guidance from GOV.UK on content you are working on
-
 [Details]
 I need help to choose a format, here's my content...
 
@@ -37,7 +34,6 @@ https://www.gov.uk/x, https://www.gov.uk/y
 
     user_requests_content_advice(
       title: "Which format",
-      nature_of_request: "Initial guidance from GOV.UK",
       details: "I need help to choose a format, here's my content...",
       urls: "https://www.gov.uk/x, https://www.gov.uk/y",
       needed_by: "12-01-2020",
@@ -53,10 +49,7 @@ https://www.gov.uk/x, https://www.gov.uk/y
       "subject" => "Tricky query - Advice on content",
       "tags" => [ "govt_form", "dept_content_advice" ],
       "comment" => { "body" =>
-"[Nature of the request]
-some details
-
-[Details]
+"[Details]
 I have a tricky query, here's my content...
 
 [Relevant URLs]
@@ -67,8 +60,6 @@ https://www.gov.uk/x, https://www.gov.uk/y
 
     user_requests_content_advice(
       title: "Tricky query",
-      nature_of_request: "Other - please give information",
-      nature_of_request_details: "some details",
       details: "I have a tricky query, here's my content...",
       urls: "https://www.gov.uk/x, https://www.gov.uk/y",
       contact_number: "0121 111111",
@@ -85,9 +76,6 @@ https://www.gov.uk/x, https://www.gov.uk/y
     expect(page).to have_content("Ask for help or advice on any content problems")
 
     fill_in "Title of request", with: details[:title]
-    choose details[:nature_of_request]
-    fill_in 'support_requests_content_advice_request_nature_of_request_details',
-      with: details[:nature_of_request_details] if details[:nature_of_request_details]
     fill_in "Please explain what you would like help with", with: details[:details]
     fill_in "Relevant URLs (if applicable)", with: details[:urls]
 

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -27,9 +27,6 @@ feature "Content change requests" do
 [Reason for time constraint]
 New law
 
-[Which part of GOV.UK is this about?]
-Services and information
-
 [URL of content to be changed]
 http://gov.uk/X
 
@@ -41,7 +38,6 @@ Out of date XX YY"})
 
     user_makes_a_content_change_request(
       title: "Update X",
-      context: "Services and information",
       details_of_change: "Out of date XX YY",
       url: "http://gov.uk/X",
       related_urls: "XXXXX",
@@ -57,7 +53,7 @@ Out of date XX YY"})
     request = expect_zendesk_to_receive_ticket(
       "subject" => "Content change request",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
-      "tags" => %w{govt_form content_amend inside_government})
+      "tags" => %w{govt_form content_amend})
 
     user_makes_a_content_change_request(
       context: "Departments and policy",
@@ -74,10 +70,6 @@ Out of date XX YY"})
     click_on "Content changes and new content requests"
 
     expect(page).to have_content("Request changes to GOV.UK content managed by GDS content designers")
-
-    within "#request-context" do
-      choose details[:context]
-    end
 
     fill_in "Title of request", with: details[:title] unless details[:title].nil?
     fill_in "Details of the requested change", with: details[:details_of_change]

--- a/spec/features/technical_fault_reports_spec.rb
+++ b/spec/features/technical_fault_reports_spec.rb
@@ -16,10 +16,10 @@ feature "Technical fault reports" do
     request = expect_zendesk_to_receive_ticket(
       "subject" => "Technical fault report",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
-      "tags" => [ "govt_form", "technical_fault", "fault_with_gov_uk_mainstream" ],
+      "tags" => [ "govt_form", "technical_fault", "fault_with_gov_uk_content" ],
       "comment" => { "body" =>
 "[Location of fault]
-GOV.UK: Services and information content
+GOV.UK: content
 
 [What is broken]
 Smart answer
@@ -34,7 +34,7 @@ Broken link
 Should have linked through"})
 
     user_makes_a_technical_fault_report(
-      location_of_fault: "GOV.UK: Services and information content",
+      location_of_fault: "GOV.UK: content",
       what_is_broken: "Smart answer",
       user_action: "Clicked on x",
       what_happened: "Broken link",

--- a/spec/models/support/requests/analytics_request_spec.rb
+++ b/spec/models/support/requests/analytics_request_spec.rb
@@ -5,7 +5,6 @@ module Support
   module Requests
     describe AnalyticsRequest do
       it { should validate_presence_of(:requester) }
-      it { should validate_presence_of(:request_context) }
 
       it { should validate_presence_of(:needed_report) }
       it { should validate_presence_of(:justification_for_needing_report) }

--- a/spec/models/support/requests/changes_to_publishing_apps_request_spec.rb
+++ b/spec/models/support/requests/changes_to_publishing_apps_request_spec.rb
@@ -6,7 +6,6 @@ module Support
     describe ChangesToPublishingAppsRequest do
       it { should validate_presence_of(:requester) }
       it { should validate_presence_of(:user_need) }
-      it { should validate_presence_of(:request_context) }
 
       it { should allow_value("XXX").for(:title) }
     end

--- a/spec/models/support/requests/content_advice_request_spec.rb
+++ b/spec/models/support/requests/content_advice_request_spec.rb
@@ -7,19 +7,9 @@ module Support
       it { should validate_presence_of(:requester) }
       it { should validate_presence_of(:details) }
       it { should allow_value("xxx").for(:title) }
-      it { should allow_value("xxx").for(:nature_of_request_details) }
       it { should allow_value("xxx").for(:urls) }
 
-      it { should validate_presence_of(:nature_of_request) }
       it { should allow_value("xxx").for(:contact_number) }
-
-      its(:nature_of_request_options) { is_expected.to have_exactly(3).items }
-
-      context "nature of request is 'other'" do
-        subject { ContentAdviceRequest.new(nature_of_request: 'other') }
-
-        it { should validate_presence_of(:nature_of_request_details) }
-      end
 
       def as_str(date)
         date.strftime("%d-%m-%Y")

--- a/spec/models/support/requests/content_change_request_spec.rb
+++ b/spec/models/support/requests/content_change_request_spec.rb
@@ -7,8 +7,6 @@ module Support
       it { should validate_presence_of(:requester) }
       it { should validate_presence_of(:details_of_change) }
 
-      it { should validate_presence_of(:request_context) }
-
       it { should allow_value("xxxx").for(:title) }
       it { should allow_value(nil).for(:title) }
 

--- a/spec/models/zendesk/ticket/changes_to_publishing_apps_request_ticket.rb
+++ b/spec/models/zendesk/ticket/changes_to_publishing_apps_request_ticket.rb
@@ -9,21 +9,13 @@ module Zendesk
         ChangesToPublishingAppsRequestTicket.new(double(defaults.merge(opts)))
       end
 
-      context "an inside government request" do
-        subject { ticket(inside_government_related?: true) }
-        its(:tags) { should include("new_feature_request", "inside_government") }
-        its(:subject) { should eq("New Feature Request") }
-      end
+      subject { ticket }
+      its(:tags) { should include("new_feature_request") }
+      its(:subject) { should eq("") }
 
-      context "a mainstream request" do
-        subject { ticket(inside_government_related?: false) }
-        its(:tags) { should include("new_need_request") }
-        its(:subject) { should eq("New Need Request") }
-
-        context "with a title" do
-          subject { ticket(title: "ABC", inside_government_related?: false) }
-          its(:subject) { should eq("ABC - New Need Request") }
-        end
+      context "with a title" do
+        subject { ticket(title: "ABC") }
+        its(:subject) { should eq("ABC") }
       end
     end
   end

--- a/spec/models/zendesk/ticket/content_change_request_ticket_spec.rb
+++ b/spec/models/zendesk/ticket/content_change_request_ticket_spec.rb
@@ -17,9 +17,8 @@ module Zendesk
         expect(ticket.subject).to eq("Content change request")
       end
 
-      context "an inside government request" do
-        subject { ticket(inside_government_related?: true) }
-        its(:tags) { should include("content_amend", "inside_government") }
+      it 'includes a "content_amend" tag' do
+        expect(ticket.tags).to include("content_amend")
       end
     end
   end


### PR DESCRIPTION
This branch is based on [Support forms text changes](https://github.com/alphagov/support/pull/282) and should not be merged before that branch.

[Trello card](https://trello.com/c/G9xf2aZZ/3-remove-radio-options-on-support-form)

Fewer options (radio buttons) on support request forms.

## UI changes

Some of the forms have had radio buttons removed similar to the following:

### Before
![general_support_before](https://cloud.githubusercontent.com/assets/1370570/17107722/63bd54fe-5288-11e6-83aa-9f9028bf6c01.png)

### After
![general_support_after](https://cloud.githubusercontent.com/assets/1370570/17107729/68c9db84-5288-11e6-87cb-3cac4af85b38.png)

The **'Report a technical fault to GDS'** form has had two radio buttons replaced with one:

### Before
![technical_before](https://cloud.githubusercontent.com/assets/1370570/17107733/6e761b9c-5288-11e6-9144-e83689f46821.png)

### After
![technical_after](https://cloud.githubusercontent.com/assets/1370570/17107746/77cc626e-5288-11e6-992a-7ea67fe3d8d7.png)



- [ ] Product Acceptance
- [ ] Deployment to production