### PR TITLE
Add the ability to export global feedback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'govuk_admin_template', '4.2.0'
 if ENV['API_DEV']
   gem "gds-api-adapters", :path => '../gds-api-adapters'
 else
-  gem "gds-api-adapters", '20.1.1'
+  gem "gds-api-adapters", '33.1.0'
 end
 gem 'gretel', '3.0.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    domain_name (0.5.24)
+    domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -88,11 +88,11 @@ GEM
       multipart-post (>= 1.2, < 3)
     formtastic (3.1.3)
       actionpack (>= 3.2.13)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (33.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
     gds-sso (11.2.0)
@@ -198,7 +198,7 @@ GEM
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rack-cache (1.2)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-protection (1.5.3)
       rack
@@ -311,7 +311,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (4.9.0)
       kgio (~> 2.6)
       rack
@@ -343,7 +343,7 @@ DEPENDENCIES
   capybara (~> 2.4.0)
   factory_girl_rails (~> 4.5.0)
   formtastic-bootstrap!
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (= 33.1.0)
   gds-sso (= 11.2.0)
   gds_zendesk (= 2.1.0)
   govuk_admin_template (= 4.2.0)
@@ -372,4 +372,4 @@ DEPENDENCIES
   webmock (~> 1.21.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/controllers/anonymous_feedback/global_export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/global_export_requests_controller.rb
@@ -1,0 +1,20 @@
+require "gds_api/support_api"
+
+class AnonymousFeedback::GlobalExportRequestsController < AuthorisationController
+  def create
+    authorize! :request, :global_export_request
+
+    support_api.create_global_export_request(export_request_params)
+    redirect_to anonymous_feedback_explore_path,
+      notice: "We are sending your CSV file to #{current_user.email}. If you don't see it in a few minutes, check your spam folder."
+  end
+
+private
+  def export_request_params
+    params.permit(:from_date, :to_date).merge(notification_email: current_user.email)
+  end
+
+  def support_api
+    GdsApi::SupportApi.new(Plek.find("support-api"))
+  end
+end

--- a/app/controllers/authorisation_controller.rb
+++ b/app/controllers/authorisation_controller.rb
@@ -1,6 +1,6 @@
 require 'support/permissions/ability'
 
-class AuthorisationController < ApplicationController  
+class AuthorisationController < ApplicationController
   check_authorization
 
   rescue_from CanCan::AccessDenied do |exception|

--- a/app/views/anonymous_feedback/explore/new.html.erb
+++ b/app/views/anonymous_feedback/explore/new.html.erb
@@ -25,4 +25,29 @@
       <%= f.action :submit, label: "Explore by organisation", button_html: { class: "btn btn-success" } %>
     <% end %>
   </div>
+  <% if can? :request, :global_export_request %>
+    <div class="col-md-8">
+      <h2>Total quantity by day</h2>
+      <%= form_tag anonymous_feedback_global_export_requests_path, class: 'well formtastic' do %>
+        <div class="string input required form-group">
+          <span class="form-label">
+            <label for="from-date" class="control-label">Start date</label>
+          </span>
+          <span class="form-wrapper">
+            <input type="text" name="from_date" id="from-date" class="input-sm form-control add-right-margin" data-module="calendar" data-max-date="0" value="<%= params[:from_date]%>"/>
+          </span>
+        </div>
+
+        <div class="string input required form-group">
+          <span class="form-label">
+            <label for="to-date" class="control-label">End date</label>
+          </span>
+          <span class="form-wrapper">
+            <input type="text" name="to_date" id="to-date" class="form-control input-sm" data-module="calendar" data-max-date="0" value="<%= params[:to_date]%>"/>
+          </span>
+        </div>
+        <input type="submit" value="Export as CSV" class="btn btn-success" />
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -10,6 +10,6 @@ if Rails.env == "development" && ENV['GDS_SSO_STRATEGY'] != 'real'
     "uid" => 'dummy-user',
     "name" => 'Ms Example',
     "email" => 'example@example.com',
-    "permissions" => ['single_points_of_contact', 'api_users']
+    "permissions" => ['single_points_of_contact', 'api_users', 'feedex_exporters']
   )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Support::Application.routes.draw do
     resources :organisations, only: :show, param: :slug, format: false
 
     resources :export_requests, only: [:create, :show], format: false
+    resources :global_export_requests, only: [:create], format: false
   end
 
   get "emergency-contact-details",

--- a/lib/support/permissions/ability.rb
+++ b/lib/support/permissions/ability.rb
@@ -17,6 +17,7 @@ module Support
         can :create, [ FoiRequest, NamedContact ] if user.has_permission?('api_users')
 
         can :read, :anonymous_feedback
+        can :request, :global_export_request if user.has_permission?('feedex_exporters')
         can :read, Support::Navigation::EmergencyContactDetailsSection
         can :create, Support::Requests::Anonymous::Explore
         can :create, [GeneralRequest, AnalyticsRequest, ContentAdviceRequest, TechnicalFaultReport, UnpublishContentRequest]

--- a/spec/controllers/anonymous_feedback/global_export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/global_export_requests_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/support_api'
+
+describe AnonymousFeedback::GlobalExportRequestsController, type: :controller do
+  include GdsApi::TestHelpers::SupportApi
+
+  let(:user) do
+    create(:user,
+           organisation_slug: 'cabinet-office',
+           email: 'foo.bar@example.gov.uk',
+           permissions: ['signin', 'feedex_exporters'],
+          )
+  end
+
+  before { login_as user }
+
+  describe "#create" do
+    let!(:stub_request) do
+      stub_support_global_export_request_creation(
+        notification_email: user.email,
+        from_date: "1 Aug 2016",
+        to_date: "8 Aug 2016",
+      )
+    end
+
+    it "makes a successful create request" do
+      post :create, from_date: "1 Aug 2016", to_date: "8 Aug 2016"
+      expect(stub_request).to have_been_made
+    end
+
+    it "sets the flash" do
+      post :create, from_date: "1 Aug 2016", to_date: "8 Aug 2016"
+      expect(flash[:notice]).to include 'foo.bar@example.gov.uk'
+    end
+
+    it "redirects to the feedback explore page" do
+      post :create, from_date: "1 Aug 2016", to_date: "8 Aug 2016"
+      expect(response).to redirect_to(anonymous_feedback_explore_path)
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/ptXseJEJ/13-export-global-anonymous-feedback-csv)

<img width="797" alt="screenshot 2016-08-08 15 28 53" src="https://cloud.githubusercontent.com/assets/615627/17483277/4d5f2e58-5d7d-11e6-8835-91921e2d488b.png">

This section of the support application (feedex) now allows the
total quantity of requests received each day to be exported as a CSV
file.

Initially, we're protecting this behind a new role (`feedex_exporters`)
so we can control who gets access to the functionality. The main
reasoning here is to allow side-by-side verification of the figures
before rolling it out to wider (perhaps 'single point of contact')
release.