### PR TITLE
Analytics form changes

### DIFF
--- a/app/controllers/analytics_requests_controller.rb
+++ b/app/controllers/analytics_requests_controller.rb
@@ -6,7 +6,7 @@ class AnalyticsRequestsController <  RequestsController
 
   protected
   def new_request
-    AnalyticsRequest.new(needed_report: Support::GDS::NeededReport.new)
+    AnalyticsRequest.new
   end
 
   def zendesk_ticket_class
@@ -19,15 +19,14 @@ class AnalyticsRequestsController <  RequestsController
 
   def analytics_request_params
     params.require(:support_requests_analytics_request).permit(
-      :justification_for_needing_report,
-      requester_attributes: [:email, :name, :collaborator_emails],
-      needed_report_attributes: [
-        :reporting_period_start,
-        :reporting_period_end,
-        :pages_or_sections,
-        :non_standard_requirements,
-        :frequency,
-        :format
+      :google_analytics_request_details,
+      :single_point_of_contact_request_details,
+      :report_request_details,
+      :help_request_details,
+      requester_attributes: [
+        :email,
+        :name,
+        :collaborator_emails
       ],
     )
   end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -21,7 +21,10 @@ class RequestsController < AuthorisationController
       end
     else
       respond_to do |format|
-        format.html { render :new, status: 400 }
+        format.html do
+          flash.now[:alert] = @request.errors.full_messages.join('\n')
+          render :new, status: 400
+        end
         format.json { render json: {"errors" => @request.errors.to_a}, status: 400 }
       end
     end

--- a/app/views/accounts_permissions_and_training_requests/_request_details.html.erb
+++ b/app/views/accounts_permissions_and_training_requests/_request_details.html.erb
@@ -11,3 +11,5 @@
 </div>
 
 <%= f.input :additional_comments, as: :text, label: "Additional comments", input_html: { class: "input-md-6", rows: 6, cols: 50 } %>
+
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/app/views/analytics_requests/_request_details.html.erb
+++ b/app/views/analytics_requests/_request_details.html.erb
@@ -1,7 +1,17 @@
-<%= f.input :google_analytics_request_details, as: :text, label: "Access to Google Analytics", input_html: {:class => "input-md-6", :rows => 6, :cols => 50 } %>
+<div class="alert alert-info alert-block">
+  <p>Only department/organisation Analytics Single Point of Contact (SPOC) can request access.</p>
+</div>
 
-<%= f.input :single_point_of_contact_request_details, as: :text, label: "Tell me who my Analytics Single Point of Contact (SPOC) is", input_html: {:class => "input-md-6", :rows => 6, :cols => 50} %>
+<%= f.input :google_analytics_request_details, as: :text, label: "Access to Google Analytics", placeholder: 'Detail full name, email address and areas of content.', input_html: {:class => "input-md-6", :rows => 6, :cols => 50 } %>
 
-<%= f.input :report_request_details, as: :text, label: "Analytics Report Request", input_html: {:class => "input-md-6", :rows => 6, :cols => 50} %>
+<%= f.input :single_point_of_contact_request_details, as: :text, label: "Tell me who my Analytics Single Point of Contact (SPOC) is", placeholder: 'Detail information on department/organisation/agency. If you have one include your parent or sponsoring department.', input_html: {:class => "input-md-6", :rows => 6, :cols => 50} %>
 
-<%= f.input :help_request_details, as: :text, label: "Analytics Help", input_html: {:class => "input-md-6", :rows => 6, :cols => 50} %>
+<div class="alert alert-info alert-block">
+  <p>GDS no longer provide basic analytic reports - you should contact your department/organisation Analytics Single Point of Contact (SPOC) for analytic reporting.</p>
+</div>
+<%= f.input :report_request_details, as: :text, label: "Analytics Report Request", placeholder: 'Detail of report including date range.', input_html: {:class => "input-md-6", :rows => 6, :cols => 50} %>
+
+<div class="alert alert-info alert-block">
+  <p>Before contacting the GDS performance analytics team please check the GOV.UK Performance Analytics Basecamp community for tips or post your query there for help.</p>
+</div>
+<%= f.input :help_request_details, as: :text, label: "Analytics Help", placeholder: 'Detail what help you require and be specific in the examples you submit.', input_html: {:class => "input-md-6", :rows => 6, :cols => 50} %>

--- a/app/views/analytics_requests/_request_details.html.erb
+++ b/app/views/analytics_requests/_request_details.html.erb
@@ -1,32 +1,7 @@
-<%= f.semantic_fields_for :needed_report do |r| %>
-  <%= r.inputs name: "What reporting period are you interested in?" do %>
-    <%= r.input :reporting_period_start, label: "From", required: true, input_html: {:class => "input-md-6", :"aria-required" => true} %>
-    <%= r.input :reporting_period_end, label: "To", required: true, input_html: {:class => "input-md-6", :"aria-required" => true} %>
-    <%= r.input :pages_or_sections, as: :text, label: "Which page(s) or section(s) on GOV.UK do you want data for? (Please provide URLs and, if possible or relevant, Need IDs)", required: true, input_html: {:class => "input-md-6", :rows => 6, :cols => 50, :"aria-required" => true } %>
-  <% end %>
+<%= f.input :google_analytics_request_details, as: :text, label: "Access to Google Analytics", input_html: {:class => "input-md-6", :rows => 6, :cols => 50 } %>
 
-  <%= f.input :justification_for_needing_report, as: :text, label: "How will you use the report and what decisions will it help you make?", required: true, input_html: {:class => "input-md-6", :rows => 6, :cols => 50, :"aria-required" => true } %>
+<%= f.input :single_point_of_contact_request_details, as: :text, label: "Tell me who my Analytics Single Point of Contact (SPOC) is", input_html: {:class => "input-md-6", :rows => 6, :cols => 50} %>
 
-  <div class="alert alert-info">
-    <p>The basic report includes the following metrics:</p>
-    <ul>
-      <li>total pageviews</li>
-      <li>total unique pageviews</li>
-      <li>total unique visitors</li>
-    </ul>
-  </div>
+<%= f.input :report_request_details, as: :text, label: "Analytics Report Request", input_html: {:class => "input-md-6", :rows => 6, :cols => 50} %>
 
-  <%= r.input :non_standard_requirements, as: :text, label: "Beyond the basic report, what other information are you interested in?", input_html: {:class => "input-md-6", :rows => 6, :cols => 50} %>
-
-  <div id="frequency">
-    <%= r.input :frequency, as: :radio, required: true, label: "How often do you need to receive these reports?", collection: r.object.frequency_options, input_html: { :"aria-required" => true } %>
-  </div>
-
-  <div id="format">
-    <%= r.input :format, as: :radio, label: "Do you want a CSV file (so you can manipulate data) or a PDF (which will be more visual)?", collection: r.object.format_options %>
-  </div>
-
-  <div class="alert alert-info">
-    <p>For recurring reports, you will need to renew your request every 6 months.</p>
-  </div>
-<% end %>
+<%= f.input :help_request_details, as: :text, label: "Analytics Help", input_html: {:class => "input-md-6", :rows => 6, :cols => 50} %>

--- a/app/views/campaign_requests/_request_details.html.erb
+++ b/app/views/campaign_requests/_request_details.html.erb
@@ -14,3 +14,5 @@
 <% end %>
 
 <%= f.input :additional_comments, as: :text, label: "Additional comments", input_html: { class: "input-md-6", rows: 6, cols: 50 } %>
+
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/app/views/changes_to_publishing_apps_requests/_request_details.html.erb
+++ b/app/views/changes_to_publishing_apps_requests/_request_details.html.erb
@@ -11,3 +11,5 @@
 <%= render partial: "support/attachment_instructions" %>
 
 <%= render partial: "support/time_constraint", locals: { f: f } %>
+
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/app/views/content_advice_requests/_request_details.html.erb
+++ b/app/views/content_advice_requests/_request_details.html.erb
@@ -27,3 +27,5 @@
     <%= r.input :time_constraint_reason, label: "Reason for deadline", input_html: { class: "input-md-6" } %>
   <% end %>
 <% end %>
+
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/app/views/content_change_requests/_request_details.html.erb
+++ b/app/views/content_change_requests/_request_details.html.erb
@@ -16,3 +16,5 @@
 <div class="alert alert-info alert-block">
   <p>If your request is urgent, please fill in this form then call 07827 992603 to let us know. (It's ONLY urgent when the public or the government is facing immediate and significant financial, legal or physical risk.)</p>
 </div>
+
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/app/views/general_requests/_request_details.html.erb
+++ b/app/views/general_requests/_request_details.html.erb
@@ -5,3 +5,5 @@
 
   <%= f.input :url, label: "URL (if applicable)", input_html: { class: "input-md-6" } %>
 <% end %>
+
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/app/views/remove_user_requests/_request_details.html.erb
+++ b/app/views/remove_user_requests/_request_details.html.erb
@@ -11,3 +11,5 @@
     <%= f.input :reason_for_removal, as: :text, label: "Reason for removal", input_html: { class: "input-md-6", rows: 6, cols: 50 } %>
   <% end %>
 </div>
+
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -12,7 +12,5 @@
 
   <%= render partial: "request_details", locals: { f: f } %>
 
-  <%= render partial: "support/collaborators", locals: { f: f } %>
-
   <%= f.action :submit, label: "Submit", button_html: { class: "btn btn-success" } %>
 <% end %>

--- a/app/views/technical_fault_reports/_request_details.html.erb
+++ b/app/views/technical_fault_reports/_request_details.html.erb
@@ -17,3 +17,5 @@
 <div class="alert alert-info alert-block">
   <p>If you have screenshots please send them as attachments in reply to the acknowledgement email you will receive shortly.</p>
 </div>
+
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/app/views/unpublish_content_requests/_request_details.html.erb
+++ b/app/views/unpublish_content_requests/_request_details.html.erb
@@ -35,3 +35,5 @@
 <div class="alert alert-danger">
   <p>Pages cannot be recovered once you have deleted them. Please ensure that all requests to GDS to unpublish content have been approved at the correct level in your organisation - if you aren't sure check with your GDS single point of contact.</p>
 </div>
+
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/lib/support/requests/analytics_request.rb
+++ b/lib/support/requests/analytics_request.rb
@@ -4,13 +4,16 @@ require 'support/requests/request'
 module Support
   module Requests
     class AnalyticsRequest < Request
-      attr_accessor :needed_report, :justification_for_needing_report
+      REQUEST_DETAILS_ATTRS = [
+        :google_analytics_request_details,
+        :single_point_of_contact_request_details,
+        :report_request_details,
+        :help_request_details
+      ].freeze
 
-      validates_presence_of :needed_report, :justification_for_needing_report
+      attr_accessor(*REQUEST_DETAILS_ATTRS)
 
-      def needed_report_attributes=(attr)
-        self.needed_report = Support::GDS::NeededReport.new(attr)
-      end
+      validate :one_or_more_request_details_present
 
       def self.label
         "Analytics access, reports and help"
@@ -18,6 +21,16 @@ module Support
 
       def self.description
         "Request access to Google Analytics or help with analytics or reports"
+      end
+
+      def one_or_more_request_details_present
+        request_details = REQUEST_DETAILS_ATTRS.select do |request_details_attribute|
+          !send(request_details_attribute).to_s.empty?
+        end
+
+        if request_details.empty?
+          errors.add(:base, 'Please enter details for at least one type of request')
+        end
       end
     end
   end

--- a/lib/zendesk/ticket/analytics_request_ticket.rb
+++ b/lib/zendesk/ticket/analytics_request_ticket.rb
@@ -15,16 +15,26 @@ module Zendesk
       protected
       def comment_snippets
         [
-          LabelledSnippet.new(on: @request.needed_report, field: :reporting_period),
-          LabelledSnippet.new(on: @request.needed_report, field: :pages_or_sections,
-                                                          label: "Requested pages/sections"),
-          LabelledSnippet.new(on: @request,               field: :justification_for_needing_report),
-          LabelledSnippet.new(on: @request.needed_report, field: :non_standard_requirements,
-                                                          label: "More detailed analysis needed?"),
-          LabelledSnippet.new(on: @request.needed_report, field: :formatted_frequency,
-                                                          label: "Reporting frequency"),
-          LabelledSnippet.new(on: @request.needed_report, field: :formatted_format,
-                                                          label: "Report format"),
+          LabelledSnippet.new(
+            on: @request,
+            field: :google_analytics_request_details,
+            label: 'Google Analytics Access'
+          ),
+          LabelledSnippet.new(
+            on: @request,
+            field: :single_point_of_contact_request_details,
+            label: 'Single Point of Contact'
+          ),
+          LabelledSnippet.new(
+            on: @request,
+            field: :report_request_details,
+            label: 'Report Request'
+          ),
+          LabelledSnippet.new(
+            on: @request,
+            field: :help_request_details,
+            label: 'Help'
+          )
         ]
       end
     end

--- a/spec/features/analytics_requests_spec.rb
+++ b/spec/features/analytics_requests_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 feature "Analytics requests" do
-  # In order to measure how well my content is meeting user need
-  # As a government content producer
-  # I want a means to request analytics data from GDS
-
   let(:user) { create(:user, name: "John Smith", email: "john.smith@agency.gov.uk") }
 
   background do
@@ -18,65 +14,49 @@ feature "Analytics requests" do
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => [ "govt_form", "analytics" ],
       "comment" => { "body" =>
-"[Reporting period]
-From Start Q4 2012 to End 2012
+"[Google Analytics Access]
+Sarah Jones sarah@example.com some area
 
-[Requested pages/sections]
-https://gov.uk/X
+[Single Point of Contact]
+Government Digital Service
 
-[Justification for needing report]
-To measure campaign success
+[Report Request]
+/my-page
 
-[More detailed analysis needed?]
-I also need KPI Y
+[Help]
+Need help with cats"})
 
-[Reporting frequency]
-One-off
-
-[Report format]
-PDF"})
-
-    user_makes_an_analytics_request(
-      from: "Start Q4 2012",
-      to: "End 2012",
-      which_part_of_govuk: "https://gov.uk/X",
-      justification: "To measure campaign success",
-      more_detailed_analysis: "I also need KPI Y",
-      frequency: "One-off",
-      format: "PDF",
-    )
-
-    expect(request).to have_been_made
-  end
-
-  private
-  def user_makes_an_analytics_request(details)
     visit '/'
 
     click_on "Analytics access, reports and help"
 
     expect(page).to have_content("Request access to Google Analytics or help with analytics or reports")
 
-    fill_in "From", :with => details[:from]
-    fill_in "To", :with => details[:to]
+    fill_in "Access to Google Analytics",
+      with: "Sarah Jones sarah@example.com some area"
 
-    fill_in "Which page(s) or section(s) on GOV.UK do you want data for? (Please provide URLs and, if possible or relevant, Need IDs)",
-      with: details[:which_part_of_govuk]
+    fill_in "Tell me who my Analytics Single Point of Contact (SPOC) is",
+      with: "Government Digital Service"
 
-    fill_in "How will you use the report and what decisions will it help you make?",
-      with: details[:justification]
+    fill_in "Analytics Report Request",
+      with: "/my-page"
 
-    fill_in "Beyond the basic report, what other information are you interested in?",
-      with: details[:more_detailed_analysis]
-
-    within "#frequency" do
-      choose details[:frequency]
-    end
-
-    within "#format" do
-      choose details[:format]
-    end
+    fill_in "Analytics Help",
+      with: "Need help with cats"
 
     user_submits_the_request_successfully
+
+    expect(request).to have_been_made
+  end
+
+  scenario 'submitting a form with no inputs fails and shows a flash message' do
+    visit '/'
+
+    click_on "Analytics access, reports and help"
+
+    click_on "Submit"
+
+    expect(page).to have_content("Request access to Google Analytics or help with analytics or reports")
+    expect(page).to have_content 'Please enter details for at least one type of request'
   end
 end

--- a/spec/models/support/requests/analytics_request_spec.rb
+++ b/spec/models/support/requests/analytics_request_spec.rb
@@ -6,8 +6,10 @@ module Support
     describe AnalyticsRequest do
       it { should validate_presence_of(:requester) }
 
-      it { should validate_presence_of(:needed_report) }
-      it { should validate_presence_of(:justification_for_needing_report) }
+      it 'fails validation if there is no request type' do
+        expect(subject.valid?).to be false
+        expect(subject.errors[:base]).to include 'Please enter details for at least one type of request'
+      end
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/wwElLNWG/21-analytics-support-form-changes)

The Analytics form now has a reduced set of inputs. We validate that the user has filled in at least one of them.

## UI changes

**Before**
![screencapture-support-integration-publishing-service-gov-uk-analytics_request-new-1471276709499](https://cloud.githubusercontent.com/assets/1370570/17670388/9557f960-6309-11e6-8f6e-f54e51536649.png)


**After**
![screencapture-support-dev-gov-uk-analytics_request-new-1471276728514](https://cloud.githubusercontent.com/assets/1370570/17670397/9c63e0f2-6309-11e6-9dfa-a6e863256b56.png)
