### PR TITLE
Contact number change

### DIFF
--- a/app/views/content_change_requests/_request_details.html.erb
+++ b/app/views/content_change_requests/_request_details.html.erb
@@ -1,19 +1,9 @@
 <div class="alert alert-info alert-block">
   <p>You'll get an automated response to confirm we've received your request. We'll then review your request within 2 working days.</p>
-  <p>When filling out this form...</p>
-  <p>Please do:</p>
-  <ul>
-    <li>explain the problem – what speciﬁcally needs to be addressed and why?</li>
-    <li>focus on the facts not the presentation</li>
-    <li>focus on what the user needs to know to complete a specific task, rather than the policy background</li>
-    <li>combine changes to one item into one ticket where possible</li>
-  </ul>
-  <p>Please don't:</p>
-  <ul>
-    <li>cut-and-paste long email chains</li>
-    <li>re-write the content</li>
-  </ul>
+
+<p>Read how to <a href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#change-mainstream-content">write a request that will get resolved quickly</a>.</p>
 </div>
+
 
 <%= f.input :title, label: "Title of request", input_html: { class: "input-md-6", placeholder: "Content change request" } %>
 
@@ -31,7 +21,7 @@
 <%= render partial: "support/time_constraint", locals: { f: f } %>
 
 <div class="alert alert-info alert-block">
-  <p>If your request is urgent, please fill in this form then call 07827 992603 to let us know. (It's ONLY urgent when the public or the government is facing immediate and significant financial, legal or physical risk.)</p>
+  <p>If your request is urgent, please fill in this form and call 07810 750 834 during office hours, or 07827 992603 out of hours. (It's ONLY urgent when the public or the government is facing immediate and significant financial, legal or physical risk.)</p>
 </div>
 
 <%= render partial: "support/collaborators", locals: { f: f } %>


### PR DESCRIPTION
Added the office hours 'emergency' number, and I removed the stuff at the top. It links out to guidance about how to get the most out of these content requests now.

This is how it should look:
![support integration publishing service gov uk-2017-12-22-11-12-33-616](https://user-images.githubusercontent.com/7126294/34296787-364b63fc-e70c-11e7-8be3-2f95a6892bb2.png)
