### PR TITLE
[DO NOT MERGE] Add Content Publisher to technical fault report

### DIFF
--- a/app/controllers/technical_fault_reports_controller.rb
+++ b/app/controllers/technical_fault_reports_controller.rb
@@ -16,7 +16,7 @@ protected
   def technical_fault_report_params
     params.require(:support_requests_technical_fault_report).permit(
       :fault_context, :fault_specifics, :actions_leading_to_problem,
-      :what_happened, :what_should_have_happened,
+      :what_happened, :what_should_have_happened, :assignee_id,
       requester_attributes: %i[email name collaborator_emails],
       fault_context_attributes: %i[name id inside_government_related],
     ).to_h

--- a/app/models/support/gds/user_facing_components.rb
+++ b/app/models/support/gds/user_facing_components.rb
@@ -21,6 +21,7 @@ module Support
             { name: "Mainstream Publisher", id: "mainstream_publisher" },
             { name: "Travel Advice Publisher", id: "travel_advice_publisher" },
             { name: "Specialist Publisher", id: "specialist_publisher" },
+            { name: "Content Publisher (beta)", id: "content_publisher" },
           ]
         end
       end

--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -10,6 +10,10 @@ module Support
         end
       end
 
+      # This is temporary while Content Publisher is in private beta.
+      # Content Publisher tickets will be assigned to Humin Miah.
+      CONTENT_PUBLISHER_ASSIGNEE = 3512638809
+
       def initialize(opts = {})
         super
         self.fault_context ||= Support::GDS::UserFacingComponent.new
@@ -33,6 +37,12 @@ module Support
 
       def self.description
         "Report something that is not working with any publishing application, eg Whitehall, finders or specialist publisher. Also use for any urgent technical changes"
+      end
+
+      def assignee_id
+        # temporary while Content Publisher is in private beta
+        return unless fault_context.id == "content_publisher"
+        CONTENT_PUBLISHER_ASSIGNEE
       end
     end
   end

--- a/app/models/zendesk/zendesk_ticket.rb
+++ b/app/models/zendesk/zendesk_ticket.rb
@@ -61,6 +61,11 @@ module Zendesk
       []
     end
 
+    def assignee_id
+      # temporary while Content Publisher is in private beta
+      @request.assignee_id if has_value?(:assignee_id)
+    end
+
   protected
 
     def request_label(attributes)

--- a/app/models/zendesk/zendesk_tickets.rb
+++ b/app/models/zendesk/zendesk_tickets.rb
@@ -1,14 +1,17 @@
 module Zendesk
   class ZendeskTickets
     def raise_ticket(ticket_to_raise)
-      ZendeskTicketWorker.perform_async(
+      ticket_data = {
         subject: ticket_to_raise.subject,
         priority: ticket_to_raise.priority,
         requester: { "locale_id" => 1, "email" => ticket_to_raise.email, "name" => ticket_to_raise.name },
         collaborators: ticket_to_raise.collaborator_emails,
         tags: ticket_to_raise.tags,
         comment: { "body" => ticket_to_raise.comment }
-      )
+      }
+      # temporary while Content Publisher is in private beta
+      ticket_data[:assignee_id] = ticket_to_raise.assignee_id if ticket_to_raise.assignee_id.present?
+      ZendeskTicketWorker.perform_async(ticket_data)
     end
   end
 end

--- a/spec/features/technical_fault_reports_spec.rb
+++ b/spec/features/technical_fault_reports_spec.rb
@@ -47,6 +47,43 @@ Should have linked through"
     expect(request).to have_been_made
   end
 
+  scenario "successful Content Publisher report" do
+    request = expect_zendesk_to_receive_ticket(
+      "subject" => "Technical fault report",
+      "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
+      "collaborators" => [],
+      "tags" => %w[govt_form technical_fault fault_with_content_publisher],
+      "comment" => {
+        "body" =>
+"[Location of fault]
+Content Publisher (beta)
+
+[What is broken]
+News story
+
+[Actions leading to problem]
+Clicked on x
+
+[What happened]
+Broken link
+
+[What should have happened]
+Should have linked through",
+      },
+      "assignee_id" => 3512638809,
+    )
+
+    user_makes_a_technical_fault_report(
+      location_of_fault: "Content Publisher (beta)",
+      what_is_broken: "News story",
+      user_action: "Clicked on x",
+      what_happened: "Broken link",
+      what_should_have_happened: "Should have linked through",
+    )
+
+    expect(request).to have_been_made
+  end
+
   private
 
   def user_makes_a_technical_fault_report(details)


### PR DESCRIPTION
For https://trello.com/c/sDIsMglD/258-add-content-publisher-to-list-of-apps-in-support-form

This PR adds Content Publisher as an option to select when raising a technical support request:

<img width="665" alt="screen shot 2018-09-21 at 17 23 42" src="https://user-images.githubusercontent.com/13434452/45893437-231a5200-bdc3-11e8-9135-78171c0cb3e9.png">

We also add a `assignee_id` attribute to the payload sent to the Zendesk API when creating a document (see Zendesk API documentation to [create a ticket](https://developer.zendesk.com/rest_api/docs/core/tickets#create-ticket) and [accepted attributes](https://developer.zendesk.com/rest_api/docs/core/tickets#json-format)).  When Content Publisher is in private beta we'd like for any support tickets raised relating to it to be automatically assigned to the Product Manager responsible for it, which is why we've hardcoded their Zendesk ID.  When the app is no longer in private beta we expect this to be reverted.

There isn't a staging environment available for Zendesk so we will only know if this approach to assigning an agent works correctly once it's been deployed to production.  In the meantime we have tested that the payload is accepted by the [gds_zendesk dummy client](https://github.com/alphagov/gds_zendesk/commit/14c28f97ffd27dfaba6c4f466ca7272e29f48fc6).