### PR TITLE
Put taxonomy requests in separate group

### DIFF
--- a/lib/support/navigation/section_groups.rb
+++ b/lib/support/navigation/section_groups.rb
@@ -11,10 +11,11 @@ module Support
       def initialize(current_user = nil)
         @current_user = current_user
         @groups = [
-          SectionGroup.new("Content request", sections_for(ContentAdviceRequest, ContentChangeRequest, UnpublishContentRequest, TaxonomyNewTopicRequest, TaxonomyChangeTopicRequest)),
+          SectionGroup.new("Content request", sections_for(ContentAdviceRequest, ContentChangeRequest, UnpublishContentRequest)),
           SectionGroup.new("Technical support", sections_for(ChangesToPublishingAppsRequest, TechnicalFaultReport)),
           SectionGroup.new("User access", sections_for(AccountsPermissionsAndTrainingRequest, RemoveUserRequest)),
           SectionGroup.new("Campaigns", sections_for(CampaignRequest, LiveCampaignRequest)),
+          SectionGroup.new("Taxonomy requests", sections_for(TaxonomyNewTopicRequest, TaxonomyChangeTopicRequest)),
           SectionGroup.new("Other requests", sections_for(AnalyticsRequest, GeneralRequest)),
         ]
       end


### PR DESCRIPTION
We're getting a bunch of requests through the two taxonomy forms that aren't about the taxonomy. We think this might be caused by the fact that for non-privileged users (with only `signin` permission) the "Add a topic" form is the first on the page. "Report a technical fault to GDS" used to be first, so maybe they're getting confused about that.

![screen shot 2017-04-28 at 12 56 42](https://cloud.githubusercontent.com/assets/233676/25527803/59e94848-2c12-11e7-9dee-4e5613746251.png)

This commit moves the taxonomy forms into a separate group at the bottom. We're hoping this will reduce mis-addressed requests. If it doesn't we'll probably restrict access to the forms to people with `content_requesters` access.

## Before

![screen shot 2017-04-28 at 11 43 31](https://cloud.githubusercontent.com/assets/233676/25527812/69692b9e-2c12-11e7-9a11-6c74131fde4e.png)

## After

![screen shot 2017-04-28 at 11 44 10](https://cloud.githubusercontent.com/assets/233676/25527818/71517e4c-2c12-11e7-9667-049a6fffd978.png)


https://trello.com/c/wdIMF2kY