### PR TITLE
Update business finder request to use facet values from Publishing API

### DIFF
--- a/app/controllers/eu_exit_business_readiness_requests_controller.rb
+++ b/app/controllers/eu_exit_business_readiness_requests_controller.rb
@@ -25,7 +25,7 @@ protected # rubocop:disable Layout/IndentationWidth https://github.com/rubocop-h
       :personal_data,
       requester_attributes: %i[email name collaborator_emails],
       sector: [],
-      business_activity: [],
+      organisation_activity: [],
       intellectual_property: [],
       funding_schemes: [],
       public_sector_procurement: [],

--- a/app/controllers/eu_exit_business_readiness_requests_controller.rb
+++ b/app/controllers/eu_exit_business_readiness_requests_controller.rb
@@ -2,7 +2,7 @@ class EuExitBusinessReadinessRequestsController < RequestsController
 protected # rubocop:disable Layout/IndentationWidth https://github.com/rubocop-hq/rubocop/issues/6861
 
   def new_request
-    Support::Requests::EuExitBusinessReadinessRequest.new
+    @eu_exit_business_readiness_request = Support::Requests::EuExitBusinessReadinessRequest.new
   end
 
   def zendesk_ticket_class

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,0 +1,11 @@
+require 'gds_api/publishing_api_v2'
+
+module Services
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      disable_cache: true,
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+    )
+  end
+end

--- a/app/models/support/requests/eu_exit_business_readiness_request.rb
+++ b/app/models/support/requests/eu_exit_business_readiness_request.rb
@@ -3,10 +3,9 @@ require 'active_support/core_ext'
 module Support
   module Requests
     class EuExitBusinessReadinessRequest < Request
-      attr_accessor :type, :url, :explanation, :sector, :business_activity,
-                    :employing_eu_citizens, :personal_data,
-                    :intellectual_property, :funding_schemes,
-                    :public_sector_procurement, :pinned_content
+      attr_accessor :type, :url, :explanation, :sector, :organisation_activity,
+        :employing_eu_citizens, :personal_data, :intellectual_property,
+        :funding_schemes, :public_sector_procurement, :pinned_content
 
       TYPE_OPTIONS = [
         "Adding content to the finder",
@@ -30,9 +29,9 @@ module Support
         "Clothing and consumer goods",
         "Clothing and consumer goods manufacture",
         "Construction",
-        "Digital, technology and computer services",
         "Creative industries",
         "Defence",
+        "Digital, technology and computer services",
         "Education",
         "Electricity",
         "Electronics, parts and machinery",
@@ -64,16 +63,16 @@ module Support
         "Pharmaceuticals",
         "Ports and airports",
         "Postal and courier services",
-        "Professional business services",
+        "Professional and business services",
         "Public administration",
         "Rail",
-        "Road (passengers and freight)",
         "Rail (passengers and freight)",
         "Real estate",
         "Repair of computers and consumer goods",
         "Research",
         "Restaurants, bars and catering",
         "Retail and wholesale (excluding motor trade, food and drink)",
+        "Road (passengers and freight)",
         "Space",
         "Sports and recreation",
         "Telecoms and information services",
@@ -83,12 +82,12 @@ module Support
         "Warehouses, services and pipelines",
       ].freeze
 
