### PR TITLE
Add bearer tokens for support-api authentication

### DIFF
--- a/app/controllers/anonymous_feedback/document_types_controller.rb
+++ b/app/controllers/anonymous_feedback/document_types_controller.rb
@@ -23,6 +23,9 @@ private
   end
 
   def support_api
-    GdsApi::SupportApi.new(Plek.find("support-api"))
+    GdsApi::SupportApi.new(
+      Plek.find("support-api"),
+      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
+    )
   end
 end

--- a/app/controllers/anonymous_feedback/explore_controller.rb
+++ b/app/controllers/anonymous_feedback/explore_controller.rb
@@ -39,7 +39,10 @@ class AnonymousFeedback::ExploreController < AuthorisationController
 private
 
   def support_api
-    GdsApi::SupportApi.new(Plek.find("support-api"))
+    GdsApi::SupportApi.new(
+      Plek.find("support-api"),
+      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
+    )
   end
 
   # TODO: explicitly permit the right set of params, rather than everything

--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -53,7 +53,10 @@ private
   end
 
   def support_api
-    GdsApi::SupportApi.new(Plek.find("support-api"))
+    GdsApi::SupportApi.new(
+      Plek.find("support-api"),
+      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
+    )
   end
 
   def get_csv_file_from_s3(filename)

--- a/app/controllers/anonymous_feedback/global_export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/global_export_requests_controller.rb
@@ -22,7 +22,10 @@ private
   end
 
   def support_api
-    GdsApi::SupportApi.new(Plek.find("support-api"))
+    GdsApi::SupportApi.new(
+      Plek.find("support-api"),
+      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
+    )
   end
 
   def exclude_spam?

--- a/app/controllers/anonymous_feedback/organisations_controller.rb
+++ b/app/controllers/anonymous_feedback/organisations_controller.rb
@@ -23,6 +23,9 @@ private
   end
 
   def support_api
-    GdsApi::SupportApi.new(Plek.find("support-api"))
+    GdsApi::SupportApi.new(
+      Plek.find("support-api"),
+      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
+    )
   end
 end

--- a/app/controllers/anonymous_feedback/problem_reports_controller.rb
+++ b/app/controllers/anonymous_feedback/problem_reports_controller.rb
@@ -43,7 +43,10 @@ private
   end
 
   def support_api
-    GdsApi::SupportApi.new(Plek.find("support-api"))
+    GdsApi::SupportApi.new(
+      Plek.find("support-api"),
+      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
+    )
   end
 
   def index_params

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -104,6 +104,9 @@ private
   end
 
   def support_api
-    GdsApi::SupportApi.new(Plek.find("support-api"))
+    GdsApi::SupportApi.new(
+      Plek.find("support-api"),
+      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
+    )
   end
 end

--- a/app/presenters/scope_filters_presenter.rb
+++ b/app/presenters/scope_filters_presenter.rb
@@ -100,6 +100,9 @@ private
   end
 
   def support_api
-    GdsApi::SupportApi.new(Plek.find("support-api"))
+    GdsApi::SupportApi.new(
+      Plek.find("support-api"),
+      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
+    )
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/WR2MNxo6

Related to: 
* https://github.com/alphagov/govuk-puppet/pull/8479
* https://github.com/alphagov/support-api/pull/266

Passes the bearer token needed to authenticate with support-api using signon.