### PR TITLE
Add ui for filtering by path and org to feedex

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'govuk_admin_template', '4.4.2'
 if ENV['API_DEV']
   gem "gds-api-adapters", :path => '../gds-api-adapters'
 else
-  gem "gds-api-adapters", '36.1.0'
+  gem "gds-api-adapters", '47.8.0'
 end
 gem 'gretel', '3.0.9'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       actionpack (>= 3.2.13)
     formtastic-bootstrap (3.1.1)
       formtastic (>= 3.0)
-    gds-api-adapters (36.1.0)
+    gds-api-adapters (47.8.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -389,7 +389,7 @@ DEPENDENCIES
   ci_reporter_rspec
   factory_girl_rails (~> 4.5.0)
   formtastic-bootstrap (= 3.1.1)
-  gds-api-adapters (= 36.1.0)
+  gds-api-adapters (= 47.8.0)
   gds-sso (~> 13.0)
   gds_zendesk (= 2.4.0)
   govuk-lint
@@ -423,4 +423,4 @@ DEPENDENCIES
   webmock (~> 1.21.0)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,12 @@
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
-  govuk.buildProject(overrideTestTask: {
-    stage("Run custom tests") {
-      govuk.runRakeTask("ci:setup:rspec default")
+  govuk.buildProject(
+    sassLint: false,
+    overrideTestTask: {
+      stage("Run custom tests") {
+        govuk.runRakeTask("ci:setup:rspec default")
+      }
     }
-  })
+  )
 }

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -26,7 +26,7 @@ class AnonymousFeedbackController < RequestsController
         # TODO: I guess we should determine this filtering information from the
         # api_response rather than user-supplied params (note it's not
         # currently available on the api_response)
-        @filtered_by = ScopeFiltersPresenter.new(path: api_params[:path_prefix], organisation_slug: api_params[:organisation_slug])
+        @filtered_by = scope_filters
         @organisations_list = support_api.organisations_list.map do |org|
           [organisation_title_for_select(org), org["slug"]]
         end
@@ -44,6 +44,10 @@ private
     params.permit(:path, :organisation, :page, :from, :to).to_h
   end
 
+  def scope_filters
+    @scope_filters ||= ScopeFiltersPresenter.new(path: index_params[:path], organisation_slug: index_params[:organisation])
+  end
+
   def present_date_filters(api_response)
     DateFiltersPresenter.new(
       requested_from: index_params[:from],
@@ -59,8 +63,8 @@ private
 
   def api_params
     {
-      path_prefix: index_params[:path],
-      organisation_slug: index_params[:organisation],
+      path_prefix: scope_filters.path,
+      organisation_slug: scope_filters.organisation_slug,
       from: index_params[:from],
       to: index_params[:to],
       page: index_params[:page],
@@ -92,8 +96,8 @@ private
 
   def organisation_title_for_select(organisation)
     title = organisation["title"]
-    title << " (#{organisation["acronym"]})" if organisation["acronym"].present?
-    title << " [#{organisation["govuk_status"].titleize}]" if organisation["govuk_status"] && organisation["govuk_status"] != "live"
+    title << " (#{organisation['acronym']})" if organisation["acronym"].present?
+    title << " [#{organisation['govuk_status'].titleize}]" if organisation["govuk_status"] && organisation["govuk_status"] != "live"
     title
   end
 end

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -23,17 +23,10 @@ class AnonymousFeedbackController < RequestsController
       format.html {
         @feedback = AnonymousFeedbackPresenter.new(api_response)
         @dates = present_date_filters(api_response)
-        # TODO: we should decide how to describe filtering by both a path and
-        # an organisation, separately and together
         # TODO: I guess we should determine this filtering information from the
-        # api_response rather than user-supplied params
-        # TODO: this shouldn't be here, it belongs in its own object, possibly
-        # combined with date filters in a more general filters presenter?
-        if index_params[:path].present?
-          @filtered_by = index_params[:path]
-        elsif index_params[:organisation].present?
-          @filtered_by = organisation_title(index_params[:organisation])
-        end
+        # api_response rather than user-supplied params (note it's not
+        # currently available on the api_response)
+        @filtered_by = ScopeFiltersPresenter.new(path: api_params[:path_prefix], organisation_slug: api_params[:organisation_slug])
       }
       format.json { render json: api_response.results }
     end
@@ -88,11 +81,6 @@ private
     AnonymousFeedbackApiResponse.new(
       support_api.anonymous_feedback(api_params).to_hash
     )
-  end
-
-  def organisation_title(slug)
-    org = support_api.organisation(slug)
-    org.present? ? org["title"] : slug
   end
 
   def support_api

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -27,6 +27,9 @@ class AnonymousFeedbackController < RequestsController
         # api_response rather than user-supplied params (note it's not
         # currently available on the api_response)
         @filtered_by = ScopeFiltersPresenter.new(path: api_params[:path_prefix], organisation_slug: api_params[:organisation_slug])
+        @organisations_list = support_api.organisations_list.map do |org|
+          [organisation_title_for_select(org), org["slug"]]
+        end
       }
       format.json { render json: api_response.results }
     end
@@ -85,5 +88,12 @@ private
 
   def support_api
     GdsApi::SupportApi.new(Plek.find("support-api"))
+  end
+
+  def organisation_title_for_select(organisation)
+    title = organisation["title"]
+    title << " (#{organisation["acronym"]})" if organisation["acronym"].present?
+    title << " [#{organisation["govuk_status"].titleize}]" if organisation["govuk_status"] && organisation["govuk_status"] != "live"
+    title
   end
 end

--- a/app/helpers/feedex_helper.rb
+++ b/app/helpers/feedex_helper.rb
@@ -1,7 +1,7 @@
 module FeedexHelper
-  def total_responses_header(total_count:, from:, to:, results_limited:, path:)
+  def total_responses_header(total_count:, from:, to:, results_limited:, scopes:)
 
-    response_total = get_response_total(total_count, results_limited, path)
+    response_total = get_response_total(total_count, results_limited, scopes)
 
     if from.present? && to.present?
       "#{response_total} between #{from} and #{to}"
@@ -11,19 +11,15 @@ module FeedexHelper
       "#{response_total} before #{to}"
     elsif total_count && total_count > 1 && !results_limited
       "All #{response_total}"
-    elsif is_done_page?(path)
+    elsif scopes.done_page?
       "All responses"
     else
       response_total
     end
   end
 
-  def is_done_page?(path)
-    path.start_with?("done", "/done")
-  end
-
-  def get_response_total(total_count, results_limited, path)
-    return "Responses" if is_done_page?(path)
+  def get_response_total(total_count, results_limited, scopes)
+    return "Responses" if scopes.done_page?
     response_total = pluralize(number_with_delimiter(total_count), "response")
     response_total = "Over #{response_total}" if results_limited
     response_total

--- a/app/presenters/scope_filters_presenter.rb
+++ b/app/presenters/scope_filters_presenter.rb
@@ -4,7 +4,7 @@ class ScopeFiltersPresenter
   attr_reader :path, :organisation_slug
 
   def initialize(path: nil, organisation_slug: nil)
-    @path = path
+    @path = normalize_path(path)
     @organisation_slug = organisation_slug
   end
 
@@ -40,6 +40,19 @@ class ScopeFiltersPresenter
   end
 
 private
+
+  def normalize_path(path_or_url)
+    return nil unless path_or_url.present?
+    normalized_path = URI.parse(path_or_url).path
+    if normalized_path.present?
+      normalized_path.sub!(/^(http(s)?(:)?(\/)+?(:)?)?((\/)?www.)?gov.uk/, '')
+      normalized_path.start_with?('/') ? normalized_path : "/#{normalized_path}"
+    else
+      '/'
+    end
+  rescue URI::InvalidURIError
+    path_or_url
+  end
 
   def support_api
     GdsApi::SupportApi.new(Plek.find("support-api"))

--- a/app/presenters/scope_filters_presenter.rb
+++ b/app/presenters/scope_filters_presenter.rb
@@ -1,0 +1,47 @@
+require 'gds_api/support_api'
+
+class ScopeFiltersPresenter
+  attr_reader :path, :organisation_slug
+
+  def initialize(path: nil, organisation_slug: nil)
+    @path = path
+    @organisation_slug = organisation_slug
+  end
+
+  def filtered?
+    path.present? || organisation_slug.present?
+  end
+
+  def invalid_filter?
+    !filtered?
+  end
+
+  def done_page?
+    path.present? ? path.start_with?("done", "/done") : false
+  end
+
+  def organisation_title
+    organisation["title"] if organisation.present?
+  end
+
+  def organisation
+    @organisation ||= support_api.organisation(organisation_slug) if organisation_slug.present?
+  end
+
+  def to_s
+    if invalid_filter?
+      "Everything"
+    else
+      [
+        organisation_title,
+        path
+      ].compact.join(' on ')
+    end
+  end
+
+private
+
+  def support_api
+    GdsApi::SupportApi.new(Plek.find("support-api"))
+  end
+end

--- a/app/views/anonymous_feedback/explore/new.html.erb
+++ b/app/views/anonymous_feedback/explore/new.html.erb
@@ -14,7 +14,7 @@
     <h2 class="add-bottom-margin">By URL</h2>
     <%= semantic_form_for @explore_by_url, url: { action: "create" }, html: {class: 'well'} do |f| %>
       <%= f.input :url, label: "URL", required: true, input_html: { class: "input-md-7", :"aria-required" => true, type: "url"} %>
-      <p class="help-block add-bottom-margin">eg <code>/vat-rates</code> or <code>https://www.gov.uk/bank-holidays</code></p>
+      <p class="help-block add-bottom-margin">For example a page like <code>/vat-rates</code> or <code>https://www.gov.uk/bank-holidays</code>, or a partial path like <code>/guidance/</code></p>
       <%= f.action :submit, label: "Explore by URL", button_html: { class: "btn btn-success" } %>
     <% end %>
   </div>

--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -2,7 +2,7 @@
 <%= content_for :header, @filtered_by %>
 <% breadcrumb :anonymous_feedback_by_filter, @filtered_by %>
 
-<%= form_tag anonymous_feedback_export_requests_path, class: "form-inline" %>
+<%= form_tag(anonymous_feedback_export_requests_path, class: "form-inline") do %>
   <p class="feedback-response-count text-muted">
     <%= total_responses_header(total_count: @feedback.total_count,
                                from: @dates.from,
@@ -11,11 +11,11 @@
                                path: @filtered_by) %>
     <% %i(from to path organisation).each do |attr| %>
       <% next if params[attr].blank? %>
-      <input type="hidden" name="<%= attr%>" value="<%= params[attr]%>" />
+      <%= hidden_field_tag attr, params[attr], id: "export_form_#{attr}" %>
     <% end %>
-    <input type="submit" value="Export as CSV" class="btn-sm btn btn-default add-left-margin" />
+    <%= submit_tag "Export as CSV", class: "btn-sm btn btn-default add-left-margin" %>
   </p>
-</form>
+<% end %>
 
 <div class="row">
   <div class="col-lg-8 col-md-9">
@@ -27,27 +27,27 @@
           </h3>
         </div>
       <% end %>
-      <form action="<%= anonymous_feedback_index_path%>" class="form-inline date-filter-form panel-body">
-        <input type="hidden" name="path" value="<%= params[:path]%>" />
-        <input type="hidden" name="organisation" value="<%= params[:organisation]%>" />
+      <%= form_tag(anonymous_feedback_index_path, class: "form-inline date-filter-form panel-body")do %>
+        <%= hidden_field_tag "path", params[:path] %>
+        <%= hidden_field_tag "organisation", params[:organisation]%>
         <fieldset>
           <legend class="rm">Filter feedback by date</legend>
-          <label class="add-right-margin" for="start-date">
+          <%= label_tag("start-date", class: "add-right-margin") do %>
             Show feedback between <span class="rm">starting date</span>
-          </label>
-          <input type="text" name="from" id="start-date" class="input-sm form-control add-right-margin" data-module="calendar" data-max-date="0" value="<%= params[:from]%>"/>
+          <% end %>
+          <%= text_field_tag "from", params[:from], id: "start-date", class: "input-sm form-control add-right-margin", data: { module: "calendar", max_date: "0"} %>
 
-          <label class="add-right-margin" for="end-date">and <span class="rm">end date</span></label>
-          <input type="text" name="to" id="end-date" class="form-control input-sm" data-module="calendar" data-max-date="0" value="<%= params[:to]%>"/>
+          <%= label_tag("end-date", class: "add-right-margin") do %>and <span class="rm">end date</span><% end %>
+          <%= text_field_tag "to", params[:to], id: "end-date", class: "form-control input-sm", data: { module: "calendar", max_date: "0" } %>
 
-          <input type="submit" value="Filter" class="btn-sm btn btn-default add-left-margin" />
+          <%= submit_tag "Filter", class: "btn-sm btn btn-default add-left-margin" %>
           <% if @dates.attempted_to_filter? %>
             <%= link_to anonymous_feedback_index_path(path:params[:path]), class: "inherit remove-filter pull-right" do %>
               <span class="glyphicon glyphicon-remove"></span>
             <% end %>
           <% end %>
         </fieldset>
-      </form>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -8,7 +8,7 @@
                                from: @dates.from,
                                to: @dates.to,
                                results_limited: @feedback.results_limited,
-                               path: @filtered_by) %>
+                               scopes: @filtered_by) %>
     <% %i(from to path organisation).each do |attr| %>
       <% next if params[attr].blank? %>
       <%= hidden_field_tag attr, params[attr], id: "export_form_#{attr}" %>

