### PR TITLE
Guard CI reporter include

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
-require 'ci/reporter/rake/rspec'
+require 'ci/reporter/rake/rspec' if Rails.env.development? || Rails.env.test?
 
 Support::Application.load_tasks
 


### PR DESCRIPTION
CI reporter should only be included in development and test environments.