### PR TITLE
Store anonymous feedback paths in Redis

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
---require spec_helper
+--color
+--require rails_helper

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -51,7 +51,8 @@ private
     if params[:path].present?
       params[:paths] = [params[:path]]
     elsif params[:paths] && params[:paths].instance_of?(String)
-      params[:paths] = params[:paths].split(',').map(&:strip)
+      saved_paths = Support::Requests::Anonymous::Paths.find(params[:paths])
+      params[:paths] = saved_paths&.paths || params[:paths].split(',').map(&:strip)
     end
   end
 

--- a/app/models/support.rb
+++ b/app/models/support.rb
@@ -1,0 +1,1 @@
+module Support; end

--- a/app/models/support/requests.rb
+++ b/app/models/support/requests.rb
@@ -1,0 +1,1 @@
+module Support::Requests; end

--- a/app/models/support/requests/anonymous.rb
+++ b/app/models/support/requests/anonymous.rb
@@ -1,0 +1,1 @@
+module Support::Requests::Anonymous; end

--- a/app/models/support/requests/anonymous/explore.rb
+++ b/app/models/support/requests/anonymous/explore.rb
@@ -16,7 +16,10 @@ module Support
         validate :urls_are_well_formed
 
         def redirect_path
-          Rails.application.routes.url_helpers.anonymous_feedback_index_path(paths: paths_from_urls)
+          saved_paths = Paths.new(paths_from_urls)
+          saved_paths.save
+
+          Rails.application.routes.url_helpers.anonymous_feedback_index_path(paths: saved_paths.id)
         end
 
         # correct user's URL entries to give them what they're after
@@ -32,7 +35,7 @@ module Support
             path = URI(url).path.sub(/^(http(s)?(:)?(\/)+?(:)?)?((\/)?www.)?gov.uk/, '')
             urls << (path.start_with?('/') ? path : "/#{path}")
           end
-          urls.uniq.join(', ')
+          urls.uniq
         end
 
         def parsed_urls

--- a/app/models/support/requests/anonymous/paths.rb
+++ b/app/models/support/requests/anonymous/paths.rb
@@ -1,0 +1,35 @@
+require "redis_client"
+
+module Support::Requests::Anonymous
+  class Paths
+    EXPIRATION_TTL = 7.days
+
+    def initialize(paths, id = nil)
+      @id = id || SecureRandom.hex(10)
+      @paths = paths
+    end
+
+    attr_reader :id, :paths
+
+    def save
+      key = Paths.redis_key(id: id)
+      Paths.redis.setex(key, EXPIRATION_TTL, paths.to_json)
+    end
+
+    def self.find(id)
+      key = redis_key(id: id)
+      paths = JSON.parse(redis.get(key))
+      Paths.new(paths, id)
+    rescue TypeError
+      nil
+    end
+
+    def self.redis_key(id:)
+      "anonymous-paths:#{id}"
+    end
+
+    def self.redis
+      RedisClient.instance.connection
+    end
+  end
+end

--- a/app/models/support/requests/anonymous/paths.rb
+++ b/app/models/support/requests/anonymous/paths.rb
@@ -1,35 +1,33 @@
 require "redis_client"
 
-module Support::Requests::Anonymous
-  class Paths
-    EXPIRATION_TTL = 7.days
+class Support::Requests::Anonymous::Paths
+  EXPIRATION_TTL = 7.days
 
-    def initialize(paths, id = nil)
-      @id = id || SecureRandom.hex(10)
-      @paths = paths
-    end
+  def initialize(paths, id = nil)
+    @id = id || SecureRandom.hex(10)
+    @paths = paths
+  end
 
-    attr_reader :id, :paths
+  attr_reader :id, :paths
 
-    def save
-      key = Paths.redis_key(id: id)
-      Paths.redis.setex(key, EXPIRATION_TTL, paths.to_json)
-    end
+  def save
+    key = self.class.redis_key(id: id)
+    self.class.redis.setex(key, EXPIRATION_TTL, paths.to_json)
+  end
 
-    def self.find(id)
-      key = redis_key(id: id)
-      paths = JSON.parse(redis.get(key))
-      Paths.new(paths, id)
-    rescue TypeError
-      nil
-    end
+  def self.find(id)
+    key = redis_key(id: id)
+    paths = JSON.parse(redis.get(key))
+    new(paths, id)
+  rescue TypeError
+    nil
+  end
 
-    def self.redis_key(id:)
-      "anonymous-paths:#{id}"
-    end
+  def self.redis_key(id:)
+    "anonymous-paths:#{id}"
+  end
 
-    def self.redis
-      RedisClient.instance.connection
-    end
+  def self.redis
+    RedisClient.instance.connection
   end
 end

--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -20,7 +20,7 @@
 <div class="row">
   <div class="col-lg-8 col-md-9">
     <div class="panel panel-default">
