### PR TITLE
Get GDS-SSO OAuth credentials from env vars

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,7 +1,7 @@
 GDS::SSO.config do |config|
   config.user_model   = 'User'
-  config.oauth_id     = 'abcdefghjasndjkasndsupport'
-  config.oauth_secret = 'secret'
+  config.oauth_id     = ENV['OAUTH_ID'] || 'abcdefghjasndjkasndsupport'
+  config.oauth_secret = ENV['OAUTH_SECRET'] || 'secret'
   config.oauth_root_url = Plek.current.find("signon")
 end
 


### PR DESCRIPTION
As of https://github.com/alphagov/support/pull/296, this app uses env vars. This commit changes the GDS-SSO initialiser to use env vars.