### PR TITLE
[DO NOT MERGE] Require 'signin' permission from signon to access app

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
   before_action :authenticate_support_user!
+  before_action :require_signin_permission!
 
   protect_from_forgery
 

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -2,7 +2,7 @@ require 'sidekiq/api'
 
 class SupportController < AuthorisationController
   skip_authorization_check
-  skip_before_action :authenticate_support_user!, only: [:queue_status]
+  skip_before_action :authenticate_support_user!, :require_signin_permission!, only: [:queue_status]
 
   def landing
     all_sections = Support::Navigation::SectionGroups.new(current_user).all_sections +

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,24 +1,46 @@
 require 'rails_helper'
 
 describe ApplicationController, :type => :controller do
-  # this controller is set up so that the auth always times out
-  controller do
-    def index
-      raise "should never reach this point because authentication should time out"
+  context 'authentication time out' do
+    # this controller is set up so that the auth always times out
+    controller do
+      def index
+        raise "should never reach this point because authentication should time out"
+      end
+
+      private
+      def authenticate_user!
+        sleep 1
+      end
+
+      def default_timeout_in_seconds
+        0.5
+      end
     end
 
-    private
-    def authenticate_user!
-      sleep 1
-    end
-
-    def default_timeout_in_seconds
-      0.5
+    it "is unavailable if authentication times out" do
+      get :index
+      expect(response).to have_http_status(503)
     end
   end
 
-  it "is unavailable if authentication times out" do
-    get :index
-    expect(response).to have_http_status(503)
+  context 'signin permissions' do
+    controller do
+      def index
+        head :ok
+      end
+    end
+
+    it 'rejects users without signin permission' do
+      login_as create(:user, permissions: [])
+      get :index
+      expect(response).to have_http_status(403)
+    end
+
+    it 'allows users with signin permission' do
+      login_as create(:user, permissions: ['signin'])
+      get :index
+      expect(response).to have_http_status(200)
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,7 +19,8 @@ FactoryGirl.define do
 
     factory :user_who_cannot_access_anything do
       after(:create) do |user, _|
-        def user.has_permission?(*args); false; end
+        # They have no permissions other than 'signin'
+        def user.has_permission?(*args); (args.first.to_s == 'signin'); end
         def user.can?(*args); false; end
       end
     end


### PR DESCRIPTION
For: https://trello.com/c/FMBZdTvk/45-support-app-should-probably-require-signon-permission-to-access

The expected behaviour of apps using signon is that they authenticate the
user and check that they have the 'signin' permission before allowing the
user to use the app.  This app only did the first part, not the second
bit.  The upside is that all signon users could access the support app;
the downside is that we have no way to limit a user so they can't use
this app, but still use other apps.  In practice this may not really be a
problem because of the purpose of the support app - it's unlikely we'd
want to allow someone to access other apps, but not support.  However it
does mean that the support app acts differently with respect to the
'signin' permission that is managed in signon and so this could be
confusing to future developers.

We will do some data work in signon to make sure that all existing users
retain signin permission, and that all new users are granted signin
permission for support by default.