--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -19,34 +19,48 @@
 
 <div class="row">
   <div class="col-lg-8 col-md-9">
-    <div class="panel <% if @dates.invalid_filter? %>panel-warning<% else %>panel-default<% end %>">
-      <% if @dates.invalid_filter? %>
-        <div class="panel-heading">
-          <h3 class="panel-title">
-            Sorry, these don’t look like dates. You can leave these fields blank.
-          </h3>
-        </div>
-      <% end %>
-      <%= form_tag(anonymous_feedback_index_path, class: "form-inline date-filter-form panel-body")do %>
-        <%= hidden_field_tag "path", params[:path] %>
-        <%= hidden_field_tag "organisation", params[:organisation]%>
-        <fieldset>
+    <div class="panel panel-default">
+      <%= form_tag(anonymous_feedback_index_path, class: "date-filter-form panel-body", novalidate: true, method: :get) do %>
+        <fieldset class="form-group" data-edit-feedback-explorer-form-target>
+          <legend class="rm">Filter feedback by path</legend>
+          <% if @filtered_by.path.present? %>
+            <%= link_to anonymous_feedback_index_path(organisation: @filtered_by.organisation_slug, from: @dates.from, to: @dates.to), class: "inherit remove-filter pull-right" do %>
+              <span class="glyphicon glyphicon-remove"><span class="rm">Remove path filter</span></span>
+            <% end %>
+          <% end %>
+          <%= label_tag('path', 'URL') %>
+          <%= url_field_tag :path, @filtered_by.path, class: "form-control" %>
+          <p class="help-block">eg <code>/vat-rates</code> or <code>https://www.gov.uk/bank-holidays</code></p>
+        </fieldset>
+        <fieldset class="form-group" data-edit-feedback-explorer-form-target>
+          <legend class="rm">Filter feedback by organisation</legend>
+          <% if @filtered_by.organisation_slug.present? %>
+            <%= link_to anonymous_feedback_index_path(path: @filtered_by.path, from: @dates.from, to: @dates.to), class: "inherit remove-filter pull-right" do %>
+              <span class="glyphicon glyphicon-remove"><span class="rm">Remove organisation filter</span></span>
+            <% end %>
+          <% end %>
+          <%= label_tag('organisation', "Organisation") %>
+          <%= select_tag :organisation, options_for_select(@organisations_list, @filtered_by.organisation_slug), include_blank: true, multiple: false, class: "form-control select2" %>
+        </fieldset>
+        <fieldset class="form-group form-inline <%= 'has-warning' if @dates.invalid_filter? %>">
           <legend class="rm">Filter feedback by date</legend>
+          <% if @dates.attempted_to_filter? %>
+            <%= link_to anonymous_feedback_index_path(path: @filtered_by.path, organisation: @filtered_by.organisation_slug), class: "inherit remove-filter pull-right" do %>
+              <span class="glyphicon glyphicon-remove"><span class="rm">Remove date filter</span></span>
+            <% end %>
+          <% end %>
           <%= label_tag("start-date", class: "add-right-margin") do %>
             Show feedback between <span class="rm">starting date</span>
           <% end %>
