### PR TITLE
Fix Zendesk name too long record invalid error

### DIFF
--- a/app/workers/zendesk_ticket_worker.rb
+++ b/app/workers/zendesk_ticket_worker.rb
@@ -6,7 +6,11 @@ class ZendeskTicketWorker
       GovukStatsd.increment("report_a_problem.submission_from_suspended_user")
     else
       begin
-        create_ticket(ticket_options)
+        if ticket_options["requester"]["name"] && ticket_options["requester"]["name"].length > 255
+          GovukStatsd.increment("report_a_problem.zendesk_ticket_name_too_long")
+        else
+          create_ticket(ticket_options)
+        end
       rescue ZendeskAPI::Error::NetworkError => e
         if e.response.status == 409
           GovukStatsd.increment("exception.409_conflict_response") #if Zendesk has already received the ticket, we should stop trying. All we do is record the error in Grafana.

--- a/spec/workers/zendesk_ticket_worker_spec.rb
+++ b/spec/workers/zendesk_ticket_worker_spec.rb
@@ -14,6 +14,20 @@ describe ZendeskTicketWorker do
     end
   end
 
+  context 'ticket creation when name length exceeds 255 characters' do
+    before do
+      zendesk_has_user(email: "a@b.com", suspended: false)
+    end
+
+    it "does not create a ticket" do
+      name = "a" * 260
+      stub = stub_zendesk_ticket_creation("some" => "options", "requester" => { "email" => "a@b.com", "name" => name })
+      ZendeskTicketWorker.new.perform("some" => "options", "requester" => { "email" => "a@b.com", "name" => name })
+
+      expect(stub).to_not have_been_made
+    end
+  end
+
   context 'with a suspended requesting user' do
     before do
       zendesk_has_user(email: "a@b.com", suspended: true)


### PR DESCRIPTION
A Zendesk ticket is created as long as the requester name is less than 256 characters.
This will remove the Zendesk name to long errors in Sentry.

We (2nd line) started looking at this issue as there were a large number of these errors in Sentry, when we looked at these errors they appears to be spam. We spoke with Liz Lutgendorff and she suggested ignoring any requests there the name was above the 255 limit as these were always spam and not requests from 'real' users.