-      BUSINESS_ACTIVITY_OPTIONS = [
-        "Selling products or goods in the UK",
-        "Buying products or goods from abroad",
-        "Selling products or goods abroad",
-        "Doing other types of business in the EU",
-        "Businesses transporting goods abroad",
+      ORGANISATION_ACTIVITY_OPTIONS = [
+        "Sell products or goods in the UK",
+        "Buy products or goods from abroad",
+        "Sell products or goods abroad",
+        "Do other types of business in the EU",
+        "Transport goods abroad",
       ].freeze
 
       EMPLOYING_EU_CITIZENS_OPTIONS = %w(Yes No).freeze
@@ -97,10 +96,10 @@ module Support
 
       INTELLECTUAL_PROPERTY_OPTIONS = [
         "Copyright",
-        "Trade Marks",
+        "Trade marks",
         "Designs",
         "Patents",
-        "Exhaustion of Rights",
+        "Exhaustion of rights",
       ].freeze
 
       FUNDING_SCHEMES_OPTIONS = [

--- a/app/models/support/requests/eu_exit_business_readiness_request.rb
+++ b/app/models/support/requests/eu_exit_business_readiness_request.rb
@@ -4,8 +4,8 @@ module Support
   module Requests
     class EuExitBusinessReadinessRequest < Request
       attr_accessor :type, :url, :explanation, :sector, :organisation_activity,
-        :employing_eu_citizens, :personal_data, :intellectual_property,
-        :funding_schemes, :public_sector_procurement, :pinned_content
+                    :employing_eu_citizens, :personal_data, :intellectual_property,
+                    :funding_schemes, :public_sector_procurement, :pinned_content
 
       TYPE_OPTIONS = [
         "Adding content to the finder",
@@ -13,106 +13,37 @@ module Support
         "Removing content from the finder",
       ].freeze
 
-      PINNED_CONTENT_OPTIONS = %w(Yes No).freeze
-
-      SECTOR_OPTIONS = [
-        "All sectors",
-        "Accommodation",
-        "Aerospace",
-        "Agriculture and forestry (including wholesale)",
-        "Air freight and air passenger services",
-        "Arts, culture and heritage",
-        "Automotive",
-        "Auxiliary activities",
-        "Charities",
-        "Chemicals",
-        "Clothing and consumer goods",
-        "Clothing and consumer goods manufacture",
-        "Construction",
-        "Creative industries",
-        "Defence",
-        "Digital, technology and computer services",
-        "Education",
-        "Electricity",
-        "Electronics, parts and machinery",
-        "Environmental services",
-        "Financial services",
-        "Fisheries (including wholesale)",
-        "Food, drink and tobacco (retail and wholesale)",
-        "Food, drink and tobacco (processing)",
-        "Furniture manufacture",
-        "Gambling",
-        "Health and social care services",
-        "Installation, servicing and repair",
-        "Insurance",
-        "Justice including prisons",
-        "Marine",
-        "Marine transport",
-        "Media and broadcasting",
-        "Medical technology",
-        "Metals manufacture",
-        "Mining",
-        "Motor trade",
-        "Non-metal materials manufacture",
-        "Nuclear",
-        "Oil, gas and coal",
-        "Other advanced manufacturing",
-        "Other energy",
-        "Other manufacturing",
-        "Personal services",
-        "Pharmaceuticals",
-        "Ports and airports",
-        "Postal and courier services",
-        "Professional and business services",
-        "Public administration",
-        "Rail",
-        "Rail (passengers and freight)",
-        "Real estate",
-        "Repair of computers and consumer goods",
-        "Research",
-        "Restaurants, bars and catering",
-        "Retail and wholesale (excluding motor trade, food and drink)",
-        "Road (passengers and freight)",
-        "Space",
-        "Sports and recreation",
-        "Telecoms and information services",
-        "Tourism",
-        "Veterinary",
-        "Voluntary and community organisations",
-        "Warehouses, services and pipelines",
-      ].freeze
-
-      ORGANISATION_ACTIVITY_OPTIONS = [
-        "Sell products or goods in the UK",
-        "Buy products or goods from abroad",
-        "Sell products or goods abroad",
-        "Do other types of business in the EU",
-        "Transport goods abroad",
-      ].freeze
+      EU_EXIT_BUSINESS_FINDER_CONTENT_ID = "52435175-82ed-4a04-adef-74c0199d0f46".freeze
 
       EMPLOYING_EU_CITIZENS_OPTIONS = %w(Yes No).freeze
 
-      PERSONAL_DATA_OPTIONS = %w(Yes No).freeze
-
-      INTELLECTUAL_PROPERTY_OPTIONS = [
-        "Copyright",
-        "Trade marks",
-        "Designs",
-        "Patents",
-        "Exhaustion of rights",
-      ].freeze
-
-      FUNDING_SCHEMES_OPTIONS = [
-        "Receiving EU funding",
-        "Receiving UK government funding",
-      ].freeze
-
-      PUBLIC_SECTOR_PROCUREMENT_OPTIONS = [
-        "Civil government contracts",
-        "Defence contracts",
-      ].freeze
+      PINNED_CONTENT_OPTIONS = %w(Yes No).freeze
 
       validates_presence_of :url
+
+      def sector_options
+        grouped_facet_values.fetch("sector_business_area")
+      end
+
+      def organisation_activity_options
+        grouped_facet_values.fetch("business_activity")
+      end
+
+      def personal_data_options
+        grouped_facet_values.fetch("personal_data")
+      end
+
+      def intellectual_property_options
+        grouped_facet_values.fetch("intellectual_property")
+      end
+
+      def founding_schemes_options
+        grouped_facet_values.fetch("eu_uk_government_funding")
+      end
+
+      def public_sector_procurement_options
+        grouped_facet_values.fetch("public_sector_procurement")
+      end
 
       def self.label
         "Request updates to content in the EU Exit business readiness finder"
@@ -120,6 +51,16 @@ module Support
 
       def self.description
         "Request to add content, update content tags or remove content from the EU Exit business readiness finder."
+      end
+
+    private
+
+      def raw_facet_group
+        @raw_facet_group ||= RemoteFacetGroupService.new.find(EU_EXIT_BUSINESS_FINDER_CONTENT_ID)
+      end
+
+      def grouped_facet_values
+        Facets::FacetGroupPresenter.new(raw_facet_group).grouped_facet_values
       end
     end
   end

--- a/app/models/zendesk/ticket/eu_exit_business_readiness_ticket.rb
+++ b/app/models/zendesk/ticket/eu_exit_business_readiness_ticket.rb
@@ -19,7 +19,7 @@ module Zendesk
 
       def fields
         %w(
-          type url pinned_content explanation sector business_activity employing_eu_citizens
+          type url pinned_content explanation sector organisation_activity employing_eu_citizens
           personal_data intellectual_property funding_schemes
           public_sector_procurement
         )

--- a/app/presenters/facets/base_presenter.rb
+++ b/app/presenters/facets/base_presenter.rb
@@ -1,0 +1,21 @@
+module Facets
+  class BasePresenter
+    attr_reader :raw_data
+
+    def initialize(raw_data)
+      @raw_data = raw_data
+    end
+
+    def title
+      raw_data["title"]
+    end
+
+    def details
+      raw_data.fetch("details", {})
+    end
+
+    def links
+      raw_data.fetch("links", {})
+    end
+  end
+end

--- a/app/presenters/facets/facet_group_presenter.rb
+++ b/app/presenters/facets/facet_group_presenter.rb
@@ -1,0 +1,26 @@
+module Facets
+  class FacetGroupPresenter < BasePresenter
+    def name
+      details["name"]
+    end
+
+    def facets
+      expanded_links.fetch("facets", []).map do |facet_data|
+        Facets::FacetPresenter.new(facet_data)
+      end
+    end
+
+    def grouped_facet_values
+      array = facets.map do |f|
+        [f.key, f.facet_values.map(&:label)]
+      end
+      array.to_h
+    end
+
+  private
+
+    def expanded_links
+      raw_data.fetch("expanded_links", {})
+    end
+  end
+end

--- a/app/presenters/facets/facet_presenter.rb
+++ b/app/presenters/facets/facet_presenter.rb
@@ -1,0 +1,13 @@
+module Facets
+  class FacetPresenter < BasePresenter
+    def key
+      details["key"]
+    end
+
+    def facet_values
+      links.fetch("facet_values", []).map do |facet_value_data|
+        Facets::FacetValuePresenter.new(facet_value_data)
+      end
+    end
+  end
+end

--- a/app/presenters/facets/facet_value_presenter.rb
+++ b/app/presenters/facets/facet_value_presenter.rb
@@ -1,0 +1,11 @@
+module Facets
+  class FacetValuePresenter < BasePresenter
+    def label
+      details["label"]
+    end
+
+    def value
+      details["value"]
+    end
+  end
+end

--- a/app/services/remote_facet_group_service.rb
+++ b/app/services/remote_facet_group_service.rb
@@ -1,0 +1,17 @@
+require 'services'
+
+class RemoteFacetGroupService
+  def find(content_id)
+    expanded_facet_group(content_id).to_hash
+  end
+
+private
+
+  def expanded_facet_group(content_id)
+    publishing_api.get_expanded_links(content_id)
+  end
+
+  def publishing_api
+    Services.publishing_api
+  end
+end

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -60,7 +60,7 @@
   input_html: { class: "input-md-6", rows: 6, cols: 50, :"aria-required" => false }
 ) %>
 
-<h2>Sector and business activity</h2>
+<h2>Sector and organisation activity</h2>
 
 <%= f.input(
   :sector,
@@ -71,10 +71,10 @@
 ) %>
 
 <%= f.input(
-  :business_activity,
+  :organisation_activity,
   as: :check_boxes,
   label: "Is the content about selling goods in the UK, importing or doing business abroad?",
-  collection: Support::Requests::EuExitBusinessReadinessRequest::BUSINESS_ACTIVITY_OPTIONS,
+  collection: Support::Requests::EuExitBusinessReadinessRequest::ORGANISATION_ACTIVITY_OPTIONS,
   required: false,
 ) %>
 

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -65,8 +65,8 @@
 <%= f.input(
   :sector,
   as: :check_boxes,
-  label: "What sector(s) is the content is about?",
-  collection: Support::Requests::EuExitBusinessReadinessRequest::SECTOR_OPTIONS,
+  label: "What sector(s) is the content about?",
+  collection: @eu_exit_business_readiness_request.sector_options,
   required: false,
 ) %>
 
@@ -74,33 +74,33 @@
   :organisation_activity,
   as: :check_boxes,
   label: "Is the content about selling goods in the UK, importing or doing business abroad?",
-  collection: Support::Requests::EuExitBusinessReadinessRequest::ORGANISATION_ACTIVITY_OPTIONS,
+  collection: @eu_exit_business_readiness_request.organisation_activity_options,
   required: false,
 ) %>
 
