### PR TITLE
Unpublish content mentions Content Publisher

### DIFF
--- a/app/views/unpublish_content_requests/_request_details.html.erb
+++ b/app/views/unpublish_content_requests/_request_details.html.erb
@@ -2,7 +2,7 @@
   <p>Please make a separate request for each target redirect.</p>
 </div>
 
-<%= f.input :urls, as: :text, required: true, label: "Please give the Whitehall URL of the page you wish to have unpublished (you can specify more than one URL, as long as it's clear where each URL should be redirected)", input_html: { class: "input-md-8", placeholder: "https://whitehall-admin.production.alphagov.co.uk/government/admin/...", rows: 6, cols: 50, :"aria-required" => true } %>
+<%= f.input :urls, as: :text, required: true, label: "Please give the Whitehall or Content Publisher URL of the page you wish to have unpublished (you can specify more than one URL, as long as it's clear where each URL should be redirected)", input_html: { class: "input-md-8", placeholder: "https://whitehall-admin.production.alphagov.co.uk/government/admin/...", rows: 6, cols: 50, :"aria-required" => true } %>
 
 <div class="alert alert-info">
   <p>You may also wish to send this information in a spreadsheet, by attaching it to the Zendesk confirmation email.

--- a/spec/features/unpublish_content_requests_spec.rb
+++ b/spec/features/unpublish_content_requests_spec.rb
@@ -83,7 +83,7 @@ true"
 
     expect(page).to have_content("Please make a separate request for each target redirect.")
 
-    fill_in "Please give the Whitehall URL of the page you wish to have unpublished (you can specify more than one URL, as long as it's clear where each URL should be redirected)", with: details[:url]
+    fill_in "Please give the Whitehall or Content Publisher URL of the page you wish to have unpublished (you can specify more than one URL, as long as it's clear where each URL should be redirected)", with: details[:url]
 
     within "#unpublish-reason" do
       choose details[:reason]


### PR DESCRIPTION
Trello: https://trello.com/c/8F7PqB3E/505-the-unpublishing-support-form-has-been-updated-to-include-instructions-for-content-publisher-as-well-as-whitehall

This is a minor change to make the unpublish content request form mention Content Publisher as well as Whitehall. Since Content Publisher is expected to be used by same users as Content Publisher, and we don't have means for them to unpublish themselves, this is intended to make this form feel less Whitehall specific