### PR TITLE
Add feedback form for the content data admin

### DIFF
--- a/app/controllers/content_data_feedback_controller.rb
+++ b/app/controllers/content_data_feedback_controller.rb
@@ -1,0 +1,26 @@
+class ContentDataFeedbackController < RequestsController
+protected
+
+  def new_request
+    Support::Requests::ContentDataFeedback.new
+  end
+
+  def zendesk_ticket_class
+    Zendesk::Ticket::ContentDataFeedbackTicket
+  end
+
+  def parse_request_from_params
+    Support::Requests::ContentDataFeedback.new(content_data_feedback_params)
+  end
+
+  def content_data_feedback_params
+    params.require(
+      :support_requests_content_data_feedback
+    ).permit(
+      :feedback_type,
+      :feedback_details,
+      :impact_on_work,
+      requester_attributes: %i[email name collaborator_emails],
+    ).to_h
+  end
+end

--- a/app/models/support/navigation/section_groups.rb
+++ b/app/models/support/navigation/section_groups.rb
@@ -10,7 +10,7 @@ module Support
           Support::Navigation::SectionGroup.new("Technical support", sections_for(Support::Requests::ChangesToPublishingAppsRequest, Support::Requests::TechnicalFaultReport)),
           Support::Navigation::SectionGroup.new("User access", sections_for(Support::Requests::AccountsPermissionsAndTrainingRequest, Support::Requests::RemoveUserRequest)),
           Support::Navigation::SectionGroup.new("Campaigns", sections_for(Support::Requests::CampaignRequest, Support::Requests::LiveCampaignRequest)),
-          Support::Navigation::SectionGroup.new("Feedback for tools in Beta", sections_for(Support::Requests::ContentPublisherFeedbackRequest)),
+          Support::Navigation::SectionGroup.new("Feedback for tools in Beta", sections_for(Support::Requests::ContentPublisherFeedbackRequest, Support::Requests::ContentDataFeedback)),
           Support::Navigation::SectionGroup.new("Taxonomy requests", sections_for(Support::Requests::TaxonomyNewTopicRequest, Support::Requests::TaxonomyChangeTopicRequest)),
           Support::Navigation::SectionGroup.new("Other requests", sections_for(Support::Requests::AnalyticsRequest, Support::Requests::GeneralRequest)),
         ]

--- a/app/models/support/permissions/ability.rb
+++ b/app/models/support/permissions/ability.rb
@@ -12,6 +12,7 @@ module Support
         can :create, [Support::Requests::GeneralRequest, Support::Requests::TechnicalFaultReport, Support::Requests::Anonymous::Explore]
         can :create, [Support::Requests::TaxonomyNewTopicRequest, Support::Requests::TaxonomyChangeTopicRequest]
         can :create, Support::Requests::ContentPublisherFeedbackRequest
+        can :create, Support::Requests::ContentDataFeedback
         can :create, :all if user.has_permission?('single_points_of_contact')
         can :create, [Support::Requests::CampaignRequest, Support::Requests::LiveCampaignRequest] if user.has_permission?('campaign_requesters')
         if user.has_permission?('content_requesters')

--- a/app/models/support/requests/content_data_feedback.rb
+++ b/app/models/support/requests/content_data_feedback.rb
@@ -1,0 +1,33 @@
+require 'active_support/core_ext'
+
+module Support
+  module Requests
+    class ContentDataFeedback < Request
+      attr_accessor :feedback_type, :feedback_details, :impact_on_work
+
+      OPTIONS = {
+        "accessibility or usability" => "accessibility or usability",
+        "working unexpectedly" => "something working differently than you expected",
+        "helpful feature" => "a feature that would help you with your work",
+        "helpful metric" => "a metric that would help you with your work",
+        "data looking wrong" => "the data looking wrong",
+        "other" => "something else",
+      }.freeze
+
+      validates_presence_of :feedback_type, :feedback_details
+      validates :feedback_type, inclusion: { in: OPTIONS.keys }
+
+      def self.label
+        "Give feedback on Content Data (Beta)"
+      end
+
+      def self.description
+        "Suggest changes to the data tool."
+      end
+
+      def feedback_type_options
+        OPTIONS.map { |key, value| [value, key] }
+      end
+    end
+  end
+end

--- a/app/models/zendesk/ticket/content_data_feedback_ticket.rb
+++ b/app/models/zendesk/ticket/content_data_feedback_ticket.rb
@@ -1,0 +1,35 @@
+module Zendesk
+  module Ticket
+    class ContentDataFeedbackTicket < Zendesk::ZendeskTicket
+      def subject
+        "Content Data feedback"
+      end
+
+      def tags
+        super + %w[content_data_feedback]
+      end
+
+    protected
+
+      def comment_snippets
+        [
+          Zendesk::LabelledSnippet.new(
+            on: @request,
+            field: :feedback_type,
+            label: "Your feedback is about"
+          ),
+          Zendesk::LabelledSnippet.new(
+            on: @request,
+            field: :feedback_details,
+            label: "Tell us a bit more"
+          ),
+          Zendesk::LabelledSnippet.new(
+            on: @request,
+            field: :impact_on_work,
+            label: "What's the impact on your work if we don't do anything about it?"
+          ),
+        ]
+      end
+    end
+  end
+end

