### PR TITLE
Remove option to pin content from Brexit form

### DIFF
--- a/app/controllers/eu_exit_business_readiness_requests_controller.rb
+++ b/app/controllers/eu_exit_business_readiness_requests_controller.rb
@@ -19,7 +19,6 @@ protected # rubocop:disable Layout/IndentationWidth https://github.com/rubocop-h
     ).permit(
       :type,
       :url,
-      :pinned_content,
       :explanation,
       :employing_eu_citizens,
       :personal_data,

--- a/app/models/support/requests/eu_exit_business_readiness_request.rb
+++ b/app/models/support/requests/eu_exit_business_readiness_request.rb
@@ -5,7 +5,7 @@ module Support
     class EuExitBusinessReadinessRequest < Request
       attr_accessor :type, :url, :explanation, :sector, :organisation_activity,
                     :employing_eu_citizens, :personal_data, :intellectual_property,
-                    :funding_schemes, :public_sector_procurement, :pinned_content
+                    :funding_schemes, :public_sector_procurement
 
       TYPE_OPTIONS = [
         "Adding content to the finder",
@@ -16,8 +16,6 @@ module Support
       EU_EXIT_BUSINESS_FINDER_CONTENT_ID = "52435175-82ed-4a04-adef-74c0199d0f46".freeze
 
       EMPLOYING_EU_CITIZENS_OPTIONS = %w(Yes No).freeze
-
-      PINNED_CONTENT_OPTIONS = %w(Yes No).freeze
 
       validates_presence_of :url
 

--- a/app/models/zendesk/ticket/eu_exit_business_readiness_ticket.rb
+++ b/app/models/zendesk/ticket/eu_exit_business_readiness_ticket.rb
@@ -19,7 +19,7 @@ module Zendesk
 
       def fields
         %w(
-          type url pinned_content explanation sector organisation_activity employing_eu_citizens
+          type url explanation sector organisation_activity employing_eu_citizens
           personal_data intellectual_property funding_schemes
           public_sector_procurement
         )

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -120,19 +120,4 @@
   required: false,
 ) %>
 
-<h2>Pinned content</h2>
-<p>
-    Pinned content is shown at the top of the results in the business readiness finder
-    when certain filters are selected and the content has been tagged to that filter.
-</p>
-<p>
-    Content should only be pinned if it gives a high level summary of what the sector or policy area is about.
-</p>
-<%= f.input(
-    :pinned_content,
-    as: :radio,
-    label: 'Does this content need to be pinned at the top of the results list?',
-    collection: Support::Requests::EuExitBusinessReadinessRequest::PINNED_CONTENT_OPTIONS
-) %>
-
 <%= render partial: "support/collaborators", locals: { f: f } %>

--- a/spec/features/eu_exit_business_readiness_request_spec.rb
+++ b/spec/features/eu_exit_business_readiness_request_spec.rb
@@ -24,9 +24,6 @@ Adding content to the finder
 [Url]
 /some/base/path
 
-[Pinned content]
-Yes
-
 [Sector]
 
 Aerospace
@@ -67,9 +64,6 @@ private
     expect(page).to have_content(page_title)
     within '#support_requests_eu_exit_business_readiness_request_type_input' do
       choose details[:request_type]
-    end
-    within '#support_requests_eu_exit_business_readiness_request_pinned_content_input' do
-      choose 'Yes'
     end
     within '#support_requests_eu_exit_business_readiness_request_sector_input' do
       check 'Aerospace'


### PR DESCRIPTION
Trello: https://trello.com/c/VTQHxlfH

Related to:
* https://github.com/alphagov/finder-frontend/pull/1202
* https://github.com/alphagov/content-tagger/pull/940

Content can no longer be pinned to the Brexit business finder, so the option needs to
be removed from the support form