### PR TITLE
Remove redundant Redis connection configuration

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,9 +1,0 @@
-development:
-  host: localhost
-  port: 6379
-test:
-  host: localhost
-  port: 6379
-production:
-  host: <%= ENV["REDIS_HOST"] %>
-  port: <%= ENV["REDIST_PORT"] %>

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -6,12 +6,6 @@ class RedisClient
   attr_reader :connection
 
   def initialize
-    @connection = Redis.new(config.symbolize_keys)
-  end
-
-private
-
-  def config
-    Rails.application.config_for(:redis)
+    @connection = Redis.new
   end
 end


### PR DESCRIPTION
The Redis client will use the environment variables by defualt, and
also knows the correct default values, so it's unnecessary to have a
Redis configuration file.

Also, I'm pretty sure nothing is specifying REDIST_PORT...