### PR TITLE
Fix link to writing content requests guidance

### DIFF
--- a/app/views/content_change_requests/_request_details.html.erb
+++ b/app/views/content_change_requests/_request_details.html.erb
@@ -1,7 +1,7 @@
 <div class="alert alert-info alert-block">
   <p>You'll get an automated response to confirm we've received your request. We'll then review your request within 2 working days.</p>
 
-<p>Read how to <a href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#change-mainstream-content">write a request that will get resolved quickly</a>.</p>
+<p><a href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#change-govuk-content">How to write a request that will get resolved quickly</a>.</p>
 </div>
 
 


### PR DESCRIPTION
Change link in alert block from .../guidance/contact-the-government-digital-service/request-a-thing#change-mainstream-content to .../request-a-thing#change-govuk-content