-<h2>Additional Tagging</h2>
+<h2>Additional tagging</h2>
 
 <%= f.input(
   :employing_eu_citizens,
   as: :radio,
-  label: "Is the content specifically about employing EU citizens?",
+  label: "Is the content specifically about employing people from other European countries?",
   collection: Support::Requests::EuExitBusinessReadinessRequest::EMPLOYING_EU_CITIZENS_OPTIONS,
   required: false,
 ) %>
 
 <%= f.input(
   :personal_data,
-  as: :radio,
-  label: "Is the content specifically about the use of personal data or data protection?",
-  collection: Support::Requests::EuExitBusinessReadinessRequest::PERSONAL_DATA_OPTIONS,
+  as: :check_boxes,
+  label: "Is the content about exchanging personal data with organisations in Europe?",
+  collection: @eu_exit_business_readiness_request.personal_data_options,
   required: false,
 ) %>
 
 <%= f.input(
   :intellectual_property,
   as: :check_boxes,
-  label: "Is the content about a specific type of intellectual property?",
-  collection: Support::Requests::EuExitBusinessReadinessRequest::INTELLECTUAL_PROPERTY_OPTIONS,
+  label: "Is the content about intellectual property?",
+  collection: @eu_exit_business_readiness_request.intellectual_property_options,
   required: false,
 ) %>
 
