### PR TITLE
Update formtastic-bootstrap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,7 @@ gem 'cancan', '1.6.10'
 gem 'jquery-ui-rails', '5.0.1'
 gem 'plek', '1.10.0'
 
-# using github version to pick up unreleased bugfix
-# https://github.com/mjbellantoni/formtastic-bootstrap/pull/119
-gem 'formtastic-bootstrap', github: 'mjbellantoni/formtastic-bootstrap', ref: '8134e3f'
+gem 'formtastic-bootstrap', '3.1.1'
 gem 'select2-rails', '3.5.9.3'
 
 gem 'jc-validates_timeliness', '3.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: git://github.com/mjbellantoni/formtastic-bootstrap.git
-  revision: 8134e3fd9af1115ee4fa019d6ef994bdc0045099
-  ref: 8134e3f
-  specs:
-    formtastic-bootstrap (3.1.0)
-      formtastic (>= 3.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -94,8 +86,10 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    formtastic (3.1.3)
+    formtastic (3.1.5)
       actionpack (>= 3.2.13)
+    formtastic-bootstrap (3.1.1)
+      formtastic (>= 3.0)
     gds-api-adapters (36.1.0)
       link_header
       lrucache (~> 0.1.1)
@@ -372,7 +366,7 @@ DEPENDENCIES
   capybara (~> 2.4.0)
   ci_reporter_rspec
   factory_girl_rails (~> 4.5.0)
-  formtastic-bootstrap!
+  formtastic-bootstrap (= 3.1.1)
   gds-api-adapters (= 36.1.0)
   gds-sso (= 11.2.0)
   gds_zendesk (= 2.3.1)
@@ -403,4 +397,4 @@ DEPENDENCIES
   webmock (~> 1.21.0)
 
 BUNDLED WITH
-   1.13.2
+   1.14.5


### PR DESCRIPTION
This commit updates the `formtastic-bootstrap` gem to use the latest released version, which includes a fix which was the original reason for pinning to a specific commit.