### PR TITLE
Permit all users to make analytics requests

### DIFF
--- a/lib/support/permissions/ability.rb
+++ b/lib/support/permissions/ability.rb
@@ -12,6 +12,7 @@ module Support
       def initialize(user)
         can :read, :anonymous_feedback
         can :read, Support::Navigation::EmergencyContactDetailsSection
+        can :create, AnalyticsRequest
 
         can :create, [GeneralRequest, TechnicalFaultReport, Support::Requests::Anonymous::Explore]
 
@@ -20,10 +21,10 @@ module Support
         can :create, CampaignRequest if user.has_permission?('campaign_requesters')
 
         if user.has_permission?('content_requesters')
-          can :create, [ ChangesToPublishingAppsRequest, ContentChangeRequest, ContentAdviceRequest, UnpublishContentRequest, AnalyticsRequest ]
+          can :create, [ ChangesToPublishingAppsRequest, ContentChangeRequest, ContentAdviceRequest, UnpublishContentRequest ]
         end
 
-        can :create, [ AccountsPermissionsAndTrainingRequest, RemoveUserRequest, AnalyticsRequest ] if user.has_permission?('user_managers')
+        can :create, [ AccountsPermissionsAndTrainingRequest, RemoveUserRequest ] if user.has_permission?('user_managers')
 
         can :create, [ FoiRequest, NamedContact ] if user.has_permission?('api_users')
 

--- a/spec/features/analytics_requests_spec.rb
+++ b/spec/features/analytics_requests_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature "Analytics requests" do
-  let(:user) { create(:content_requester, name: "John Smith", email: "john.smith@agency.gov.uk") }
+  let(:user) { create(:user, name: "John Smith", email: "john.smith@agency.gov.uk") }
 
   background do
     login_as user

--- a/spec/models/support/requests/permissions_spec.rb
+++ b/spec/models/support/requests/permissions_spec.rb
@@ -7,6 +7,7 @@ module Support
       let(:requests_anyone_can_make) { [
         GeneralRequest,
         TechnicalFaultReport,
+        AnalyticsRequest,
       ] }
 
       let(:all_request_types) {
@@ -14,7 +15,6 @@ module Support
           :anonymous_feedback,
           UnpublishContentRequest,
           ContentAdviceRequest,
-          AnalyticsRequest,
           CampaignRequest,
           ContentChangeRequest,
           AccountsPermissionsAndTrainingRequest,


### PR DESCRIPTION
A previous change (from [card](https://trello.com/c/COcqtgck/29-modify-support-permissions)) removed the ability to access this feature from all users and instead only permitted those with 'single point of access' and 'user managers' permissions. This commit reinstates the ability of all users to make analytics requests following feedback from the support team.