@@ -108,7 +108,7 @@
   :funding_schemes,
   as: :check_boxes,
   label: "Is the content about EU or UK government funding schemes?",
-  collection: Support::Requests::EuExitBusinessReadinessRequest::FUNDING_SCHEMES_OPTIONS,
+  collection: @eu_exit_business_readiness_request.founding_schemes_options,
   required: false,
 ) %>
 
@@ -116,7 +116,7 @@
   :public_sector_procurement,
   as: :check_boxes,
   label: "Is the content about public sector procurement?",
-  collection: Support::Requests::EuExitBusinessReadinessRequest::PUBLIC_SECTOR_PROCUREMENT_OPTIONS,
+  collection: @eu_exit_business_readiness_request.public_sector_procurement_options,
   required: false,
 ) %>
 

--- a/spec/features/eu_exit_business_readiness_request_spec.rb
+++ b/spec/features/eu_exit_business_readiness_request_spec.rb
@@ -31,10 +31,10 @@ Yes
 
 Aerospace
 
-[Business activity]
+[Organisation activity]
 
-Buying products or goods from abroad
-Selling products or goods abroad
+Buy products or goods from abroad
+Sell products or goods abroad
 
 [Employing eu citizens]
 Yes
@@ -74,9 +74,9 @@ private
     within '#support_requests_eu_exit_business_readiness_request_sector_input' do
       check 'Aerospace'
     end
