### PR TITLE
Optional secondary contacts

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -1,5 +1,5 @@
 require 'sidekiq/api'
-
+require 'emergency_contact_details'
 class SupportController < AuthorisationController
   skip_authorization_check
   skip_before_action :authenticate_support_user!, only: [:queue_status]
@@ -11,10 +11,11 @@ class SupportController < AuthorisationController
   end
 
   def emergency_contact_details
-    @primary_contact_details = EMERGENCY_CONTACT_DETAILS[:primary_contacts]
-    @secondary_contact_details = EMERGENCY_CONTACT_DETAILS[:secondary_contacts]
-    @verify_contact_details = EMERGENCY_CONTACT_DETAILS[:verify_contacts]
-    @current_at = Date.parse(EMERGENCY_CONTACT_DETAILS[:current_at])
+    emergency_contact_details = EmergencyContactDetails.fetch
+    @primary_contact_details = emergency_contact_details[:primary_contacts]
+    @secondary_contact_details = emergency_contact_details[:secondary_contacts]
+    @verify_contact_details = emergency_contact_details[:verify_contacts]
+    @current_at = Date.parse(emergency_contact_details[:current_at])
   end
 
   def acknowledge

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -1,5 +1,4 @@
 require 'sidekiq/api'
-require 'emergency_contact_details'
 class SupportController < AuthorisationController
   skip_authorization_check
   skip_before_action :authenticate_support_user!, only: [:queue_status]

--- a/app/lib/emergency_contact_details.rb
+++ b/app/lib/emergency_contact_details.rb
@@ -1,10 +1,10 @@
 class EmergencyContactDetails
   def self.fetch
-    if ENV["EMERGENCY_CONTACT_DETAILS"]
-      config = JSON.parse(ENV["EMERGENCY_CONTACT_DETAILS"])
-    else
-      config = JSON.load(Rails.root.join("config", "emergency_contact_details.json"))
-    end
+    config = if ENV["EMERGENCY_CONTACT_DETAILS"]
+               JSON.parse(ENV["EMERGENCY_CONTACT_DETAILS"])
+             else
+               JSON.parse(File.load(Rails.root.join("config", "emergency_contact_details.json")))
+             end
     ActiveSupport::HashWithIndifferentAccess.new(config)
   end
 end

--- a/app/lib/emergency_contact_details.rb
+++ b/app/lib/emergency_contact_details.rb
@@ -1,0 +1,10 @@
+class EmergencyContactDetails
+  def self.fetch
+    if ENV["EMERGENCY_CONTACT_DETAILS"]
+      config = JSON.parse(ENV["EMERGENCY_CONTACT_DETAILS"])
+    else
+      config = JSON.load(Rails.root.join("config", "emergency_contact_details.json"))
+    end
+    ActiveSupport::HashWithIndifferentAccess.new(config)
+  end
+end

--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -104,26 +104,28 @@
 
 </section>
 
-<section class="add-bottom-padding add-top-padding">
-  <h3>Backup contact</h3>
-  <div class="row">
-    <div class="col-md-6">
-      <p>If you can’t get through on the other numbers, you can call the Head of GOV.UK.</p>
+<% if @secondary_contact_details %>
+    <section class="add-bottom-padding add-top-padding">
+    <h3>Backup contact</h3>
+    <div class="row">
+        <div class="col-md-6">
+        <p>If you can’t get through on the other numbers, you can call the Head of GOV.UK.</p>
+        </div>
     </div>
-  </div>
-  <div class="row">
-    <% @secondary_contact_details.each do |details| %>
-      <div class="col-md-6 add-bottom-padding">
-        <p>
-          <%= details[:name] %><br>
-          <span class="text-muted"><%= details[:role] %></span>
-        </p>
-        <%= mail_to details[:email] %>
-        <p><strong><%= details[:phone] %></strong></p>
-      </div>
-    <% end %>
-  </div>
-</section>
+    <div class="row">
+        <% @secondary_contact_details.each do |details| %>
+        <div class="col-md-6 add-bottom-padding">
+            <p>
+            <%= details[:name] %><br>
+            <span class="text-muted"><%= details[:role] %></span>
+            </p>
+            <%= mail_to details[:email] %>
+            <p><strong><%= details[:phone] %></strong></p>
+        </div>
+        <% end %>
+    </div>
+    </section>
+<% end %>
 
 <section class="add-bottom-padding add-top-padding">
   <h2>GOV.UK Verify contacts</h2>

--- a/config/initializers/emergency_contact_details.rb
+++ b/config/initializers/emergency_contact_details.rb
@@ -1,7 +1,0 @@
-if ENV["EMERGENCY_CONTACT_DETAILS"]
-  config = JSON.parse(ENV["EMERGENCY_CONTACT_DETAILS"])
-else
-  config = JSON.load(Rails.root.join("config", "emergency_contact_details.json"))
-end
-
-EMERGENCY_CONTACT_DETAILS = ActiveSupport::HashWithIndifferentAccess.new(config)

--- a/spec/features/emergency_contact_details_spec.rb
+++ b/spec/features/emergency_contact_details_spec.rb
@@ -13,17 +13,37 @@ feature "Emergency contact details" do
     allow(ENV).to receive(:[]).with(anything)
     allow(ENV).to receive(:[])
       .with("EMERGENCY_CONTACT_DETAILS")
-      .and_return(
-        File.read(Rails.root.join("config", "emergency_contact_details.json"))
-      )
+      .and_return(contacts_json)
   end
 
-  scenario "access the emergency contact details" do
-    visit '/'
+  context 'with all contacts supplied' do
+    let(:contacts_json) do
+      File.read(Rails.root.join("config", "emergency_contact_details.json"))
+    end
 
-    click_on "Emergency contact details"
+    scenario "access the emergency contact details" do
+      visit '/'
 
-    expect(page).to have_content("05555 555 555") # Billy Director
-    expect(page).to have_content("05555 555 556") # Bob Manager
+      click_on "Emergency contact details"
+
+      expect(page).to have_content("05555 555 555") # Billy Director
+      expect(page).to have_content("05555 555 556") # Bob Manager
+    end
+  end
+
+  context 'when secondary contacts are missing' do
+    let(:contacts_json) do
+      contacts = JSON.parse File.read(Rails.root.join("config", "emergency_contact_details.json"))
+      contacts.reject { |k, _| k == 'secondary_contacts' }.to_json
+    end
+
+    scenario "access the emergency contact details" do
+      visit '/'
+
+      click_on "Emergency contact details"
+
+      expect(page).to have_content("National emergency publishing")
+      expect(page).not_to have_content("05555 555 556") # Bob Manager
+    end
   end
 end


### PR DESCRIPTION
We have a request to remove a secondary contact.

This commit allows the emergency-contacts page to 
render when `secondary_contacts` is missing from the JSON.

Trello: https://trello.com/c/6WGS32f2/403-delete-jen-allums-details-from-the-govuk-publishing-support-page