### PR TITLE
Change text for campaign support form

### DIFF
--- a/app/models/zendesk/ticket/campaign_request_ticket.rb
+++ b/app/models/zendesk/ticket/campaign_request_ticket.rb
@@ -26,7 +26,7 @@ module Zendesk
           Zendesk::LabelledSnippet.new(on: @request.campaign, field: :performance_review_contact_email,
                                                      label: "Contact email/s for website performance review every 6 months"),
           Zendesk::LabelledSnippet.new(on: @request.campaign, field: :government_theme,
-                                                     label: "Which of the current government priority themes does this campaign website support and how?"),
+                                                     label: "Which of the current Government Communications Plan priority themes does this campaign website support and how?"),
           Zendesk::LabelledSnippet.new(on: @request.campaign, field: :description,
                                                      label: "Campaign description"),
           Zendesk::LabelledSnippet.new(on: @request.campaign, field: :call_to_action,

--- a/app/views/campaign_requests/_request_details.html.erb
+++ b/app/views/campaign_requests/_request_details.html.erb
@@ -28,7 +28,7 @@
                 as: :boolean,
                 input_html: {:class => "input-md-6"} %>
     <%= r.input :has_read_oasis_guidance_confirmation,
-                label: "<b>Have you followed the #{link_to('GCS guidance for OASIS planning', 'https://gcs.civilservice.gov.uk/wp-content/uploads/2015/09/6.3938_CO_GCS-Campaign-Planning_FINAL_A4_111017.pdf')} and are using the #{link_to('GCS website recommended OASIS template?', 'https://gcs.civilservice.gov.uk/guidance/campaigns/strategy-planning-templates/')}</b>".html_safe,
+                label: "<b>Have you followed the #{link_to('GCS guidance for OASIS planning', 'https://gcs.civilservice.gov.uk/wp-content/uploads/2015/09/6.3938_CO_GCS-Campaign-Planning_FINAL_A4_111017.pdf')} and are using the #{link_to('mandatory GCS OASIS template?', 'https://gcs.civilservice.gov.uk/guidance/campaigns/strategy-planning-templates/')}</b>".html_safe,
                 as: :boolean,
                 input_html: {:class => "input-md-6"} %>
     <%= r.input :signed_campaign,
@@ -76,7 +76,7 @@
     </p>
 
     <%= r.input :government_theme,
-                label: "Which of the current government priority themes does this campaign website support and how?",
+                label: "Which of the current Government Communications Plan priority themes does this campaign website support and how?",
                 required: true,
                 input_html: {:class => "input-md-6",
                              :rows => 6,

--- a/spec/features/campaign_requests_spec.rb
+++ b/spec/features/campaign_requests_spec.rb
@@ -37,7 +37,7 @@ John Smith
 [Contact email/s for website performance review every 6 months]
 john.smith@example.com
 
-[Which of the current government priority themes does this campaign website support and how?]
+[Which of the current Government Communications Plan priority themes does this campaign website support and how?]
 Example government theme
 
 [Campaign description]
@@ -96,13 +96,13 @@ Some comment"
 
     choose details[:type_of_site]
     check "Have you read the the GCS guidance on campaign websites and accept the requirements for a Campaign Platform website?" if details[:has_read_guidance]
-    check "Have you followed the GCS guidance for OASIS planning and are using the GCS website recommended OASIS template?" if details[:has_read_oasis_guidance]
+    check "Have you followed the GCS guidance for OASIS planning and are using the mandatory GCS OASIS template?" if details[:has_read_oasis_guidance]
     fill_in "Name of the head of digital who signed off the campaign website application*", with: details[:signed_campaign]
     fill_in "Start date of campaign site*", with: details[:start_date]
     fill_in "Proposed end date of campaign site*", with: details[:end_date]
     fill_in "Site build to commence on", with: details[:development_start_date]
     fill_in "Contact email/s for website performance review every 6 months*", with: details[:performance_review_contact_email]
-    fill_in "Which of the current government priority themes does this campaign website support and how?*", with: details[:government_theme]
+    fill_in "Which of the current Government Communications Plan priority themes does this campaign website support and how?*", with: details[:government_theme]
     fill_in "Campaign description*", with: details[:description]
     fill_in "Call to action*", with: details[:call_to_action]
     fill_in "Proposed URL (in the form of xxxxx.campaign.gov.uk or xxxxx.gov.uk)*", with: details[:proposed_url]


### PR DESCRIPTION
This change helps people give better quality responses, improving the quality of thinking that goes in to creating campaign sites.

[Trello Card](https://trello.com/c/zGpgCvS7/32-2-change-text-for-campaign-support-form)