### PR TITLE
Add linting to the default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,10 @@ require File.expand_path('../config/application', __FILE__)
 
 Support::Application.load_tasks
 
-task :default => [:spec, 'jasmine:ci']
+Rake::Task['default'].clear
+
+task :default do
+  Rake::Task['lint'].invoke
+  Rake::Task['spec'].invoke
+  Rake::Task['jasmine:ci'].invoke
+end


### PR DESCRIPTION
The lint task is not run by default.

This means you don't find out about linting errors until CI.

We want to `fail fast` so adding linting as part of the default
rake task.