--- a/app/views/content_data_feedback/_request_details.html.erb
+++ b/app/views/content_data_feedback/_request_details.html.erb
@@ -1,0 +1,37 @@
+<p class="alert alert-info">
+  Content Data is in private beta. With this form you can tell us
+  about your experience using the new data tool, so we can make it
+  better.
+</p>
+<div id="feedback-type">
+  <%= f.input(
+    :feedback_type,
+    as: :radio,
+    required: true,
+    label: "Your feedback is about",
+    collection: f.object.feedback_type_options,
+    input_html: { :"aria-required" => true }
+  ) %>
+  <%= f.input(
+    :feedback_details,
+    as: :text,
+    required: true,
+    label: "Tell us a bit more",
+    input_html: { class: "input-md-6", rows: 6, cols: 50, :"aria-required" => true }
+  ) %>
+  <%= f.input(
+    :impact_on_work,
+    as: :text,
+    required: false,
+    label: "What's the impact on your work if we don't do anything about it?",
+    hint: "This information will help us prioritise changes and future work",
+    input_html: { class: "input-md-6", rows: 6, cols: 50, :"aria-required" => false }
+  ) %>
+</div>
+
+<p class="alert alert-info">
+  To add screenshots to this feedback, reply to the acknowledgement
+  email you receive and attach them.
+</p>
+
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.uncountable %w( feedback )
+  inflect.irregular 'feedback', 'feedback'
 end
 
 # These inflection rules are supported but not enabled by default:

--- a/spec/features/content_data_feedback_spec.rb
+++ b/spec/features/content_data_feedback_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+feature 'New Content Data feedback' do
+  let(:user) do
+    create(:content_requester, name: 'John Smith', email: 'john.smith@agency.gov.uk')
+  end
+
+  background do
+    login_as user
+    zendesk_has_no_user_with_email(user.email)
+  end
+
+  scenario 'successful request' do
+    request = expect_zendesk_to_receive_ticket(
+      'subject' => 'Content Data feedback',
+      'requester' => hash_including('name' => 'John Smith', 'email' => 'john.smith@agency.gov.uk'),
+      'tags' => %w[govt_form content_data_feedback],
+      'comment' => {
+        'body' =>
+"[Your feedback is about]
+accessibility or usability
+
+[Tell us a bit more]
+I am having trouble reading the screen
+
+[What's the impact on your work if we don't do anything about it?]
+Cannot work"
+      }
+    )
+
+    user_provides_feedback(
+      feedback_type: 'accessibility or usability',
+      description: 'I am having trouble reading the screen',
+      impact_on_work: 'Cannot work'
+    )
+
+    expect(request).to have_been_made
+  end
+
+private
+
+  def user_provides_feedback(details)
+    visit '/'
+    click_on 'Give feedback on Content Data (Beta)'
+    expect(page).to have_content('Give feedback on Content Data (Beta)')
+    within '#feedback-type' do
+      choose 'accessibility or usability'
+    end
+    fill_in 'Tell us a bit more', with: details[:description]
+    fill_in "What's the impact on your work if we don't do anything about it?", with: details[:impact_on_work]
+    user_submits_the_request_successfully
+  end
+end

--- a/spec/models/support/requests/content_data_feedback_spec.rb
+++ b/spec/models/support/requests/content_data_feedback_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+module Support
+  module Requests
+    describe ContentDataFeedback do
+      it { should validate_presence_of(:feedback_type) }
+      it { should validate_presence_of(:feedback_details) }
+
+      it { should allow_value("accessibility or usability").for(:feedback_type) }
+      it { should allow_value("working unexpectedly").for(:feedback_type) }
+      it { should allow_value("helpful feature").for(:feedback_type) }
+      it { should allow_value("other").for(:feedback_type) }
+      it { should_not allow_value("xxx").for(:feedback_type) }
+
+      it { should allow_value("").for(:impact_on_work) }
+    end
+  end
+end

--- a/spec/models/zendesk/ticket/content_data_feedback_ticket_spec.rb
+++ b/spec/models/zendesk/ticket/content_data_feedback_ticket_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+module Zendesk
+  module Ticket
+    describe ContentDataFeedbackTicket do
+      let(:ticket) do
+        ContentDataFeedbackTicket.new(double(requester: nil))
+      end
+
+      it "has a default subject" do
+        expect(ticket.subject).to eq("Content Data feedback")
+      end
+
+      it 'includes a "content_data_feedback" tag' do
+        expect(ticket.tags).to include("content_data_feedback")
+      end
+    end
+  end
+end


### PR DESCRIPTION
![screen shot 2018-11-29 at 13 18 04](https://user-images.githubusercontent.com/1130010/49224377-38ba8200-f3d9-11e8-8353-b4bab248c8fe.png)

https://trello.com/c/Vn3YwWXl/874-3-build-a-new-form-in-the-support-app-for-content-data