### PR TITLE
Support asset:precompile without Redis

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -6,10 +6,14 @@ GDS::SSO.config do |config|
 end
 
 if Rails.env == "development" && ENV['GDS_SSO_STRATEGY'] != 'real'
-  GDS::SSO.test_user = User.upsert!(
-    "uid" => 'dummy-user',
-    "name" => 'Ms Example',
-    "email" => 'example@example.com',
-    "permissions" => ['single_points_of_contact', 'api_users', 'feedex_exporters']
-  )
+  begin
+    GDS::SSO.test_user = User.upsert!(
+      "uid" => 'dummy-user',
+      "name" => 'Ms Example',
+      "email" => 'example@example.com',
+      "permissions" => ['single_points_of_contact', 'api_users', 'feedex_exporters']
+    )
+  rescue Redis::CannotConnectError
+    puts "Redis::CannotConnectError: Unable to create dummy user"
+  end
 end


### PR DESCRIPTION
In the Rails development environment, this would fail without
Redis. It's not necessary to create the dummy user, so capture the
exception, and just print it.

This should allow asset precompilation to be enabled for the package
in govuk-guix.