### PR TITLE
Disallow search engine indexing

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,2 @@
-# See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-Agent: *
-# Disallow: /
+User-Agent: *
+Disallow: /


### PR DESCRIPTION
This disallows all search engines from indexing the pages by this app. There's nothing for the public to see here, and service domains shouldn't be indexed anyway:

https://www.gov.uk/service-manual/technology/get-a-domain-name#using-robotstxt-and-root-level-redirects

Thanks @dashouse and @edwardhorsford