### PR TITLE
Add data.gov.uk to 'Report a technical fault to GDS'

### DIFF
--- a/app/models/support/gds/user_facing_components.rb
+++ b/app/models/support/gds/user_facing_components.rb
@@ -22,6 +22,7 @@ module Support
             { name: "Travel Advice Publisher", id: "travel_advice_publisher" },
             { name: "Specialist Publisher", id: "specialist_publisher" },
             { name: "Content Publisher (beta)", id: "content_publisher" },
+            { name: "data.gov.uk", id: "datagovuk" },
           ]
         end
       end


### PR DESCRIPTION
2nd line have received a number of tickets recently where the requester has selected 'Specialist Publisher' when they are using data.gov.uk.  Adding a new option to reduce the chance of confusion when these tickets are received.