### PR TITLE
Update content advice description

### DIFF
--- a/lib/support/requests/content_advice_request.rb
+++ b/lib/support/requests/content_advice_request.rb
@@ -22,7 +22,7 @@ module Support
       end
 
       def self.description
-        "Ask for help or advice on any content problems"
+        "Ask for help or advice on any content problems. Request short URLs, topical event pages, groups or manuals."
       end
     end
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/2PxYo5tt/2-text-changes-to-support-forms)

> I have a very small amendment for one of the descriptions. Can this be amended? For content advice, need to add Request short URLs, topical event pages, groups or manuals. So the entire description would be: Ask for help or advice on any content problems. Request short URLs, topical event pages, groups or manuals.