### PR TITLE
Improvements to feedex

### DIFF
--- a/app/helpers/feedex_helper.rb
+++ b/app/helpers/feedex_helper.rb
@@ -23,4 +23,12 @@ module FeedexHelper
     response_total = "Over #{response_total}" if results_limited
     response_total
   end
+
+  def confirmation_message(total_count, results_limited)
+    if results_limited
+      "This is a large number of records (more than #{total_count}) and may take some time.\n\nAre you sure you want to export?"
+    else
+      "This will export #{total_count} records.\n\nAre you sure you want to export?"
+    end
+  end
 end

--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -13,7 +13,7 @@
     <%= hidden_field_tag :to, @dates.to if @dates.to.present? %>
     <%= hidden_field_tag :path, @filtered_by.path if @filtered_by.path.present? %>
     <%= hidden_field_tag :organisation, @filtered_by.organisation_slug if @filtered_by.organisation_slug.present? %>
-    <%= submit_tag "Export as CSV", class: "btn-sm btn btn-default add-left-margin" %>
+    <%= submit_tag "Export as CSV", class: "btn-sm btn btn-default add-left-margin", data: { confirm: confirmation_message(@feedback.total_count, @feedback.results_limited) } %>
   </p>
 <% end %>
 


### PR DESCRIPTION
For: https://trello.com/c/amR8AiD5/309-feedex-changes-to-workflow

## Background 
While working on feedex, I requested an export for all the '/done' pages: https://support.integration.publishing.service.gov.uk/anonymous_feedback?path=%2Fdone

This export took 7 hours to perform and resulted in a 1.1 GB file. There was unfortunately no warning that the export would be so big, or that it would require a large amount of time. Had I received a warning, I would have thought twice about asking for such a large file. 

## What this does

Adds warning when attempting to export a search result. 