-      <%= form_tag(anonymous_feedback_index_path, class: "date-filter-form panel-body", novalidate: true, method: :get) do %>
+      <%= form_tag(anonymous_feedback_index_path, class: "date-filter-form panel-body", novalidate: true, method: :post) do %>
         <fieldset class="form-group" data-edit-feedback-explorer-form-target>
           <legend class="rm">Filter feedback by path</legend>
           <% if @filtered_by.paths.present? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
     format: false,
     as: "emergency_contact_details"
 
-  resources :anonymous_feedback, only: :index, format: false
+  resources :anonymous_feedback, only: %i(index create), format: false
 
   get "acknowledge" => "support#acknowledge"
   get "_status" => "support#queue_status"

--- a/spec/controllers/anonymous_feedback/explore_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/explore_controller_spec.rb
@@ -68,14 +68,14 @@ describe AnonymousFeedback::ExploreController, type: :controller do
     context "when exploring by URL" do
       it "redirects to the anonymous feedback index page" do
         post :create, params: { support_requests_anonymous_explore_by_multiple_paths: { list_of_urls: "https://www.gov.uk/tax-disc, /vat-rates, /guidance/" } }
-        expect(response).to redirect_to("/anonymous_feedback?paths=%2Ftax-disc%2C+%2Fvat-rates%2C+%2Fguidance%2F")
+        expect(response.location).to start_with("http://test.host/anonymous_feedback?paths=")
       end
     end
 
     context "when exploring by uploaded URL list" do
       it "redirects to the anonymous feedback index page" do
         post :create, params: { support_requests_anonymous_explore_by_multiple_paths: { uploaded_list: fixture_file_upload("#{Rails.root}/spec/fixtures/list_of_urls.csv", 'text/plain') } }
-        expect(response).to redirect_to("/anonymous_feedback?paths=%2Fvat-rates%2C+%2Fdone%2C+%2Fvehicle-tax")
+        expect(response.location).to start_with("http://test.host/anonymous_feedback?paths=")
       end
     end
 

--- a/spec/controllers/anonymous_feedback_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback_controller_spec.rb
@@ -79,8 +79,17 @@ describe AnonymousFeedbackController, type: :controller do
       end
 
       context "HTML representation" do
-        it "renders the results" do
+        it "renders the results given raw paths" do
           get :index, params: { paths: "/tax-disc", from: "13/10/2014", to: "25th November 2014" }
+          expect(response).to have_http_status(:success)
+        end
+
+        it "renders the results given a saved paths ID" do
+          saved_paths = Support::Requests::Anonymous::Paths.new(%w(/tax-disc))
+          saved_paths.save
+
+          get :index, params: { paths: saved_paths.id, from: "13/10/2014", to: "25th November 2014" }
+
           expect(response).to have_http_status(:success)
         end
       end

--- a/spec/models/support/requests/anonymous/paths.rb
+++ b/spec/models/support/requests/anonymous/paths.rb
@@ -1,0 +1,31 @@
+RSpec.describe Support::Requests::Anonymous::Paths do
+  let(:paths) { %w(/test-1 /test-2) }
+  let(:id) { nil }
+
+  subject { described_class.new(paths, id) }
+
+  it "can be saved" do
+    expect { subject.save }.to_not raise_error
+  end
+
+  it "can be saved and loaded" do
+    subject.save
+    expect(subject.paths).to eq(described_class.find(subject.id).paths)
+  end
+
+  context "with an existing ID" do
+    let(:id) { "test-id" }
+
+    it "cannot be found" do
+      expect(described_class.find(id)).to be_nil
+    end
+
+    context "and saving it first" do
+      before { subject.save }
+
+      it "can be found" do
+        expect(described_class.find(id)).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,10 +4,6 @@ require 'redis_client'
 require 'gds-sso/lint/user_spec'
 
 describe User, type: :model do
-  before do
-    RedisClient.instance.connection.del "support-test:users-12345"
-  end
-
   it "supports persistent creation and retrieval" do
     expect(User.where(uid: "12345")).to be_empty
     User.upsert!("uid" => "12345", "name" => "A", "email" => "a@b.com")

--- a/spec/support/redis.rb
+++ b/spec/support/redis.rb
@@ -1,0 +1,7 @@
+require "redis_client"
+
+RSpec.configure do |config|
+  config.before do
+    RedisClient.instance.connection.flushall
+  end
+end


### PR DESCRIPTION
This stores the paths for an anonymous feedback request in Redis, allowing the user to input many more paths than is currently possible. Currently, the paths are stored in the query parameter for the GET request, and this limits the length of the string. An alternative would be to switch to using POST to execute the query, but this makes it impossible to share the URL. Instead, a solution that involves using POST to submit the form, which then saves the paths in an object in Redis and then includes a reference to the object in the resulting GET request URL was chosen.

[Trello Card](https://trello.com/c/EGvu5WoK/757-make-feedex-able-to-return-results-for-larger-sets-of-urls-by-changing-request-from-get-to-post)