### PR TITLE
Removes question mark from field label

### DIFF
--- a/app/views/content_change_requests/_request_details.html.erb
+++ b/app/views/content_change_requests/_request_details.html.erb
@@ -22,7 +22,7 @@
 
   <%= f.input :details_of_change, as: :text, label: "Details of the requested change", required: true, input_html: { :class => "input-md-6", :rows => 16, :cols => 50, :"aria-required" => true } %>
 
-  <%= f.input :related_urls, as: :text, label: "Does this affect any other URLs? (including any existing Welsh translations that need to be updated). Put each new URL on a new line.", input_html: { class: "input-md-6", rows: 4, cols: 50 } %>
+  <%= f.input :related_urls, as: :text, label: "Does this affect any other URLs (including any existing Welsh translations that need to be updated)? Put each new URL on a new line.", input_html: { class: "input-md-6", rows: 4, cols: 50 } %>
 
 <% end %>
 

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -74,7 +74,7 @@ Out of date XX YY"})
     fill_in "Title of request", with: details[:title] unless details[:title].nil?
     fill_in "Details of the requested change", with: details[:details_of_change]
     fill_in "URL", with: details[:url]
-    fill_in "Does this affect any other URLs? (including any existing Welsh translations that need to be updated). Put each new URL on a new line.", with: details[:related_urls]
+    fill_in "Does this affect any other URLs (including any existing Welsh translations that need to be updated)? Put each new URL on a new line.", with: details[:related_urls]
 
     user_fills_out_time_constraints(details)
 


### PR DESCRIPTION
For [Trello card](https://trello.com/c/gdX8tv08/186-rename-field-in-content-request-form)

Follow up to https://github.com/alphagov/support/pull/316