### PR TITLE
Don't expand params when loading paths

### DIFF
--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -68,13 +68,19 @@ private
     if params[:path].present?
       params[:paths] = [params[:path]]
     elsif params[:paths] && params[:paths].instance_of?(String)
-      saved_paths = Support::Requests::Anonymous::Paths.find(params[:paths])
-      params[:paths] = saved_paths.try(:paths) || params[:paths].split(',').map(&:strip)
+      params[:paths] = params[:paths].split(',').map(&:strip)
     end
   end
 
+  def paths
+    return [] unless index_params[:paths].present?
+
+    saved_paths = Support::Requests::Anonymous::Paths.find(index_params[:paths].first)
+    saved_paths.try(:paths) || index_params[:paths]
+  end
+
   def scope_filters
-    @scope_filters ||= ScopeFiltersPresenter.new(paths: index_params[:paths], organisation_slug: index_params[:organisation], document_type: index_params[:document_type])
+    @scope_filters ||= ScopeFiltersPresenter.new(paths: paths, organisation_slug: index_params[:organisation], document_type: index_params[:document_type])
   end
 
   def present_date_filters(api_response)


### PR DESCRIPTION
This fixed a bug that was introduced in #606. In that implementation, the `params` variable gets modified with the expanded paths. However this means the pagination, which is automatically generated based on the params, links to the expanded paths rather than the shorted params. Therefore users wouldn't be able to visit second pages when uploading lots of URLs because the same problem as before would occur.

[Trello Card](https://trello.com/c/zfFWlA9r/965-feedex-error-when-viewing-results)