-          <%= text_field_tag "from", params[:from], id: "start-date", class: "input-sm form-control add-right-margin", data: { module: "calendar", max_date: "0"} %>
+          <%= text_field_tag "from", @dates.from, id: "start-date", class: "input-sm form-control add-right-margin", data: { module: "calendar", max_date: "0"} %>
 
           <%= label_tag("end-date", class: "add-right-margin") do %>and <span class="rm">end date</span><% end %>
-          <%= text_field_tag "to", params[:to], id: "end-date", class: "form-control input-sm", data: { module: "calendar", max_date: "0" } %>
-
-          <%= submit_tag "Filter", class: "btn-sm btn btn-default add-left-margin" %>
-          <% if @dates.attempted_to_filter? %>
-            <%= link_to anonymous_feedback_index_path(path:params[:path]), class: "inherit remove-filter pull-right" do %>
-              <span class="glyphicon glyphicon-remove"></span>
-            <% end %>
+          <%= text_field_tag "to", @dates.to, id: "end-date", class: "form-control input-sm", data: { module: "calendar", max_date: "0" } %>
+          <% if @dates.invalid_filter? %>
+            <p class="help-block">Sorry, these don’t look like dates. You can leave these fields blank.</p>
           <% end %>
         </fieldset>
+        <%= submit_tag "Filter", class: "btn-sm btn btn-default" %>
       <% end %>
     </div>
   </div>

--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -30,7 +30,7 @@
           <% end %>
           <%= label_tag('path', 'URL') %>
           <%= url_field_tag :path, @filtered_by.path, class: "form-control" %>
-          <p class="help-block">eg <code>/vat-rates</code> or <code>https://www.gov.uk/bank-holidays</code></p>
+          <p class="help-block">For example a page like <code>/vat-rates</code> or <code>https://www.gov.uk/bank-holidays</code>, or a partial path like <code>/guidance/</code></p>
         </fieldset>
         <fieldset class="form-group" data-edit-feedback-explorer-form-target>
           <legend class="rm">Filter feedback by organisation</legend>

--- a/spec/controllers/anonymous_feedback/explore_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/explore_controller_spec.rb
@@ -4,7 +4,7 @@ require 'gds_api/test_helpers/support_api'
 describe AnonymousFeedback::ExploreController, :type => :controller do
   include GdsApi::TestHelpers::SupportApi
   before do