-    within '#support_requests_eu_exit_business_readiness_request_business_activity_input' do
-      check 'Buying products or goods from abroad'
-      check 'Selling products or goods abroad'
+    within '#support_requests_eu_exit_business_readiness_request_organisation_activity_input' do
+      check 'Buy products or goods from abroad'
+      check 'Sell products or goods abroad'
     end
     within '#support_requests_eu_exit_business_readiness_request_employing_eu_citizens_input' do
       choose 'Yes'

--- a/spec/features/eu_exit_business_readiness_request_spec.rb
+++ b/spec/features/eu_exit_business_readiness_request_spec.rb
@@ -50,7 +50,7 @@ Yes
 Civil government contracts"
       }
     )
-
+    stub_facet_group_lookup(Support::Requests::EuExitBusinessReadinessRequest::EU_EXIT_BUSINESS_FINDER_CONTENT_ID)
     user_requests_update(
       request_type: 'Adding content to the finder'
     )
@@ -86,5 +86,151 @@ private
     end
     fill_in 'URL of content', with: '/some/base/path'
     user_submits_the_request_successfully
+  end
+
+  def stub_facet_group_lookup(content_id = "FACET-GROUP-UUID")
+    uri_regex = Regexp.new("publishing-api.*?\/v2\/expanded-links\/#{content_id}")
+    stub_request(:get, uri_regex)
+    .to_return(body: {
+      content_id: content_id,
+      expanded_links: facet_group,
+      version: 54_321,
+    }.to_json)
+  end
+
+  def facet_group
+    {
+      "content_id" => "FACET-GROUP-UUID",
+      "title" => "Find EU Exit guidance business",
+      "facets" => [
+        {
+          "content_id" => "FACET-UUID",
+          "title" => "Sector / Business area",
+          "details" => { "key" => "sector_business_area" },
+          "links" => {
+            "facet_values" => [
+              {
+                "content_id" => "ANOTHER-FACET-VALUE-UUID",
+                "title" => "Aerospace",
+                "details" => {
+                  "label" => "Aerospace",
+                  "value" => "aerospace",
+                }
+              }
+            ]
+          }
+        },
+        {
+          "content_id" => "FACET-UUID1",
+          "title" => "Organisation activity",
+          "details" => { "key" => "business_activity" },
+          "links" => {
+            "facet_values" => [
+              {
+                "content_id" => "ANOTHER-FACET-VALUE-UUID1",
+                "title" => "Buy products or goods from abroad",
+                "details" => {
+                  "label" => "Buy products or goods from abroad",
+                  "value" => "buying",
+                  }
+              },
+              {
+                "content_id" => "ANOTHER-FACET-VALUE-UUID2",
+                "title" => "Sell products or goods from abroad",
+                "details" => {
+                  "label" => "Sell products or goods abroad",
+                  "value" => "selling",
+                  }
+              }
+            ]
+          }
+        },
+        {
+          "content_id" => "FACET-UUID1",
+          "title" => "Who you employ",
+          "details" => { "key" => "employ_eu_citizens" },
+          "links" => {
+            "facet_values" => [
+              {
+                "content_id" => "ANOTHER-FACET-VALUE-UUID1",
+                "title" => "EU citizens",
+                "details" => {
+                  "label" => "EU citizens",
+                  "value" => "yes",
+                  }
+              },
+            ]
+          }
+        },
+        {
+          "content_id" => "FACET-UUID",
+          "title" => "Personal data",
+          "details" => { "key" => "personal_data" },
+          "links" => {
+            "facet_values" => [
+              {
+                "content_id" => "ANOTHER-FACET-VALUE-UUID",
+                "title" => "Processing personal data from Europe",
+                "details" => {
+                  "label" => "Processing personal data from Europe",
+                  "value" => "processing-personal-data",
+                }
+              }
+            ]
+          }
+        },
+        {
+          "content_id" => "FACET-UUID",
+          "title" => "Intellectual property",
+          "details" => { "key" => "intellectual_property" },
+          "links" => {
+            "facet_values" => [
+              {
+                "content_id" => "ANOTHER-FACET-VALUE-UUID",
+                "title" => "Copyright",
+                "details" => {
+                  "label" => "Copyright",
+                  "value" => "copyright",
+                }
+              }
+            ]
+          }
+        },
+        {
+          "content_id" => "FACET-UUID",
+          "title" => "EU or UK government funding",
+          "details" => { "key" => "eu_uk_government_funding" },
+          "links" => {
+            "facet_values" => [
+              {
+                "content_id" => "ANOTHER-FACET-VALUE-UUID",
+                "title" => "EU funding",
+                "details" => {
+                  "label" => "EU funding",
+                  "value" => "eu-funding",
+                }
+              }
+            ]
+          }
+        },
+        {
+          "content_id" => "FACET-UUID",
+          "title" => "Public sector procurement",
+          "details" => { "key" => "public_sector_procurement" },
+          "links" => {
+            "facet_values" => [
+              {
+                "content_id" => "ANOTHER-FACET-VALUE-UUID",
+                "title" => "Civil government contracts",
+                "details" => {
+                  "label" => "Civil government contracts",
+                  "value" => "civil-government-contracts",
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
   end
 end

--- a/spec/models/support/requests/eu_exit_business_readiness_request_spec.rb
+++ b/spec/models/support/requests/eu_exit_business_readiness_request_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+module Support
+  module Requests
+    describe EuExitBusinessReadinessRequest do
+      subject { described_class.new }
+      let(:response_hash) do
+        { "sector_business_area" => %w(Accommodation Aerospace),
+         "business_activity" =>
+          ["Sell products or goods in the UK",
+           "Buy products or goods from abroad"],
+         "employ_eu_citizens" => ["EU citizens", "No EU citizens"],
+         "personal_data" =>
+          ["Processing personal data from Europe",
+           "Using websites or services hosted in Europe"],
+         "intellectual_property" =>
+          ["Copyright", "Trade marks", "Designs"],
+         "eu_uk_government_funding" => ["EU funding", "UK government funding"],
+         "public_sector_procurement" =>
+          ["Civil government contracts", "Defence contracts"] }
+      end
+      before do
+        allow(subject).to receive(:grouped_facet_values).and_return(response_hash)
+      end
+
+      it { should validate_presence_of(:url) }
+
+      describe 'sector_options' do
+        it "returns an array of facet values for Sector" do
+          expect(subject.sector_options).to eq(%w(Accommodation Aerospace))
+        end
+      end
+
+      describe 'organisation_activity_options' do
+        it "returns an array of facet values for Organisation activity" do
+          expect(subject.organisation_activity_options).to eq(["Sell products or goods in the UK", "Buy products or goods from abroad"])
+        end
+      end
+
+      describe 'personal_data_options' do
+        it "returns an array of facet values for Personal data" do
+          expect(subject.personal_data_options).to eq(["Processing personal data from Europe", "Using websites or services hosted in Europe"])
+        end
+      end
+
+      describe 'intellectual_property_options' do
+        it "returns an array of facet values for Intellectual property" do
+          expect(subject.intellectual_property_options).to eq(["Copyright", "Trade marks", "Designs"])
+        end
+      end
+
+      describe 'founding_schemes_options' do
+        it "returns an array of facet values for EU or UK government funding" do
+          expect(subject.founding_schemes_options).to eq(["EU funding", "UK government funding"])
+        end
+      end
+
+      describe 'public_sector_procurement_options' do
+        it "returns an array of facet values for Public sector procurement" do
+          expect(subject.public_sector_procurement_options).to eq(["Civil government contracts", "Defence contracts"])
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/facets/facet_group_presenter_spec.rb
+++ b/spec/presenters/facets/facet_group_presenter_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Facets::FacetGroupPresenter do
+  let(:raw_data) do
+    {
+      "content_id" => "abc-123",
+      "title" => "Facet group 1",
+      "details" => { "name" => "Facet group 1", "description" => "This is facet group 1" },
+      "publication_state" => "published",
+      "expanded_links" => {
+        "facets" => [
+          {
+            "title" => "Facet 1",
+            "details" => { "key" => "facet_1" },
+            "links" => {
+              "facet_values" => [
+                {
+                  "details" => { "label" => "Facet value 1" }
+                },
+                {
+                  "details" => { "label" => "Facet value 2" }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  end
+
+  subject(:instance) { described_class.new(raw_data) }
+
+  describe "facet group attributes" do
+    it "exposes content_id, title, name, description and state" do
+      expect(instance.title).to eq(raw_data["title"])
+      expect(instance.name).to eq(raw_data["details"]["name"])
+    end
+  end
+
+  describe "facets" do
+    it "presents facets" do
+      expect(instance.facets.first).to be_a(Facets::FacetPresenter)
+    end
+  end
+
+  describe "grouped_facet_values" do
+    it "creates a facet values hash" do
+      expect(instance.grouped_facet_values).to eq(
+        "facet_1" => ["Facet value 1", "Facet value 2"]
+      )
+    end
+  end
+end

--- a/spec/presenters/facets/facet_presenter_spec.rb
+++ b/spec/presenters/facets/facet_presenter_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Facets::FacetPresenter do
+  let(:raw_data) do
+    {
+      "title" => "Facet 1",
+      "details" => { "key" => "facet_1" },
+      "links" => {
+        "facet_values" => [
+          { "title" => "Facet value 1" },
+        ]
+      }
+    }
+  end
+
+  subject(:instance) { described_class.new(raw_data) }
+
+  describe "facet attributes" do
+    it "exposes title and key" do
+      expect(instance.title).to eq(raw_data["title"])
+      expect(instance.key).to eq(raw_data["details"]["key"])
+    end
+  end
+
+  describe "facet_values" do
+    it "presents facet values" do
+      expect(instance.facet_values.first).to be_a(Facets::FacetValuePresenter)
+    end
+  end
+end

--- a/spec/services/remote_facet_group_service_spec.rb
+++ b/spec/services/remote_facet_group_service_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+require 'services'
+require 'remote_facet_group_service'
+
+RSpec.describe RemoteFacetGroupService do
+  let(:publishing_api) { Services.publishing_api }
+
+  describe "find" do
+    let(:api_response) { double(:response, to_hash: "Yeah!") }
+    before do
+      allow(publishing_api).to receive(:get_expanded_links).and_return(api_response)
+    end
+
+    it "fetches the expanded facet group from the publishing api" do
+      result = subject.find("abc-123")
+      expect(result).to eq("Yeah!")
+      expect(publishing_api).to have_received(:get_expanded_links).with("abc-123")
+    end
+  end
+end


### PR DESCRIPTION
Facet values are currently hardcoded in the EU Exit business readiness request from and therefore have to be manually changed when the facet value is updated in the finder.

This populates a support form with values obtained from the Publishing API.

Dependent on https://github.com/alphagov/govuk-puppet/pull/9080 

Test by checking if options for _Is the content about selling goods in the UK, importing or doing business abroad?_ question are in the ground form (eg. _sell_, not _selling_)

[Trello card](https://trello.com/c/HPOb08N2/69-change-business-activity-title-to-organisation-activity-in-zendesk-ticket-generated-by-support-form)
