### PR TITLE
Tweak body of taxonomy request tickets

### DIFF
--- a/lib/zendesk/ticket/taxonomy_change_topic_request_ticket.rb
+++ b/lib/zendesk/ticket/taxonomy_change_topic_request_ticket.rb
@@ -17,8 +17,9 @@ module Zendesk
       def comment_snippets
         [
           LabelledSnippet.new(on: @request, field: :formatted_type_of_change, label: "Type of change"),
-          request_label(field: :details),
-          request_label(field: :reasons),
+          LabelledSnippet.new(on: @request, field: :title, label: "Requested topic"),
+          LabelledSnippet.new(on: @request, field: :details, label: "Details of changes"),
+          LabelledSnippet.new(on: @request, field: :reasons, label: "Reasons for changes"),
         ]
       end
     end

--- a/lib/zendesk/ticket/taxonomy_new_topic_request_ticket.rb
+++ b/lib/zendesk/ticket/taxonomy_new_topic_request_ticket.rb
@@ -16,9 +16,10 @@ module Zendesk
 
       def comment_snippets
         [
-          request_label(field: :url),
-          request_label(field: :details),
-          request_label(field: :parent),
+          LabelledSnippet.new(on: @request, field: :title, label: "Requested topic"),
+          LabelledSnippet.new(on: @request, field: :url, label: "URL of new topic"),
+          LabelledSnippet.new(on: @request, field: :details, label: "Evidence"),
+          LabelledSnippet.new(on: @request, field: :parent, label: "Parent topic"),
         ]
       end
     end

--- a/spec/features/taxonomy_change_topic_requests_spec.rb
+++ b/spec/features/taxonomy_change_topic_requests_spec.rb
@@ -21,10 +21,13 @@ feature "Taxonomy topic change requests" do
 "[Type of change]
 Name of topic
 
-[Details]
+[Requested topic]
+Abc
+
+[Details of changes]
 Change the name to \"XYZ\".
 
-[Reasons]
+[Reasons for changes]
 People expect to find it here."})
 
     user_makes_a_taxomomy_change_topic_request(

--- a/spec/features/taxonomy_new_topic_requests_spec.rb
+++ b/spec/features/taxonomy_new_topic_requests_spec.rb
@@ -18,13 +18,16 @@ feature "New taxonomy topic requests" do
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => ["govt_form", "taxonomy_new_topic_request"],
       "comment" => { "body" =>
-"[Url]
+"[Requested topic]
+Abc
+
+[URL of new topic]
 https://www.gov.uk/government
 
-[Details]
+[Evidence]
 People expect to find it here.
 
-[Parent]
+[Parent topic]
 Education, training and skills"})
 
     user_makes_a_taxomomy_new_topic_request(


### PR DESCRIPTION
This commit tweaks the body text of taxonomy request tickets to add the name of the topic as well as rename some fields to be more descriptive.

Trello: https://trello.com/c/RwM6KeSd/508-improve-the-support-form-for-making-add-topic-or-change-topic-requests