### PR TITLE
Move CSV exports to S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rails', '5.2.2'
 
 gem 'bootstrap-kaminari-views', '0.0.5'
 gem 'cancancan', '~> 2.3'
+gem 'fog-aws', '~> 3.3'
 gem 'formtastic-bootstrap', '3.1.1'
 gem 'gretel', '3.0.9'
 gem 'jc-validates_timeliness', '3.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
+    excon (0.62.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -87,6 +88,23 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
+    fog-aws (3.3.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.1.2)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic-bootstrap (3.1.1)
@@ -142,6 +160,7 @@ GEM
     i18n (1.2.0)
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
+    ipaddress (0.8.3)
     jaro_winkler (1.5.1)
     jasmine (3.3.0)
       jasmine-core (~> 3.3.0)
@@ -416,6 +435,7 @@ DEPENDENCIES
   cancancan (~> 2.3)
   capybara (~> 3.12)
   factory_bot_rails
+  fog-aws (~> 3.3)
   formtastic-bootstrap (= 3.1.1)
   gds-api-adapters (~> 55.0)
   gds-sso (~> 14.0)
@@ -449,4 +469,4 @@ DEPENDENCIES
   webmock (~> 3.4.2)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -15,7 +15,9 @@ class AnonymousFeedback::ExportRequestsController < AuthorisationController
 
     response = support_api.feedback_export_request(params[:id])
     if response["ready"]
-      send_file "/data/uploads/support-api/csvs/#{response['filename']}"
+      filename = response['filename']
+      file = get_csv_file_from_s3(filename)
+      send_data(file, filename: filename)
     else
       head :not_found
     end
@@ -52,5 +54,20 @@ private
 
   def support_api
     GdsApi::SupportApi.new(Plek.find("support-api"))
+  end
+
+  def get_csv_file_from_s3(filename)
+    connection = Fog::Storage.new(
+      provider: 'AWS',
+      region: ENV['AWS_REGION'],
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+    )
+
+    directory = connection.directories.get(ENV['AWS_S3_BUCKET_NAME'])
+
+    file = directory.files.get(filename)
+
+    file.body
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -37,26 +37,6 @@
       "user_input": "(Unresolved Model).new.url",
       "confidence": "Weak",
       "note": "This is not an issue as it comes from a new instance of a model."
-    },
-    {
-      "warning_type": "File Access",
-      "warning_code": 16,
-      "fingerprint": "9e73fe0915c1416875f85b7e5dc3b1b436fd3e2a16c915c7072b502d1c4f12a5",
-      "check_name": "SendFile",
-      "message": "Parameter value used in file name",
-      "file": "app/controllers/anonymous_feedback/export_requests_controller.rb",
-      "line": 18,
-      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(\"/data/uploads/support-api/csvs/#{support_api.feedback_export_request(params[:id])[\"filename\"]}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "AnonymousFeedback::ExportRequestsController",
-        "method": "show"
-      },
-      "user_input": "params[:id]",
-      "confidence": "Weak",
-      "note": "It doesn't come directly from a parameter, instead it comes from a reponse from the Support API which we can trust."
     }
   ],
   "updated": "2018-08-02 15:31:34 +0100",


### PR DESCRIPTION
This commit changes the support app to retrieve CSV exports from S3.

Depends on https://github.com/alphagov/support-api/pull/263