### PR TITLE
Normalise path when talking to support api

### DIFF
--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -20,22 +20,25 @@ class AnonymousFeedback::ExportRequestsController < AuthorisationController
     end
   end
 
+private
+
   def export_request_params
-    clean_params = anonymous_feedback_params
     {
-      path_prefix: clean_params[:path],
-      from: clean_params[:from],
-      to: clean_params[:to],
-      organisation: clean_params[:organisation],
+      path_prefix: scope_filters.path,
+      organisation: scope_filters.organisation_slug,
+      from: anonymous_feedback_params[:from],
+      to: anonymous_feedback_params[:to],
       notification_email: current_user.email
     }
   end
 
   def anonymous_feedback_params
-    params.permit(:from, :to, :path, :organisation).to_h
+    @anonymous_feedback_params ||= params.permit(:from, :to, :path, :organisation).to_h
   end
 
-private
+  def scope_filters
+    @scope_filters ||= ScopeFiltersPresenter.new(path: anonymous_feedback_params[:path], organisation_slug: anonymous_feedback_params[:organisation])
+  end
 
   def support_api
     GdsApi::SupportApi.new(Plek.find("support-api"))

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -42,7 +42,7 @@ class AnonymousFeedbackController < RequestsController
 private
 
   def index_params
-    params.permit(:path, :organisation, :page, :from, :to).to_h
+    @index_params ||= params.permit(:path, :organisation, :page, :from, :to).to_h
   end
 
   def scope_filters

--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -9,10 +9,10 @@
                                to: @dates.to,
                                results_limited: @feedback.results_limited,
                                scopes: @filtered_by) %>
-    <% %i(from to path organisation).each do |attr| %>
-      <% next if params[attr].blank? %>
-      <%= hidden_field_tag attr, params[attr], id: "export_form_#{attr}" %>
-    <% end %>
+    <%= hidden_field_tag :from, @dates.from if @dates.from.present? %>
+    <%= hidden_field_tag :to, @dates.to if @dates.to.present? %>
+    <%= hidden_field_tag :path, @filtered_by.path if @filtered_by.path.present? %>
+    <%= hidden_field_tag :organisation, @filtered_by.organisation_slug if @filtered_by.organisation_slug.present? %>
     <%= submit_tag "Export as CSV", class: "btn-sm btn btn-default add-left-margin" %>
   </p>
 <% end %>

--- a/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
@@ -43,9 +43,15 @@ describe AnonymousFeedback::ExportRequestsController, type: :controller do
                                                                       from: "2015-05-01",
                                                                       to: "2015-06-01"))
       end
+
+      it "normalises the path before sending it to the api" do
+        post :create, params: { path: "foo", from: "2015-05-01", to: "2015-06-01" }
+
+        expect(stub_request).to have_been_made
+      end
     end
 
