### PR TITLE
Putting in a new support feedback page for the content publisher

### DIFF
--- a/app/controllers/content_publisher_feedback_requests_controller.rb
+++ b/app/controllers/content_publisher_feedback_requests_controller.rb
@@ -1,0 +1,24 @@
+class ContentPublisherFeedbackRequestsController < RequestsController
+protected
+
+  def new_request
+    Support::Requests::ContentPublisherFeedbackRequest.new
+  end
+
+  def zendesk_ticket_class
+    Zendesk::Ticket::ContentPublisherFeedbackRequestTicket
+  end
+
+  def parse_request_from_params
+    Support::Requests::ContentPublisherFeedbackRequest.new(content_publisher_feedback_request_params)
+  end
+
+  def content_publisher_feedback_request_params
+    params.require(:support_requests_content_publisher_feedback_request).permit(
+      :feedback_type,
+      :feedback_details,
+      :impact_on_work,
+      requester_attributes: %i[email name collaborator_emails],
+    ).to_h
+  end
+end

--- a/app/models/support/navigation/section_groups.rb
+++ b/app/models/support/navigation/section_groups.rb
@@ -10,6 +10,7 @@ module Support
           Support::Navigation::SectionGroup.new("Technical support", sections_for(Support::Requests::ChangesToPublishingAppsRequest, Support::Requests::TechnicalFaultReport)),
           Support::Navigation::SectionGroup.new("User access", sections_for(Support::Requests::AccountsPermissionsAndTrainingRequest, Support::Requests::RemoveUserRequest)),
           Support::Navigation::SectionGroup.new("Campaigns", sections_for(Support::Requests::CampaignRequest, Support::Requests::LiveCampaignRequest)),
+          Support::Navigation::SectionGroup.new("Feedback for tools in Beta", sections_for(Support::Requests::ContentPublisherFeedbackRequest)),
           Support::Navigation::SectionGroup.new("Taxonomy requests", sections_for(Support::Requests::TaxonomyNewTopicRequest, Support::Requests::TaxonomyChangeTopicRequest)),
           Support::Navigation::SectionGroup.new("Other requests", sections_for(Support::Requests::AnalyticsRequest, Support::Requests::GeneralRequest)),
         ]

--- a/app/models/support/permissions/ability.rb
+++ b/app/models/support/permissions/ability.rb
@@ -8,15 +8,12 @@ module Support
       def initialize(user)
         can :read, :anonymous_feedback
         can :read, Support::Navigation::EmergencyContactDetailsSection
-
         can :create, Support::Requests::AnalyticsRequest
         can :create, [Support::Requests::GeneralRequest, Support::Requests::TechnicalFaultReport, Support::Requests::Anonymous::Explore]
         can :create, [Support::Requests::TaxonomyNewTopicRequest, Support::Requests::TaxonomyChangeTopicRequest]
-
+        can :create, Support::Requests::ContentPublisherFeedbackRequest
         can :create, :all if user.has_permission?('single_points_of_contact')
-
         can :create, [Support::Requests::CampaignRequest, Support::Requests::LiveCampaignRequest] if user.has_permission?('campaign_requesters')
-
         if user.has_permission?('content_requesters')
           can :create, [
             Support::Requests::ChangesToPublishingAppsRequest,
@@ -25,11 +22,8 @@ module Support
             Support::Requests::UnpublishContentRequest
           ]
         end
-
         can :create, [Support::Requests::AccountsPermissionsAndTrainingRequest, Support::Requests::RemoveUserRequest] if user.has_permission?('user_managers')
-
         can :create, [Support::Requests::FoiRequest, Support::Requests::NamedContact] if user.has_permission?('api_users')
-
         can :request, :global_export_request if user.has_permission?('feedex_exporters')
         can :request, :review_feedback if user.has_permission?('feedex_reviewers')
       end

--- a/app/models/support/requests/content_publisher_feedback_request.rb
+++ b/app/models/support/requests/content_publisher_feedback_request.rb
@@ -1,0 +1,31 @@
+require 'active_support/core_ext'
+
+module Support
+  module Requests
+    class ContentPublisherFeedbackRequest < Request
+      attr_accessor :feedback_type, :feedback_details, :impact_on_work
+
+      OPTIONS = {
+        "accessibility or usability" => "accessibility or usability",
+        "working unexpectedly" => "something working differently than you expected",
+        "helpful feature" => "a feature that would help you with your work",
+        "other" => "something else",
+      }.freeze
+
+      validates_presence_of :feedback_type, :feedback_details
+      validates :feedback_type, inclusion: { in: OPTIONS.keys }
+
+      def self.label
+        "Give feedback on Content Publisher (Beta)"
+      end
+
+      def self.description
+        "Suggest changes to features within Content Publisher."
+      end
+
+      def feedback_type_options
+        OPTIONS.map { |key, value| [value, key] }
+      end
+    end
+  end
+end

