### PR TITLE
Increase GdsApi timeout to 30 seconds

### DIFF
--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,5 +1,7 @@
 require 'gds_api/base'
 
+GdsApi::Base.default_options = { timeout: 30 }
+
 if %w(development test).include? Rails.env
-  GdsApi::Base.default_options = { disable_cache: true }
+  GdsApi::Base.default_options[:disable_cache] = true
 end


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/2540091

Requests to `suppport-api/anonymous_feedback` are
taking about 8 seconds to complete which is timing
out and causing 503 errors in this application.

This sets the default timeout to a maximum of 30
seconds, which is the same as the Nginx timeout.

Really, we should look at fixing the slow queries,
but this solves the immediate problem of users not
being able to use the `/anonymous_feedback` endpoint
of this application.