-    context "with a path" do
+    context "with an organisation" do
       let!(:stub_request) do
         stub_support_api_feedback_export_request_creation(notification_email: "foo.bar@example.gov.uk",
                                                       path_prefix: nil,

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -53,152 +53,165 @@ describe AnonymousFeedbackController, type: :controller do
     end
   end
 
-  context "valid input, problem reports" do
-    before do
-      stub_support_api_anonymous_feedback(
-        { path_prefix: "/tax-disc", from: "13/10/2014", to: "25th November 2014" },
-        "current_page" => 1,
-        "pages" => 1,
-        "page_size" => 1,
-        "results" => [
-          {
-            id: "123",
-            type: "problem-report",
-            path: "/tax-disc",
-            url: "http://www.dev.gov.uk/tax-disc",
-            created_at: DateTime.parse("2013-03-01"),
-            what_doing: "looking at 3rd paragraph",
-            what_wrong: "typo in 2rd word",
-            referrer: "https://www.gov.uk",
-            user_agent: "Safari",
-          },
-        ]
-      )
-    end
-
-    context "HTML representation" do
-      it "renders the results" do
-        get :index, params: { path: "/tax-disc", from: "13/10/2014", to: "25th November 2014" }
-        expect(response).to have_http_status(:success)
-      end
-    end
-
-    context "JSON" do
-      render_views
-
-      it "returns the results for problem" do
-        get :index, params: { "path" => "/tax-disc", "format" => "json", from: "13/10/2014", to: "25th November 2014" }
-
-        expect(response).to have_http_status(:success)
-        expect(json_response).to have(1).item
-        expect(json_response.first).to include(
-          "id" => "123",
-          "type" => "problem-report",
-          "what_wrong" => "typo in 2rd word",
-          "what_doing" => "looking at 3rd paragraph",
-          "url" => "http://www.dev.gov.uk/tax-disc",
-          "referrer" => "https://www.gov.uk",
-          "user_agent" => "Safari",
+  context "browsing by path" do
+    context "valid input, problem reports" do
+      before do
+        stub_support_api_anonymous_feedback(
+          { path_prefix: "/tax-disc", from: "13/10/2014", to: "25th November 2014" },
+          "current_page" => 1,
+          "pages" => 1,
+          "page_size" => 1,
+          "results" => [
+            {
+              id: "123",
+              type: "problem-report",
+              path: "/tax-disc",
+              url: "http://www.dev.gov.uk/tax-disc",
+              created_at: DateTime.parse("2013-03-01"),
+              what_doing: "looking at 3rd paragraph",
+              what_wrong: "typo in 2rd word",
+              referrer: "https://www.gov.uk",
+              user_agent: "Safari",
+            },
+          ]
         )
       end
-    end
-  end
 
-  context "valid input, long-form feedback" do
-    before do
-      stub_support_api_anonymous_feedback(
-        { path_prefix: "/contact/govuk" },
-        "current_page" => 1,
-        "pages" => 1,
-        "page_size" => 1,
-        "results" => [
-          {
-            id: "123",
-            type: "long-form-contact",
-            url: "http://www.dev.gov.uk/contact/govuk",
-            path: "/contact/govuk",
-            referrer: "https://www.gov.uk/contact",
-            details: "Abc def",
-            user_agent: "Safari",
-          },
-        ]
-      )
-    end
+      context "HTML representation" do
+        it "renders the results" do
+          get :index, params: { path: "/tax-disc", from: "13/10/2014", to: "25th November 2014" }
+          expect(response).to have_http_status(:success)
+        end
+      end
 
-    context "HTML representation" do
-      it "renders the results for an HTML request" do
-        get :index, params: { path: "/contact/govuk" }
-        expect(response).to have_http_status(:success)
+      context "JSON" do
+        render_views
+
+        it "returns the results for problem" do
+          get :index, params: { "path" => "/tax-disc", "format" => "json", from: "13/10/2014", to: "25th November 2014" }
+
+          expect(response).to have_http_status(:success)
+          expect(json_response).to have(1).item
+          expect(json_response.first).to include(
+            "id" => "123",
+            "type" => "problem-report",
+            "what_wrong" => "typo in 2rd word",
+            "what_doing" => "looking at 3rd paragraph",
+            "url" => "http://www.dev.gov.uk/tax-disc",
+            "referrer" => "https://www.gov.uk",
+            "user_agent" => "Safari",
+          )
+        end
       end
     end
 
-    context "JSON representation" do
-      render_views
-
-      it "returns the results for problem" do
-        get :index, params: { "path" => "/contact/govuk", "format" => "json" }
-
-        expect(response).to have_http_status(:success)
-        expect(json_response).to have(1).item
-        expect(json_response.first).to include(
-          "id" => "123",
-          "type" => "long-form-contact",
-          "details" => "Abc def",
-          "url" => "http://www.dev.gov.uk/contact/govuk",
-          "referrer" => "https://www.gov.uk/contact",
-          "user_agent" => "Safari",
+    context "valid input, long-form feedback" do
+      before do
+        stub_support_api_anonymous_feedback(
+          { path_prefix: "/contact/govuk" },
+          "current_page" => 1,
+          "pages" => 1,
+          "page_size" => 1,
+          "results" => [
+            {
+              id: "123",
+              type: "long-form-contact",
+              url: "http://www.dev.gov.uk/contact/govuk",
+              path: "/contact/govuk",
+              referrer: "https://www.gov.uk/contact",
+              details: "Abc def",
+              user_agent: "Safari",
+            },
+          ]
         )
       end
-    end
-  end
 
-  context "valid input, service feedback" do
-    before do
-      stub_support_api_anonymous_feedback(
-        { path_prefix: "/done/apply-carers-allowance" },
-        "current_page" => 1,
-        "pages" => 1,
-        "page_size" => 1,
-        "results" => [
-          {
-            id: "123",
-            type: "service-feedback",
-            slug: "apply-carers-allowance",
-            url: "http://www.dev.gov.uk/done/apply-carers-allowance",
-            path: "/done/apply-carers-allowance",
-            details: "It's great",
-            service_satisfaction_rating: 5,
-            user_agent: "Safari",
-          },
-        ]
-      )
-    end
+      context "HTML representation" do
+        it "renders the results for an HTML request" do
+          get :index, params: { path: "/contact/govuk" }
+          expect(response).to have_http_status(:success)
+        end
+      end
 
-    context "HTML representation" do
-      it "renders the results" do
-        get :index, params: { path: "/done/apply-carers-allowance" }
-        expect(response).to have_http_status(:success)
+      context "JSON representation" do
+        render_views
+
+        it "returns the results for problem" do
+          get :index, params: { "path" => "/contact/govuk", "format" => "json" }
+
+          expect(response).to have_http_status(:success)
+          expect(json_response).to have(1).item
+          expect(json_response.first).to include(
+            "id" => "123",
+            "type" => "long-form-contact",
+            "details" => "Abc def",
+            "url" => "http://www.dev.gov.uk/contact/govuk",
+            "referrer" => "https://www.gov.uk/contact",
+            "user_agent" => "Safari",
+          )
+        end
       end
     end
 
-    context "JSON representation" do
-      render_views
-
-      it "returns the results" do
-        get :index, params: { "path" => "/done/apply-carers-allowance", "format" => "json" }
-
-        expect(response).to have_http_status(:success)
-        expect(json_response).to have(1).item
-        expect(json_response.first).to include(
-          "id" => "123",
-          "type" => "service-feedback",
-          "slug" => "apply-carers-allowance",
-          "details" => "It's great",
-          "url" => "http://www.dev.gov.uk/done/apply-carers-allowance",
-          "service_satisfaction_rating" => 5,
-          "user_agent" => "Safari",
+    context "valid input, service feedback" do
+      before do
+        stub_support_api_anonymous_feedback(
+          { path_prefix: "/done/apply-carers-allowance" },
+          "current_page" => 1,
+          "pages" => 1,
+          "page_size" => 1,
+          "results" => [
+            {
+              id: "123",
+              type: "service-feedback",
+              slug: "apply-carers-allowance",
+              url: "http://www.dev.gov.uk/done/apply-carers-allowance",
+              path: "/done/apply-carers-allowance",
+              details: "It's great",
+              service_satisfaction_rating: 5,
+              user_agent: "Safari",
+            },
+          ]
         )
       end
+
+      context "HTML representation" do
+        it "renders the results" do
+          get :index, params: { path: "/done/apply-carers-allowance" }
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      context "JSON representation" do
+        render_views
+
+        it "returns the results" do
+          get :index, params: { "path" => "/done/apply-carers-allowance", "format" => "json" }
+
+          expect(response).to have_http_status(:success)
+          expect(json_response).to have(1).item
+          expect(json_response.first).to include(
+            "id" => "123",
+            "type" => "service-feedback",
+            "slug" => "apply-carers-allowance",
+            "details" => "It's great",
+            "url" => "http://www.dev.gov.uk/done/apply-carers-allowance",
+            "service_satisfaction_rating" => 5,
+            "user_agent" => "Safari",
+          )
+        end
+      end
+    end
+
+    it "normalises the path before talking to the api" do
+      api_request = stub_support_api_anonymous_feedback(
+        hash_including("path_prefix" => '/done/apply-carers-allowance'),
+        "results" => [], "pages" => 0, "current_page" => 1
+      )
+
+      get :index, params: { path: 'done/apply-carers-allowance' }
+
+      expect(api_request).to have_been_made
     end
   end
 


### PR DESCRIPTION
For: https://trello.com/c/CQBhAvxt/286-fix-feedex-export

When talking to support-api to show results and talking to support-api to generate an export we were treating the params differently.  This meant that you could enter a slash-less path like `done` to get results on the index, but if you tried to export a CSV you would get no results.  This PR fixes that by using the same parameter normalising code in both places.  The API will still return no results for slash-less paths, but the UI will make it hard (impossible?) to send that kind of path to the API.