--- a/app/models/zendesk/ticket/content_publisher_feedback_request_ticket.rb
+++ b/app/models/zendesk/ticket/content_publisher_feedback_request_ticket.rb
@@ -1,0 +1,23 @@
+module Zendesk
+  module Ticket
+    class ContentPublisherFeedbackRequestTicket < Zendesk::ZendeskTicket
+      def subject
+        "Content Publisher feedback request"
+      end
+
+      def tags
+        super + %w[content_publisher_feedback_request]
+      end
+
+    protected
+
+      def comment_snippets
+        [
+          Zendesk::LabelledSnippet.new(on: @request, field: :feedback_type, label: "Your feedback is about"),
+          Zendesk::LabelledSnippet.new(on: @request, field: :feedback_details, label: "Tell us a bit more"),
+          Zendesk::LabelledSnippet.new(on: @request, field: :impact_on_work, label: "What's the impact on your work if we don't do anything about it?"),
+        ]
+      end
+    end
+  end
+end

--- a/app/views/content_publisher_feedback_requests/_request_details.html.erb
+++ b/app/views/content_publisher_feedback_requests/_request_details.html.erb
@@ -1,0 +1,15 @@
+<div class="alert alert-info">
+  <p>Content Publisher is in private beta and supports most of the features that are available on Whitehall.</p>
+  <p>With this form you can tell us more about your experience with the new app so we can make it better. If you’re having issues publishing or editing a document raise a <a class="link-inherit" href="<%= new_technical_fault_report_path %>">support request</a> so you can get technical help.</p>
+</div>
+<div id="feedback-type">
+  <%= f.input :feedback_type, as: :radio, required: true, label: "Your feedback is about", collection: f.object.feedback_type_options, input_html: { :"aria-required" => true } %>
+  <%= f.input :feedback_details, as: :text, required: true,
+              label: "Tell us a bit more",
+              input_html: { class: "input-md-6", rows: 6, cols: 50, :"aria-required" => true } %>
+  <%= f.input :impact_on_work, as: :text, required: false,
+              label: "What's the impact on your work if we don't do anything about it?",
+              hint: "This information will help us prioritise changes and future work",
+              input_html: { class: "input-md-6", rows: 6, cols: 50, :"aria-required" => false } %>
+</div>
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/spec/features/content_publisher_feedback_requests_spec.rb
+++ b/spec/features/content_publisher_feedback_requests_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+feature "New Content Publisher feedback requests" do
+  let(:user) { create(:content_requester, name: "John Smith", email: "john.smith@agency.gov.uk") }
+
+  background do
+    login_as user
+    zendesk_has_no_user_with_email(user.email)
+  end
+
+  scenario "successful request" do
+    request = expect_zendesk_to_receive_ticket(
+      "subject" => "Content Publisher feedback request",
+      "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
+      "tags" => %w[govt_form content_publisher_feedback_request],
+      "comment" => {
+        "body" =>
+"[Your feedback is about]
+accessibility or usability
+
+[Tell us a bit more]
+I am having trouble reading the screen
+
+[What's the impact on your work if we don't do anything about it?]
+Cannot work"
+      }
+    )
+
+    user_provides_feedback(
+      feedback_type: "accessibility or usability",
+      description: "I am having trouble reading the screen",
+      impact_on_work: "Cannot work"
+    )
+
+    expect(request).to have_been_made
+  end
+
+private
+
+  def user_provides_feedback(details)
+    visit '/'
+    click_on "Give feedback on Content Publisher (Beta)"
+    expect(page).to have_content("Give feedback on Content Publisher (Beta)")
+    within "#feedback-type" do
+      choose "accessibility or usability"
+    end
+    fill_in "Tell us a bit more", with: details[:description]
+    fill_in "What's the impact on your work if we don't do anything about it?", with: details[:impact_on_work]
+    user_submits_the_request_successfully
+  end
+end

--- a/spec/models/support/requests/content_publisher_feedback_request_spec.rb
+++ b/spec/models/support/requests/content_publisher_feedback_request_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+module Support
+  module Requests
+    describe ContentPublisherFeedbackRequest do
+      def request(options = {})
+        ContentPublisherFeedbackRequest.new(options).tap(&:valid?)
+      end
+
+      it { should validate_presence_of(:feedback_type) }
+      it { should validate_presence_of(:feedback_details) }
+
+      it { should allow_value("accessibility or usability").for(:feedback_type) }
+      it { should allow_value("working unexpectedly").for(:feedback_type) }
+      it { should allow_value("helpful feature").for(:feedback_type) }
+      it { should allow_value("other").for(:feedback_type) }
+      it { should_not allow_value("xxx").for(:feedback_type) }
+
+      it { should allow_value("").for(:impact_on_work) }
+
+      it "provides type of change choices" do
+        expect(request.feedback_type_options).to_not be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Putting in a new support feedback page for the content publisher.

These show the changes that were made to the support app to add a new support page.  Wherever possible in the code and the tests, I've borrowed conventions from how the other pages.