-    stub_organisations_list([
+    stub_support_api_organisations_list([
       {
         slug: "cabinet-office",
         web_url: "https://www.gov.uk/government/organisations/cabinet-office",

--- a/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
@@ -25,7 +25,7 @@ describe AnonymousFeedback::ExportRequestsController, type: :controller do
 
     context "with a path" do
       let!(:stub_request) do
-        stub_support_feedback_export_request_creation(notification_email: "foo.bar@example.gov.uk",
+        stub_support_api_feedback_export_request_creation(notification_email: "foo.bar@example.gov.uk",
                                                       path_prefix: "/foo",
                                                       from: "2015-05-01",
                                                       to: "2015-06-01",
@@ -47,7 +47,7 @@ describe AnonymousFeedback::ExportRequestsController, type: :controller do
 
     context "with a path" do
       let!(:stub_request) do
-        stub_support_feedback_export_request_creation(notification_email: "foo.bar@example.gov.uk",
+        stub_support_api_feedback_export_request_creation(notification_email: "foo.bar@example.gov.uk",
                                                       path_prefix: nil,
                                                       from: "2015-05-01",
                                                       to: "2015-06-01",
@@ -72,7 +72,7 @@ describe AnonymousFeedback::ExportRequestsController, type: :controller do
     let(:filename) { "feedex_0000-00-00_2015-05-28_vat-rates.csv" }
 
     context "with a ready file" do
-      before { stub_support_feedback_export_request(1, ready: true, filename: filename) }
+      before { stub_support_api_feedback_export_request(1, ready: true, filename: filename) }
 
       it "sends the relevant file" do
         # NOTE send_file acts as a render call, so to avoid breaking the controller
@@ -89,7 +89,7 @@ describe AnonymousFeedback::ExportRequestsController, type: :controller do
     end
 
     context "with a pending file" do
-      before { stub_support_feedback_export_request(2, ready: false, filename: filename) }
+      before { stub_support_api_feedback_export_request(2, ready: false, filename: filename) }
 
       it "replies with a 404" do
         get :show, params: { id: 2 }

--- a/spec/controllers/anonymous_feedback/global_export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/global_export_requests_controller_spec.rb
@@ -16,7 +16,7 @@ describe AnonymousFeedback::GlobalExportRequestsController, type: :controller do
 
   describe "#create" do
     let!(:stub_request) do
-      stub_support_global_export_request_creation(
+      stub_support_api_global_export_request_creation(
         notification_email: user.email,
         from_date: "1 Aug 2016",
         to_date: "8 Aug 2016",

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -5,6 +5,7 @@ describe AnonymousFeedbackController, :type => :controller do
   include GdsApi::TestHelpers::SupportApi
   before do
     login_as create(:user)
+    stub_support_api_organisations_list
   end
 
   context "when no `path` or `organisation` given" do

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -27,7 +27,7 @@ describe AnonymousFeedbackController, :type => :controller do
   context "no results" do
     context "on the first page" do
       it "should show no results" do
-        stub_anonymous_feedback(
+        stub_support_api_anonymous_feedback(
           { path_prefix: "/a" },
           { "results" => [], "pages" => 0, "current_page" => 1 },
         )
@@ -40,7 +40,7 @@ describe AnonymousFeedbackController, :type => :controller do
 
     context "user has manually entered a non-existent page" do
       it "should redirect to the first page" do
-        stub_anonymous_feedback(
+        stub_support_api_anonymous_feedback(
           { path_prefix: "/a", page: 4 },
           { "results" => [], "pages" => 3, "current_page" => 4 },
         )
@@ -54,7 +54,7 @@ describe AnonymousFeedbackController, :type => :controller do
 
   context "valid input, problem reports" do
     before do
-      stub_anonymous_feedback(
+      stub_support_api_anonymous_feedback(
         { path_prefix: "/tax-disc", from: "13/10/2014", to: "25th November 2014" },
         {
           "current_page" => 1,
@@ -107,7 +107,7 @@ describe AnonymousFeedbackController, :type => :controller do
 
   context "valid input, long-form feedback" do
     before do
-      stub_anonymous_feedback(
+      stub_support_api_anonymous_feedback(
         { path_prefix: "/contact/govuk" },
         {
           "current_page" => 1,
@@ -157,7 +157,7 @@ describe AnonymousFeedbackController, :type => :controller do
 
   context "valid input, service feedback" do
     before do
-      stub_anonymous_feedback(
+      stub_support_api_anonymous_feedback(
         { path_prefix: "/done/apply-carers-allowance" },
         {
           "current_page" => 1,
@@ -211,7 +211,7 @@ describe AnonymousFeedbackController, :type => :controller do
     render_views
 
     before do
-      stub_anonymous_feedback(
+      stub_support_api_anonymous_feedback(
         { organisation_slug: "cabinet-office" },
         {
           "current_page" => 1,
@@ -232,7 +232,7 @@ describe AnonymousFeedbackController, :type => :controller do
           ],
         }
       )
-      stub_organisation("cabinet-office")
+      stub_support_api_organisation("cabinet-office")
     end
 
     it "resolves the slug to a title" do

--- a/spec/features/feedex_organisation_summary_spec.rb
+++ b/spec/features/feedex_organisation_summary_spec.rb
@@ -36,14 +36,16 @@ feature "Summary of Organisation feedback" do
   end
 
   def stub_summary_sorted_by(ordering)
-    stub_anonymous_feedback_organisation_summary('cabinet-office', ordering, {
+    stub_support_api_anonymous_feedback_organisation_summary(
+      'cabinet-office',
+      ordering,
       "title" => "Cabinet Office",
       "anonymous_feedback_counts" => [
         { path: '/done-well', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
         { path: '/not-bad-my-friend' },
         { path: '/fair-enough' },
       ],
-    })
+    )
   end
 
   def organisation_summary

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -70,15 +70,13 @@ feature "Exploring anonymous feedback" do
     stub_support_api_anonymous_feedback_organisation_summary(
       'cabinet-office',
       'last_7_days',
-      {
-        "title" => "Cabinet Office",
-        "slug" => 'cabinet-office',
-        "anonymous_feedback_counts" => [
-          { path: '/done-well', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
-          { path: '/not-bad-my-friend' },
-          { path: '/fair-enough' },
-        ],
-      }
+      "title" => "Cabinet Office",
+      "slug" => 'cabinet-office',
+      "anonymous_feedback_counts" => [
+        { path: '/done-well', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
+        { path: '/not-bad-my-friend' },
+        { path: '/fair-enough' },
+      ],
     )
 
     organisation_summary = [
@@ -107,7 +105,9 @@ feature "Exploring anonymous feedback" do
 
   scenario "exploring feedback by organisation and URL" do
     stub_support_api_organisation('cabinet-office')
-    org_summary_request = stub_support_api_anonymous_feedback_organisation_summary('cabinet-office', 'last_7_days', {
+    org_summary_request = stub_support_api_anonymous_feedback_organisation_summary(
+      'cabinet-office',
+      'last_7_days',
       "title" => "Cabinet Office",
       "slug" => 'cabinet-office',
       "anonymous_feedback_counts" => [
@@ -115,113 +115,106 @@ feature "Exploring anonymous feedback" do
         { path: '/guidance/doing-fun-things' },
         { path: '/guidance/not-doing-bad-things' },
       ],
-    })
+    )
 
     org_feedback_request = stub_support_api_anonymous_feedback(
       { organisation_slug: "cabinet-office" },
-      {
-        "current_page" => 1,
-        "pages" => 1,
-        "page_size" => 3,
-        "results" => [
-          {
-            type: "problem-report",
-            path: "/vat-rates",
-            url: "http://www.dev.gov.uk/vat-rates",
-            created_at: DateTime.parse("2013-03-01"),
-            what_doing: "looking at 3rd paragraph",
-            what_wrong: "typo in 2rd word",
-            referrer: "https://www.gov.uk/",
-          },
-          {
-            type: "problem-report",
-            path: "/guidance/doing-fun-things",
-            url: "http://www.dev.gov.uk/guidance/doing-fun-things",
-            created_at: DateTime.parse("2013-02-01"),
-            what_doing: "finding out about fun",
-            what_wrong: "no mention of petting a dog",
-            referrer: "https://www.gov.uk/having-fun",
-          },
-          {
-            type: "problem-report",
-            path: "/guidance/doing-bad-things",
-            url: "http://www.dev.gov.uk/guidance/not-doing-bad-things",
-            created_at: DateTime.parse("2013-02-01"),
-            what_doing: "looking at what you consider bad",
-            what_wrong: "so many typos, whoever wrote this must have been angry",
-            referrer: "https://www.gov.uk/having-fun",
-          },
-        ]
-      }
+      "current_page" => 1,
+      "pages" => 1,
+      "page_size" => 3,
+      "results" => [
+        {
+          type: "problem-report",
+          path: "/vat-rates",
+          url: "http://www.dev.gov.uk/vat-rates",
+          created_at: DateTime.parse("2013-03-01"),
+          what_doing: "looking at 3rd paragraph",
+          what_wrong: "typo in 2rd word",
+          referrer: "https://www.gov.uk/",
+        },
+        {
+          type: "problem-report",
+          path: "/guidance/doing-fun-things",
+          url: "http://www.dev.gov.uk/guidance/doing-fun-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "finding out about fun",
+          what_wrong: "no mention of petting a dog",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+        {
+          type: "problem-report",
+          path: "/guidance/doing-bad-things",
+          url: "http://www.dev.gov.uk/guidance/not-doing-bad-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "looking at what you consider bad",
+          what_wrong: "so many typos, whoever wrote this must have been angry",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+      ]
     )
 
     org_and_path_feedback_request = stub_support_api_anonymous_feedback(
       { organisation_slug: "cabinet-office", path_prefix: '/guidance' },
-      {
-        "current_page" => 1,
-        "pages" => 1,
-        "page_size" => 2,
-        "results" => [
-          {
-            type: "problem-report",
-            path: "/guidance/doing-fun-things",
-            url: "http://www.dev.gov.uk/guidance/doing-fun-things",
-            created_at: DateTime.parse("2013-02-01"),
-            what_doing: "finding out about fun",
-            what_wrong: "no mention of petting a dog",
-            referrer: "https://www.gov.uk/having-fun",
-          },
-          {
-            type: "problem-report",
-            path: "/guidance/doing-bad-things",
-            url: "http://www.dev.gov.uk/guidance/doing-bad-things",
-            created_at: DateTime.parse("2013-02-01"),
-            what_doing: "looking at what you consider bad",
-            what_wrong: "so many typos, whoever wrote this must have been angry",
-            referrer: "https://www.gov.uk/having-fun",
-          },
-        ]
-      }
+      "current_page" => 1,
+      "pages" => 1,
+      "page_size" => 2,
+      "results" => [
+        {
+          type: "problem-report",
+          path: "/guidance/doing-fun-things",
+          url: "http://www.dev.gov.uk/guidance/doing-fun-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "finding out about fun",
+          what_wrong: "no mention of petting a dog",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+        {
+          type: "problem-report",
+          path: "/guidance/doing-bad-things",
+          url: "http://www.dev.gov.uk/guidance/doing-bad-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "looking at what you consider bad",
+          what_wrong: "so many typos, whoever wrote this must have been angry",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+      ]
     )
 
     path_feedback_request = stub_support_api_anonymous_feedback(
       { path_prefix: '/guidance' },
-      {
-        "current_page" => 1,
-        "pages" => 1,
-        "page_size" => 2,
-        "results" => [
-          {
-            type: "problem-report",
-            path: "/guidance/doing-fun-things",
-            url: "http://www.dev.gov.uk/guidance/doing-fun-things",
-            created_at: DateTime.parse("2013-02-01"),
-            what_doing: "finding out about fun",
-            what_wrong: "no mention of petting a dog",
-            referrer: "https://www.gov.uk/having-fun",
-          },
-          {
-            type: "problem-report",
-            path: "/guidance/doing-bad-things",
-            url: "http://www.dev.gov.uk/guidance/doing-bad-things",
-            created_at: DateTime.parse("2013-02-01"),
-            what_doing: "looking at what you consider bad",
-            what_wrong: "so many typos, whoever wrote this must have been angry",
-            referrer: "https://www.gov.uk/having-fun",
-          },
-          {
-            type: "problem-report",
-            path: "/guidance/wearing-a-hat",
-            url: "http://www.dev.gov.uk/guidance/wearing-a-hat",
-            created_at: DateTime.parse("2013-02-01"),
-            what_doing: "want to know about balaclavas",
-            what_wrong: "I know they're not really a hat, but would it hurt to mention them",
-            referrer: "https://www.gov.uk/hats",
-          },
-        ]
-      }
+      "current_page" => 1,
+      "pages" => 1,
+      "page_size" => 2,
+      "results" => [
+        {
+          type: "problem-report",
+          path: "/guidance/doing-fun-things",
+          url: "http://www.dev.gov.uk/guidance/doing-fun-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "finding out about fun",
+          what_wrong: "no mention of petting a dog",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+        {
+          type: "problem-report",
+          path: "/guidance/doing-bad-things",
+          url: "http://www.dev.gov.uk/guidance/doing-bad-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "looking at what you consider bad",
+          what_wrong: "so many typos, whoever wrote this must have been angry",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+        {
+          type: "problem-report",
+          path: "/guidance/wearing-a-hat",
+          url: "http://www.dev.gov.uk/guidance/wearing-a-hat",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "want to know about balaclavas",
+          what_wrong: "I know they're not really a hat, but would it hurt to mention them",
+          referrer: "https://www.gov.uk/hats",
+        },
+      ]
     )
-
 
     explore_anonymous_feedback_with(organisation: "Cabinet Office")
 

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -10,31 +10,7 @@ feature "Exploring anonymous feedback" do
   scenario "exploring feedback by URL" do
     stub_support_api_anonymous_feedback(
       { path_prefix: "/vat-rates" },
-      {
-        "current_page" => 1,
-        "pages" => 1,
-        "page_size" => 2,
-        "results" => [
-          {
-            type: "problem-report",
-            path: "/vat-rates",
-            url: "http://www.dev.gov.uk/vat-rates",
-            created_at: DateTime.parse("2013-03-01"),
-            what_doing: "looking at 3rd paragraph",
-            what_wrong: "typo in 2rd word",
-            referrer: "https://www.gov.uk/",
-          },
-          {
-            type: "problem-report",
-            path: "/vat-rates",
-            url: "http://www.dev.gov.uk/vat-rates",
-            created_at: DateTime.parse("2013-02-01"),
-            what_doing: "looking at rates",
-            what_wrong: "standard rate is wrong",
-            referrer: "https://www.gov.uk/pay-vat",
-          },
-        ]
-      }
+      vat_rates_path_results
     )
 
     feedback_reports = [
@@ -58,7 +34,7 @@ feature "Exploring anonymous feedback" do
   scenario "no feedback found" do
     stub_support_api_anonymous_feedback(
       { path_prefix: "/non-existent-path" },
-      { "results" => [], "pages" => 0, "current_page" => 1 }
+      no_results
     )
 
     explore_anonymous_feedback_with(url: "https://www.gov.uk/non-existent-path")
@@ -70,28 +46,22 @@ feature "Exploring anonymous feedback" do
     stub_support_api_anonymous_feedback_organisation_summary(
       'cabinet-office',
       'last_7_days',
-      "title" => "Cabinet Office",
-      "slug" => 'cabinet-office',
-      "anonymous_feedback_counts" => [
-        { path: '/done-well', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
-        { path: '/not-bad-my-friend' },
-        { path: '/fair-enough' },
-      ],
+      cabinet_office_last_7_days_summary_results
     )
 
     organisation_summary = [
       {
-        "Page" => "/done-well",
+        "Page" => "/vat-rates",
         "7 days" => "5 items",
         "30 days" => "10 items",
         "90 days" => "20 items",
       }, {
-        "Page" => "/not-bad-my-friend",
+        "Page" => "/guidance/doing-fun-things",
         "7 days" => "0 items",
         "30 days" => "0 items",
         "90 days" => "0 items",
       }, {
-        "Page" => "/fair-enough",
+        "Page" => "/guidance/not-doing-bad-things",
         "7 days" => "0 items",
         "30 days" => "0 items",
         "90 days" => "0 items",
@@ -108,112 +78,22 @@ feature "Exploring anonymous feedback" do
     org_summary_request = stub_support_api_anonymous_feedback_organisation_summary(
       'cabinet-office',
       'last_7_days',
-      "title" => "Cabinet Office",
-      "slug" => 'cabinet-office',
-      "anonymous_feedback_counts" => [
-        { path: '/vat-rates', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
-        { path: '/guidance/doing-fun-things' },
-        { path: '/guidance/not-doing-bad-things' },
-      ],
+      cabinet_office_last_7_days_summary_results
     )
 
     org_feedback_request = stub_support_api_anonymous_feedback(
       { organisation_slug: "cabinet-office" },
-      "current_page" => 1,
-      "pages" => 1,
-      "page_size" => 3,
-      "results" => [
-        {
-          type: "problem-report",
-          path: "/vat-rates",
-          url: "http://www.dev.gov.uk/vat-rates",
-          created_at: DateTime.parse("2013-03-01"),
-          what_doing: "looking at 3rd paragraph",
-          what_wrong: "typo in 2rd word",
-          referrer: "https://www.gov.uk/",
-        },
-        {
-          type: "problem-report",
-          path: "/guidance/doing-fun-things",
-          url: "http://www.dev.gov.uk/guidance/doing-fun-things",
-          created_at: DateTime.parse("2013-02-01"),
-          what_doing: "finding out about fun",
-          what_wrong: "no mention of petting a dog",
-          referrer: "https://www.gov.uk/having-fun",
-        },
-        {
-          type: "problem-report",
-          path: "/guidance/doing-bad-things",
-          url: "http://www.dev.gov.uk/guidance/not-doing-bad-things",
-          created_at: DateTime.parse("2013-02-01"),
-          what_doing: "looking at what you consider bad",
-          what_wrong: "so many typos, whoever wrote this must have been angry",
-          referrer: "https://www.gov.uk/having-fun",
-        },
-      ]
+      cabinet_office_results
     )
 
     org_and_path_feedback_request = stub_support_api_anonymous_feedback(
       { organisation_slug: "cabinet-office", path_prefix: '/guidance' },
-      "current_page" => 1,
-      "pages" => 1,
-      "page_size" => 2,
-      "results" => [
-        {
-          type: "problem-report",
-          path: "/guidance/doing-fun-things",
-          url: "http://www.dev.gov.uk/guidance/doing-fun-things",
-          created_at: DateTime.parse("2013-02-01"),
-          what_doing: "finding out about fun",
-          what_wrong: "no mention of petting a dog",
-          referrer: "https://www.gov.uk/having-fun",
-        },
-        {
-          type: "problem-report",
-          path: "/guidance/doing-bad-things",
-          url: "http://www.dev.gov.uk/guidance/doing-bad-things",
-          created_at: DateTime.parse("2013-02-01"),
-          what_doing: "looking at what you consider bad",
-          what_wrong: "so many typos, whoever wrote this must have been angry",
-          referrer: "https://www.gov.uk/having-fun",
-        },
-      ]
+      cabinet_office_and_guidance_path_results
     )
 
     path_feedback_request = stub_support_api_anonymous_feedback(
       { path_prefix: '/guidance' },
-      "current_page" => 1,
-      "pages" => 1,
-      "page_size" => 2,
-      "results" => [
-        {
-          type: "problem-report",
-          path: "/guidance/doing-fun-things",
-          url: "http://www.dev.gov.uk/guidance/doing-fun-things",
-          created_at: DateTime.parse("2013-02-01"),
-          what_doing: "finding out about fun",
-          what_wrong: "no mention of petting a dog",
-          referrer: "https://www.gov.uk/having-fun",
-        },
-        {
-          type: "problem-report",
-          path: "/guidance/doing-bad-things",
-          url: "http://www.dev.gov.uk/guidance/doing-bad-things",
-          created_at: DateTime.parse("2013-02-01"),
-          what_doing: "looking at what you consider bad",
-          what_wrong: "so many typos, whoever wrote this must have been angry",
-          referrer: "https://www.gov.uk/having-fun",
-        },
-        {
-          type: "problem-report",
-          path: "/guidance/wearing-a-hat",
-          url: "http://www.dev.gov.uk/guidance/wearing-a-hat",
-          created_at: DateTime.parse("2013-02-01"),
-          what_doing: "want to know about balaclavas",
-          what_wrong: "I know they're not really a hat, but would it hurt to mention them",
-          referrer: "https://www.gov.uk/hats",
-        },
-      ]
+      guidance_path_results
     )
 
     explore_anonymous_feedback_with(organisation: "Cabinet Office")
@@ -256,5 +136,151 @@ feature "Exploring anonymous feedback" do
     expect(page).to have_field("URL", with: '/guidance')
 
     expect(path_feedback_request).to have_been_requested
+  end
+
+  let(:vat_rates_path_results) do
+    {
+      "current_page" => 1,
+      "pages" => 1,
+      "page_size" => 2,
+      "results" => [
+        {
+          type: "problem-report",
+          path: "/vat-rates",
+          url: "http://www.dev.gov.uk/vat-rates",
+          created_at: DateTime.parse("2013-03-01"),
+          what_doing: "looking at 3rd paragraph",
+          what_wrong: "typo in 2rd word",
+          referrer: "https://www.gov.uk/",
+        },
+        {
+          type: "problem-report",
+          path: "/vat-rates",
+          url: "http://www.dev.gov.uk/vat-rates",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "looking at rates",
+          what_wrong: "standard rate is wrong",
+          referrer: "https://www.gov.uk/pay-vat",
+        },
+      ]
+    }
+  end
+
+  let(:no_results) do
+    { "results" => [], "pages" => 0, "current_page" => 1 }
+  end
+
+  let(:cabinet_office_results) do
+    {
+      "current_page" => 1,
+      "pages" => 1,
+      "page_size" => 3,
+      "results" => [
+        {
+          type: "problem-report",
+          path: "/vat-rates",
+          url: "http://www.dev.gov.uk/vat-rates",
+          created_at: DateTime.parse("2013-03-01"),
+          what_doing: "looking at 3rd paragraph",
+          what_wrong: "typo in 2rd word",
+          referrer: "https://www.gov.uk/",
+        },
+        {
+          type: "problem-report",
+          path: "/guidance/doing-fun-things",
+          url: "http://www.dev.gov.uk/guidance/doing-fun-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "finding out about fun",
+          what_wrong: "no mention of petting a dog",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+        {
+          type: "problem-report",
+          path: "/guidance/doing-bad-things",
+          url: "http://www.dev.gov.uk/guidance/not-doing-bad-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "looking at what you consider bad",
+          what_wrong: "so many typos, whoever wrote this must have been angry",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+      ]
+    }
+  end
+
+  let(:cabinet_office_and_guidance_path_results) do
+    {
+      "current_page" => 1,
+      "pages" => 1,
+      "page_size" => 2,
+      "results" => [
+        {
+          type: "problem-report",
+          path: "/guidance/doing-fun-things",
+          url: "http://www.dev.gov.uk/guidance/doing-fun-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "finding out about fun",
+          what_wrong: "no mention of petting a dog",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+        {
+          type: "problem-report",
+          path: "/guidance/doing-bad-things",
+          url: "http://www.dev.gov.uk/guidance/doing-bad-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "looking at what you consider bad",
+          what_wrong: "so many typos, whoever wrote this must have been angry",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+      ]
+    }
+  end
+
+  let(:guidance_path_results) do
+    {
+      "current_page" => 1,
+      "pages" => 1,
+      "page_size" => 2,
+      "results" => [
+        {
+          type: "problem-report",
+          path: "/guidance/doing-fun-things",
+          url: "http://www.dev.gov.uk/guidance/doing-fun-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "finding out about fun",
+          what_wrong: "no mention of petting a dog",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+        {
+          type: "problem-report",
+          path: "/guidance/doing-bad-things",
+          url: "http://www.dev.gov.uk/guidance/doing-bad-things",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "looking at what you consider bad",
+          what_wrong: "so many typos, whoever wrote this must have been angry",
+          referrer: "https://www.gov.uk/having-fun",
+        },
+        {
+          type: "problem-report",
+          path: "/guidance/wearing-a-hat",
+          url: "http://www.dev.gov.uk/guidance/wearing-a-hat",
+          created_at: DateTime.parse("2013-02-01"),
+          what_doing: "want to know about balaclavas",
+          what_wrong: "I know they're not really a hat, but would it hurt to mention them",
+          referrer: "https://www.gov.uk/hats",
+        },
+      ]
+    }
+  end
+
+  let(:cabinet_office_last_7_days_summary_results) do
+    {
+      "title" => "Cabinet Office",
+      "slug" => 'cabinet-office',
+      "anonymous_feedback_counts" => [
+        { path: '/vat-rates', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
+        { path: '/guidance/doing-fun-things' },
+        { path: '/guidance/not-doing-bad-things' },
+      ],
+    }
   end
 end

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -72,6 +72,7 @@ feature "Exploring anonymous feedback" do
       'last_7_days',
       {
         "title" => "Cabinet Office",
+        "slug" => 'cabinet-office',
         "anonymous_feedback_counts" => [
           { path: '/done-well', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
           { path: '/not-bad-my-friend' },
@@ -102,5 +103,165 @@ feature "Exploring anonymous feedback" do
     explore_anonymous_feedback_with(organisation: "Cabinet Office")
     expect(page).to have_content("Feedback for Cabinet Office")
     expect(organisation_summary_results).to eq(organisation_summary)
+  end
+
+  scenario "exploring feedback by organisation and URL" do
+    stub_support_api_organisation('cabinet-office')
+    org_summary_request = stub_support_api_anonymous_feedback_organisation_summary('cabinet-office', 'last_7_days', {
+      "title" => "Cabinet Office",
+      "slug" => 'cabinet-office',
+      "anonymous_feedback_counts" => [
+        { path: '/vat-rates', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
+        { path: '/guidance/doing-fun-things' },
+        { path: '/guidance/not-doing-bad-things' },
+      ],
+    })
+
+    org_feedback_request = stub_support_api_anonymous_feedback(
+      { organisation_slug: "cabinet-office" },
+      {
+        "current_page" => 1,
+        "pages" => 1,
+        "page_size" => 3,
+        "results" => [
+          {
+            type: "problem-report",
+            path: "/vat-rates",
+            url: "http://www.dev.gov.uk/vat-rates",
+            created_at: DateTime.parse("2013-03-01"),
+            what_doing: "looking at 3rd paragraph",
+            what_wrong: "typo in 2rd word",
+            referrer: "https://www.gov.uk/",
+          },
+          {
+            type: "problem-report",
+            path: "/guidance/doing-fun-things",
+            url: "http://www.dev.gov.uk/guidance/doing-fun-things",
+            created_at: DateTime.parse("2013-02-01"),
+            what_doing: "finding out about fun",
+            what_wrong: "no mention of petting a dog",
+            referrer: "https://www.gov.uk/having-fun",
+          },
+          {
+            type: "problem-report",
+            path: "/guidance/doing-bad-things",
+            url: "http://www.dev.gov.uk/guidance/not-doing-bad-things",
+            created_at: DateTime.parse("2013-02-01"),
+            what_doing: "looking at what you consider bad",
+            what_wrong: "so many typos, whoever wrote this must have been angry",
+            referrer: "https://www.gov.uk/having-fun",
+          },
+        ]
+      }
+    )
+
+    org_and_path_feedback_request = stub_support_api_anonymous_feedback(
+      { organisation_slug: "cabinet-office", path_prefix: '/guidance' },
+      {
+        "current_page" => 1,
+        "pages" => 1,
+        "page_size" => 2,
+        "results" => [
+          {
+            type: "problem-report",
+            path: "/guidance/doing-fun-things",
+            url: "http://www.dev.gov.uk/guidance/doing-fun-things",
+            created_at: DateTime.parse("2013-02-01"),
+            what_doing: "finding out about fun",
+            what_wrong: "no mention of petting a dog",
+            referrer: "https://www.gov.uk/having-fun",
+          },
+          {
+            type: "problem-report",
+            path: "/guidance/doing-bad-things",
+            url: "http://www.dev.gov.uk/guidance/doing-bad-things",
+            created_at: DateTime.parse("2013-02-01"),
+            what_doing: "looking at what you consider bad",
+            what_wrong: "so many typos, whoever wrote this must have been angry",
+            referrer: "https://www.gov.uk/having-fun",
+          },
+        ]
+      }
+    )
+
+    path_feedback_request = stub_support_api_anonymous_feedback(
+      { path_prefix: '/guidance' },
+      {
+        "current_page" => 1,
+        "pages" => 1,
+        "page_size" => 2,
+        "results" => [
+          {
+            type: "problem-report",
+            path: "/guidance/doing-fun-things",
+            url: "http://www.dev.gov.uk/guidance/doing-fun-things",
+            created_at: DateTime.parse("2013-02-01"),
+            what_doing: "finding out about fun",
+            what_wrong: "no mention of petting a dog",
+            referrer: "https://www.gov.uk/having-fun",
+          },
+          {
+            type: "problem-report",
+            path: "/guidance/doing-bad-things",
+            url: "http://www.dev.gov.uk/guidance/doing-bad-things",
+            created_at: DateTime.parse("2013-02-01"),
+            what_doing: "looking at what you consider bad",
+            what_wrong: "so many typos, whoever wrote this must have been angry",
+            referrer: "https://www.gov.uk/having-fun",
+          },
+          {
+            type: "problem-report",
+            path: "/guidance/wearing-a-hat",
+            url: "http://www.dev.gov.uk/guidance/wearing-a-hat",
+            created_at: DateTime.parse("2013-02-01"),
+            what_doing: "want to know about balaclavas",
+            what_wrong: "I know they're not really a hat, but would it hurt to mention them",
+            referrer: "https://www.gov.uk/hats",
+          },
+        ]
+      }
+    )
+
+
+    explore_anonymous_feedback_with(organisation: "Cabinet Office")
+
+    expect(org_summary_request).to have_been_requested
+    expect(org_feedback_request).not_to have_been_requested
+    expect(org_and_path_feedback_request).not_to have_been_requested
+    expect(path_feedback_request).not_to have_been_requested
+
+    click_on 'All feedback for Cabinet Office'
+
+    expect(org_feedback_request).to have_been_requested
+    expect(org_and_path_feedback_request).not_to have_been_requested
+    expect(path_feedback_request).not_to have_been_requested
+
+    expect(page).to have_title("Feedback for “Cabinet Office”")
+    expect(page).to have_select("Organisation", selected: 'Cabinet Office (CO)')
+
+    # NOTE: this doesn't work as the value of the input is nil and that doesn't
+    # match "" (capybara to_s's the with so we can't pass in nil either
+    # expect(page).to have_field("URL", with: "")
+    empty_url_field = page.find_field("URL")
+    expect(empty_url_field).not_to be_nil
+    expect(empty_url_field.value).to be_blank
+
+    fill_in 'URL', with: '/guidance'
+    click_on 'Filter'
+
+    expect(org_and_path_feedback_request).to have_been_requested
+    expect(path_feedback_request).not_to have_been_requested
+
+    expect(page).to have_title('Feedback for “Cabinet Office on /guidance”')
+    expect(page).to have_select("Organisation", selected: 'Cabinet Office (CO)')
+    expect(page).to have_field("URL", with: '/guidance')
+
+    click_on "Remove organisation filter"
+
+    expect(page).to have_title('Feedback for “/guidance”')
+    expect(page).to have_select("Organisation", selected: [])
+    expect(page).to have_field("URL", with: '/guidance')
+
+    expect(path_feedback_request).to have_been_requested
   end
 end

--- a/spec/features/feedex_spec.rb
+++ b/spec/features/feedex_spec.rb
@@ -8,7 +8,7 @@ feature "Exploring anonymous feedback" do
   end
 
   scenario "exploring feedback by URL" do
-    stub_anonymous_feedback(
+    stub_support_api_anonymous_feedback(
       { path_prefix: "/vat-rates" },
       {
         "current_page" => 1,
@@ -56,7 +56,7 @@ feature "Exploring anonymous feedback" do
   end
 
   scenario "no feedback found" do
-    stub_anonymous_feedback(
+    stub_support_api_anonymous_feedback(
       { path_prefix: "/non-existent-path" },
       { "results" => [], "pages" => 0, "current_page" => 1 }
     )
@@ -67,14 +67,18 @@ feature "Exploring anonymous feedback" do
   end
 
   scenario "exploring feedback by organisation" do
-    stub_anonymous_feedback_organisation_summary('cabinet-office', 'last_7_days', {
-      "title" => "Cabinet Office",
-      "anonymous_feedback_counts" => [
-        { path: '/done-well', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
-        { path: '/not-bad-my-friend' },
-        { path: '/fair-enough' },
-      ],
-    })
+    stub_support_api_anonymous_feedback_organisation_summary(
+      'cabinet-office',
+      'last_7_days',
+      {
+        "title" => "Cabinet Office",
+        "anonymous_feedback_counts" => [
+          { path: '/done-well', last_7_days: 5, last_30_days: 10, last_90_days: 20 },
+          { path: '/not-bad-my-friend' },
+          { path: '/fair-enough' },
+        ],
+      }
+    )
 
     organisation_summary = [
       {

--- a/spec/features/global_export_request_spec.rb
+++ b/spec/features/global_export_request_spec.rb
@@ -5,7 +5,7 @@ feature 'Exporting Global CSV of Feedback' do
   let(:user) { create :user_who_can_access_everything }
 
   background do
-    stub_organisations_list
+    stub_support_api_organisations_list
 
     login_as user
   end

--- a/spec/features/review_anonymous_feedback_spec.rb
+++ b/spec/features/review_anonymous_feedback_spec.rb
@@ -53,7 +53,7 @@ feature 'Reviewing Anonymous Feedback' do
   }
 
   before do
-    stub_organisations_list
+    stub_support_api_organisations_list
   end
 
   context 'Viewing the table of feedback' do
@@ -75,7 +75,7 @@ feature 'Reviewing Anonymous Feedback' do
 
     context 'with default filtering' do
       before do
-        stub_support_problem_reports('', default_problem_report_list)
+        stub_support_api_problem_reports('', default_problem_report_list)
 
         login_as user
 
@@ -118,8 +118,8 @@ feature 'Reviewing Anonymous Feedback' do
       }
 
       before do
-        stub_support_problem_reports('', default_problem_report_list)
-        stub_support_problem_reports('include_reviewed=true', problem_report_list)
+        stub_support_api_problem_reports('', default_problem_report_list)
+        stub_support_api_problem_reports('include_reviewed=true', problem_report_list)
 
         login_as user
 
@@ -181,8 +181,8 @@ feature 'Reviewing Anonymous Feedback' do
       }
 
       before do
-        stub_support_problem_reports('', problem_report_list)
-        stub_support_problem_reports('from_date=1%20Sep%202016&to_date=1%20Sep%202016', problem_report_list)
+        stub_support_api_problem_reports('', problem_report_list)
+        stub_support_api_problem_reports('from_date=1%20Sep%202016&to_date=1%20Sep%202016', problem_report_list)
 
         login_as user
 
@@ -236,8 +236,8 @@ feature 'Reviewing Anonymous Feedback' do
       }
 
       before do
-        stub_support_problem_reports('', first_problem_report_list_page)
-        stub_support_problem_reports('page=2', second_problem_report_list_page)
+        stub_support_api_problem_reports('', first_problem_report_list_page)
+        stub_support_api_problem_reports('page=2', second_problem_report_list_page)
 
         login_as user
 
@@ -322,7 +322,7 @@ feature 'Reviewing Anonymous Feedback' do
 
       click_link "Feedback explorer"
 
-      first_stub_request = stub_support_problem_reports('', first_unreviewed_problem_report_list_page)
+      first_stub_request = stub_support_api_problem_reports('', first_unreviewed_problem_report_list_page)
 
       click_button "Review Anonymous Feedback"
 
@@ -336,8 +336,8 @@ feature 'Reviewing Anonymous Feedback' do
 
       WebMock.reset!
 
-      second_stub_request = stub_support_problem_reports('', second_unreviewed_problem_report_list_page)
-      reviewed_request = stub_support_mark_reviewed_for_spam(params, { "success" => true })
+      second_stub_request = stub_support_api_problem_reports('', second_unreviewed_problem_report_list_page)
+      reviewed_request = stub_support_api_mark_reviewed_for_spam(params, "success" => true)
 
       click_button 'Save'
 
@@ -368,10 +368,10 @@ feature 'Reviewing Anonymous Feedback' do
     }
 
     before do
-      stub_support_problem_reports('', problem_report_list)
-      stub_support_problem_reports('from_date=1%20Sep%202016&to_date=1%20Sep%202016', problem_report_list)
-      stub_support_mark_reviewed_for_spam({ "1" => "true" },{ "success" => "true" })
-      stub_support_problem_reports('include_reviewed=true&from_date=1%20Sep%202016&to_date=1%20Sep%202016', problem_report_list)
+      stub_support_api_problem_reports('', problem_report_list)
+      stub_support_api_problem_reports('from_date=1%20Sep%202016&to_date=1%20Sep%202016', problem_report_list)
+      stub_support_api_mark_reviewed_for_spam({ "1" => "true" }, "success" => "true")
+      stub_support_api_problem_reports('include_reviewed=true&from_date=1%20Sep%202016&to_date=1%20Sep%202016', problem_report_list)
 
       login_as user
 

--- a/spec/features/user_satisfaction_survey_spec.rb
+++ b/spec/features/user_satisfaction_survey_spec.rb
@@ -13,7 +13,7 @@ feature "User satisfaction survey submissions" do
   end
 
   scenario "submission with comment" do
-    stub_anonymous_feedback(
+    stub_support_api_anonymous_feedback(
       { path_prefix: "/done/find-court-tribunal" },
       {
         "current_page" => 1,
@@ -49,7 +49,7 @@ feature "User satisfaction survey submissions" do
   end
 
   scenario "submission without a comment" do
-    stub_anonymous_feedback(
+    stub_support_api_anonymous_feedback(
       { path_prefix: "/done/some-service" },
       {
         "current_page" => 1,

--- a/spec/helpers/feedex_helper_spec.rb
+++ b/spec/helpers/feedex_helper_spec.rb
@@ -10,7 +10,7 @@ describe FeedexHelper, type: :helper do
         from: from,
         to: to,
         results_limited: results_limited,
-        path: path
+        scopes: ScopeFiltersPresenter.new(path: path)
       )
     }
 

--- a/spec/presenters/scope_filters_presenter_spec.rb
+++ b/spec/presenters/scope_filters_presenter_spec.rb
@@ -1,0 +1,176 @@
+require 'rails_helper'
+
+describe ScopeFiltersPresenter, type: :presenter do
+  describe "#filtered?" do
+    it 'is false when path and organisation are blank' do
+      presenter = described_class.new(path: nil, organisation_slug: nil)
+      expect(presenter).not_to be_filtered
+    end
+
+    it 'is true when path is provided and organisation is blank' do
+      presenter = described_class.new(path: '/done/buying-a-new-hat', organisation_slug: nil)
+      expect(presenter).to be_filtered
+    end
+
+    it 'is true when organisation is provided and path is blank' do
+      presenter = described_class.new(path: nil, organisation_slug: 'department-of-hats')
+      expect(presenter).to be_filtered
+    end
+
+    it 'is true when both organisation and path are provided' do
+      presenter = described_class.new(path: '/done/buying-a-new-hat', organisation_slug: 'department-of-hats')
+      expect(presenter).to be_filtered
+    end
+  end
+
+  describe "#invalid_filter?" do
+    it 'is true when path and organisation are blank' do
+      presenter = described_class.new(path: nil, organisation_slug: nil)
+      expect(presenter).to be_invalid_filter
+    end
+
+    it 'is false when path is provided and organisation is blank' do
+      presenter = described_class.new(path: '/done/buying-a-new-hat', organisation_slug: nil)
+      expect(presenter).not_to be_invalid_filter
+    end
+
+    it 'is false when organisation is provided and path is blank' do
+      presenter = described_class.new(path: nil, organisation_slug: 'department-of-hats')
+      expect(presenter).not_to be_invalid_filter
+    end
+
+    it 'is false when both organisation and path are provided' do
+      presenter = described_class.new(path: '/done/buying-a-new-hat', organisation_slug: 'department-of-hats')
+      expect(presenter).not_to be_invalid_filter
+    end
+  end
+
+  describe "#done_page?" do
+    it "is false when no path was provided" do
+      presenter = described_class.new(path: nil)
+      expect(presenter).not_to be_done_page
+    end
+
+    it 'is true when the provided path starts with "/done"' do
+      presenter = described_class.new(path: "/done/buying-a-new-hat")
+      expect(presenter).to be_done_page
+    end
+
+    it 'is true when the provided path starts with "done"' do
+      presenter = described_class.new(path: "done/buying-a-new-hat")
+      expect(presenter).to be_done_page
+    end
+
+    it 'is false when the provided path starts with anything else' do
+      presenter = described_class.new(path: "/start/buying-a-new-hat")
+      expect(presenter).not_to be_done_page
+    end
+
+    it 'is false when the provided path has done somewhere other than the start' do
+      presenter = described_class.new(path: "/start/getting-things-done")
+      expect(presenter).not_to be_done_page
+    end
+  end
+
+  describe "#organisation" do
+    include GdsApi::TestHelpers::SupportApi
+
+    it "fetches the org from the support api using the supplied slug" do
+      org_request = stub_support_api_organisation(
+        "department-of-hats",
+        slug: 'department-of-hats',
+        web_url: "https://www.gov.uk/government/organisations/department-of-hats",
+        title: "Department of Hats",
+        acronym: "DoH",
+        govuk_status: "live"
+      )
+      presenter = described_class.new(organisation_slug: 'department-of-hats')
+      presenter.organisation
+      expect(org_request).to have_been_requested
+    end
+
+    it "does not talk to the support api if the organisation slug is not present" do
+      org_request = stub_support_api_organisation(
+        "department-of-hats",
+        slug: 'department-of-hats',
+        web_url: "https://www.gov.uk/government/organisations/department-of-hats",
+        title: "Department of Hats",
+        acronym: "DoH",
+        govuk_status: "live"
+      )
+      presenter = described_class.new(organisation_slug: nil)
+      presenter.organisation
+      expect(org_request).not_to have_been_requested
+    end
+
+    it "raises any error from the support API" do
+      stub_any_support_api_call.to_return(status: 500)
+      presenter = described_class.new(organisation_slug: 'department-of-hats')
+      expect {
+        presenter.organisation
+      }.to raise_error GdsApi::HTTPErrorResponse
+    end
+  end
+
+  describe "#organisation_title" do
+    include GdsApi::TestHelpers::SupportApi
+
+    it "delegates to the org from the support api using the supplied slug" do
+      stub_support_api_organisation(
+        "department-of-hats",
+        slug: 'department-of-hats',
+        web_url: "https://www.gov.uk/government/organisations/department-of-hats",
+        title: "Department of Hats",
+        acronym: "DoH",
+        govuk_status: "live"
+      )
+      presenter = described_class.new(organisation_slug: 'department-of-hats')
+      expect(presenter.organisation_title).to eq 'Department of Hats'
+    end
+
+    it "is nil if no organisation_slug was provided" do
+      presenter = described_class.new(organisation_slug: nil)
+      expect(presenter.organisation_title).to eq nil
+    end
+  end
+
+  describe '#to_s' do
+    it 'is "Everything" when path and organisation are omitted' do
+      presenter = described_class.new(path: nil, organisation_slug: nil)
+      expect(presenter.to_s).to eq 'Everything'
+    end
+
+    it 'is the path when path is provided and organisation is blank' do
+      presenter = described_class.new(path: '/done/buying-a-new-hat', organisation_slug: nil)
+      expect(presenter.to_s).to eq '/done/buying-a-new-hat'
+    end
+
+    it 'is the organisation title when organisation is provided and path is blank' do
+      stub_support_api_organisation(
+        "department-of-hats",
+        slug: 'department-of-hats',
+        web_url: "https://www.gov.uk/government/organisations/department-of-hats",
+        title: "Department of Hats",
+        acronym: "DoH",
+        govuk_status: "live"
+      )
+
+      presenter = described_class.new(path: nil, organisation_slug: 'department-of-hats')
+      expect(presenter.to_s).to eq 'Department of Hats'
+    end
+
+    it 'is the organistion title and path when both organisation and path are provided' do
+      stub_support_api_organisation(
+        "department-of-hats",
+        slug: 'department-of-hats',
+        web_url: "https://www.gov.uk/government/organisations/department-of-hats",
+        title: "Department of Hats",
+        acronym: "DoH",
+        govuk_status: "live"
+      )
+
+      presenter = described_class.new(path: '/done/buying-a-new-hat', organisation_slug: 'department-of-hats')
+      expect(presenter.to_s).to eq 'Department of Hats on /done/buying-a-new-hat'
+    end
+  end
+end

--- a/spec/support/app_actions.rb
+++ b/spec/support/app_actions.rb
@@ -6,7 +6,7 @@ module AppActions
   def explore_anonymous_feedback_with(options)
     visit "/"
 
-    stub_organisations_list
+    stub_support_api_organisations_list
 
     click_on "Feedback explorer"
     assert page.has_title?("Anonymous Feedback"), page.html


### PR DESCRIPTION
For: https://trello.com/c/8wwFr5y0/196-improvements-to-feedex-ui

It's possible to filter feedex by both path and organisation if you manipulate the URL, but there's no UI so it's not obvious.  This PR adds UI elements to make it more obvious and easier to do.

## Screenshots

We choose to browse by org, and then decide we want to also filter by a specific path, and finally remove the org constraint.

### Before

![feedex-before](https://user-images.githubusercontent.com/608/29963959-7ce09d5a-8f00-11e7-9371-be5c6cf03eee.gif)

There's no UI for adding path or removing organisation filters, but we can do it by manually hacking the URL.  The page doesn't tell us we've filtered by multiple things, but the data has been updated accordingly.

### After

![feedex-after](https://user-images.githubusercontent.com/608/30067783-b14d186a-9253-11e7-8806-acd53cc74a2b.gif)

UI for path and org filtering is always present on the page, and we've tweaked the help text to make it clear you can use a partial path to filter results.

#### Discarded alternates

##### V1 - icon button in header

![feedex-after-v1](https://user-images.githubusercontent.com/608/29963946-7622f97c-8f00-11e7-867d-7bbd450ff54c.gif)

##### V2 - text button in form

![feedex-after-v2](https://user-images.githubusercontent.com/608/29975216-7b060a92-8f2d-11e7-940b-a59735a95f52.gif)

---

Would particularly appreciate thoughts on the UI choices I've made as I'm not 100% sure they're the best.