### PR TITLE
Add pinning to business readiness form

### DIFF
--- a/app/controllers/eu_exit_business_readiness_requests_controller.rb
+++ b/app/controllers/eu_exit_business_readiness_requests_controller.rb
@@ -19,6 +19,7 @@ protected
     ).permit(
       :type,
       :url,
+      :pinned_content,
       :explanation,
       :employing_eu_citizens,
       :personal_data,

--- a/app/models/support/requests/eu_exit_business_readiness_request.rb
+++ b/app/models/support/requests/eu_exit_business_readiness_request.rb
@@ -5,12 +5,17 @@ module Support
     class EuExitBusinessReadinessRequest < Request
       attr_accessor :type, :url, :explanation, :sector, :business_activity,
         :employing_eu_citizens, :personal_data, :intellectual_property,
-        :funding_schemes, :public_sector_procurement
+        :funding_schemes, :public_sector_procurement, :pinned_content
 
       TYPE_OPTIONS = {
         "adding content" => "Adding content to the finder",
         "update tagging" => "Update to tagging",
         "removing content" => "Removing content from the finder",
+      }.freeze
+
+      PINNED_CONTENT_OPTIONS = {
+        "yes" => "Yes",
+        "no" => "No",
       }.freeze
 
       SECTOR_OPTIONS = {
@@ -108,6 +113,10 @@ module Support
 
       def type_options
         TYPE_OPTIONS.map { |key, value| [value, key] }
+      end
+
+      def pinned_content_options
+        PINNED_CONTENT_OPTIONS.map { |key, value| [value, key] }
       end
 
       def sector_options

--- a/app/models/zendesk/ticket/eu_exit_business_readiness_ticket.rb
+++ b/app/models/zendesk/ticket/eu_exit_business_readiness_ticket.rb
@@ -19,7 +19,7 @@ module Zendesk
 
       def fields
         %w(
-          type url explanation sector business_activity employing_eu_citizens
+          type url pinned_content explanation sector business_activity employing_eu_citizens
           personal_data intellectual_property funding_schemes
           public_sector_procurement
         )

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -120,4 +120,19 @@
   required: false,
 ) %>
 
+<h2>Pinned content</h2>
+<p>
+    Pinned content is shown at the top of the results in the business readiness finder
+    when certain filters are selected and the content has been tagged to that filter.
+</p>
+<p>
+    Content should only be pinned if it gives a high level summary of what the sector or policy area is about.
+</p>
+<%= f.input(
+    :pinned_content,
+    as: :radio,
+    label: 'Does this content need to be pinned at the top of the results list?',
+    collection: f.object.pinned_content_options
+) %>
+
 <%= render partial: "support/collaborators", locals: { f: f } %>

--- a/spec/features/eu_exit_business_readiness_request_spec.rb
+++ b/spec/features/eu_exit_business_readiness_request_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+feature 'New EU Exit Business Readiness Finder request' do
+  let(:user) do
+    create(:content_requester, name: 'John Smith', email: 'john.smith@agency.gov.uk')
+  end
+
+  background do
+    login_as user
+    zendesk_has_no_user_with_email(user.email)
+  end
+
+  scenario 'sucessful request for adding content' do
+    request = expect_zendesk_to_receive_ticket(
+      'subject' => 'EU Exit Business Readiness - /some/base/path',
+      'priority' => 'normal',
+      'requester' => hash_including('name' => 'John Smith', 'email' => 'john.smith@agency.gov.uk'),
+      'tags' =>  %w[govt_form business_readiness dapper govt_form eu_exit],
+      'comment' => {
+        'body' =>
+"[Type]
+adding content
+
+[Url]
+/some/base/path
+
+[Sector]
+
+aerospace
+
+[Business activity]
+
+buying
+selling
+
+[Employing eu citizens]
+yes
+
+[Intellectual property]
+
+
+[Funding schemes]
+
+
+[Public sector procurement]
+
+civil-government-contracts"
+      }
+    )
+
+    user_requests_update(
+      request_type: 'Adding content to the finder'
+    )
+
+    expect(request).to have_been_made
+  end
+
+private
+
+  def user_requests_update(details)
+    page_title = 'Request updates to content in the EU Exit business readiness finder'
+    visit '/'
+    click_on page_title
+    expect(page).to have_content(page_title)
+    within '#support_requests_eu_exit_business_readiness_request_type_input' do
+      choose details[:request_type]
+    end
+    within '#support_requests_eu_exit_business_readiness_request_sector_input' do
+      check 'Aerospace'
+    end
+    within '#support_requests_eu_exit_business_readiness_request_business_activity_input' do
+      check 'Buying products or goods from abroad'
+      check 'Selling products or goods abroad'
+    end
+    within '#support_requests_eu_exit_business_readiness_request_employing_eu_citizens_input' do
+      choose 'Yes'
+    end
+    within '#support_requests_eu_exit_business_readiness_request_public_sector_procurement_input' do
+      check 'Civil government contracts'
+    end
+    fill_in 'URL of content', with: '/some/base/path'
+    user_submits_the_request_successfully
+  end
+end

--- a/spec/features/eu_exit_business_readiness_request_spec.rb
+++ b/spec/features/eu_exit_business_readiness_request_spec.rb
@@ -24,6 +24,9 @@ adding content
 [Url]
 /some/base/path
 
+[Pinned content]
+yes
+
 [Sector]
 
 aerospace
@@ -64,6 +67,9 @@ private
     expect(page).to have_content(page_title)
     within '#support_requests_eu_exit_business_readiness_request_type_input' do
       choose details[:request_type]
+    end
+    within '#support_requests_eu_exit_business_readiness_request_pinned_content_input' do
+      choose 'Yes'
     end
     within '#support_requests_eu_exit_business_readiness_request_sector_input' do
       check 'Aerospace'


### PR DESCRIPTION
When creating the Zendesk ticket to add content to the business
finder. We want to be able to specify if the content should
be pinned.

This PR allows the user to specify this in the support form.
The resulting ZenDesk ticket will have this information.

Trello: https://trello.com/c/rEBhX1IB/190-add-a-pinning-option-to-the-business-readiness-support-form