### PR TITLE
Update guidance on Brexit business form

### DIFF
--- a/app/models/support/requests/eu_exit_business_readiness_request.rb
+++ b/app/models/support/requests/eu_exit_business_readiness_request.rb
@@ -44,7 +44,7 @@ module Support
       end
 
       def self.label
-        "Request updates to content in the EU Exit business readiness finder"
+        "Request a change to the Brexit business finder"
       end
 
       def self.description

--- a/app/models/support/requests/eu_exit_business_readiness_request.rb
+++ b/app/models/support/requests/eu_exit_business_readiness_request.rb
@@ -48,7 +48,7 @@ module Support
       end
 
       def self.description
-        "Request to add content, update content tags or remove content from the EU Exit business readiness finder."
+        "Ask for content to be added or removed, or change content tags"
       end
 
     private

--- a/app/models/support/requests/eu_exit_business_readiness_request.rb
+++ b/app/models/support/requests/eu_exit_business_readiness_request.rb
@@ -15,7 +15,10 @@ module Support
 
       EU_EXIT_BUSINESS_FINDER_CONTENT_ID = "52435175-82ed-4a04-adef-74c0199d0f46".freeze
 
-      EMPLOYING_EU_CITIZENS_OPTIONS = %w(Yes No).freeze
+      EMPLOYING_EU_CITIZENS_OPTIONS = [
+        "Employing EU or EEA citizens",
+        "Employing UK citizens or people not from the EU or EEA",
+      ].freeze
 
       validates_presence_of :url
 

--- a/app/models/zendesk/ticket/eu_exit_business_readiness_ticket.rb
+++ b/app/models/zendesk/ticket/eu_exit_business_readiness_ticket.rb
@@ -2,11 +2,11 @@ module Zendesk
   module Ticket
     class EuExitBusinessReadinessTicket < Zendesk::ZendeskTicket
       def subject
-        "EU Exit Business Readiness - #{@request.url}"
+        "Brexit business finder - #{@request.url}"
       end
 
       def tags
-        super + %w[business_readiness dapper govt_form eu_exit]
+        super + %w[business_readiness dapper govt_form eu_exit brexit]
       end
 
     protected

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -3,32 +3,17 @@
 </p>
 
 <p>
-  The <a href="https://www.gov.uk/business-uk-leaving-eu">EU Exit business
-  readiness</a> tool aims to help businesses find content that gives them
-  actionable steps to prepare for EU Exit. It asks users a series of questions
-  before showing them links to relevant content in a
-  <a href="https://www.gov.uk/find-eu-exit-guidance-business">finder</a>.
-  Content shown in the finder is already published on GOV.UK.
+  Content tagged to the <a href="https://www.gov.uk/find-eu-exit-guidance-business">Brexit business
+  finder</a> must:
 </p>
-
-<h4>Adding content to the finder</h4>
-
+<ul>
+  <li>give businesses and organisations actionable steps to prepare for Brexit</li>
+  <li>be in a guidance format, for example detailed guide, publication or step by step</li>
+</ul>
 <p>
-  Content must be in a GOV.UK guidance format (such as a detailed guide or a
-  guidance publication) to be included in the finder. You can submit content
-  which is either in draft or has been published.
+  Do not add news stories, policy papers, press releases or correspondence.
 </p>
 
-<p>
-  Formats such as news stories or press releases cannot be added to the tool.
-  We’d also not recommend adding policy papers or correspondence as this is not
-  a guidance format.
-</p>
-
-<p>
-  If you’re unsure, please <a href="/content_advice_request/new">contact GOV.UK
-  content support</a> before completing this form.
-</p>
 
 <%= f.input(
   :type,

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -43,12 +43,12 @@
   Be as specific as you can, especially when choosing sectors.
 </p>
 
-<h2>Sector and organisation activity</h2>
+<h2>Sector tagging</h2>
 
 <%= f.input(
   :sector,
   as: :check_boxes,
-  label: "What sector(s) is the content about?",
+  label: "What sector(s) is the content for?",
   collection: @eu_exit_business_readiness_request.sector_options,
   required: false,
 ) %>

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -33,8 +33,10 @@
 <%= f.input(
   :explanation,
   as: :text,
-  label: "If you’re requesting an update to tagging or removing content, please explain your request.",
-  input_html: { class: "input-md-6", rows: 6, cols: 50, :"aria-required" => false }
+  label: "Why does this content need adding, updating or removing?",
+  required: true,
+  hint: "You can also add other information or questions here.",
+  input_html: { class: "input-md-6", rows: 6, cols: 50, :"aria-required" => true }
 ) %>
 
 <h2>Sector and organisation activity</h2>

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -68,7 +68,7 @@
 <%= f.input(
   :employing_eu_citizens,
   as: :radio,
-  label: "Is the content specifically about employing people from other European countries?",
+  label: "Is the content about employing people?",
   collection: Support::Requests::EuExitBusinessReadinessRequest::EMPLOYING_EU_CITIZENS_OPTIONS,
   required: false,
 ) %>

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -26,15 +26,9 @@
 <%= f.input(
   :url,
   required: true,
-  label: "URL of content",
-  placeholder: "/government/… or /guidance/…",
+  label: "Which page is this about? Add the full URL",
   input_html: { :"aria-required" => true }
 ) %>
-
-<p>
-  Please don’t submit a Whitehall admin URL or a full GOV.UK URL, only
-  /government/… or /guidance/…
-</p>
 
 <%= f.input(
   :explanation,

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -1,6 +1,4 @@
 <p class="alert alert-info">
-  Request content to be added, updated or removed in the EU Exit business readiness finder.
-  <br />
   We'll review your request within 2 working days.
 </p>
 

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -39,6 +39,10 @@
   input_html: { class: "input-md-6", rows: 6, cols: 50, :"aria-required" => true }
 ) %>
 
+<p class="alert alert-info">
+  Be as specific as you can, especially when choosing sectors.
+</p>
+
 <h2>Sector and organisation activity</h2>
 
 <%= f.input(

--- a/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
+++ b/app/views/eu_exit_business_readiness_requests/_request_details.html.erb
@@ -53,10 +53,12 @@
   required: false,
 ) %>
 
+<h2>Organisation activity tagging</h2>
+
 <%= f.input(
   :organisation_activity,
   as: :check_boxes,
-  label: "Is the content about selling goods in the UK, importing or doing business abroad?",
+  label: "Does the content relate to any of these activities?",
   collection: @eu_exit_business_readiness_request.organisation_activity_options,
   required: false,
 ) %>

--- a/spec/features/eu_exit_business_readiness_request_spec.rb
+++ b/spec/features/eu_exit_business_readiness_request_spec.rb
@@ -78,7 +78,7 @@ private
     within '#support_requests_eu_exit_business_readiness_request_public_sector_procurement_input' do
       check 'Civil government contracts'
     end
-    fill_in 'URL of content', with: '/some/base/path'
+    fill_in 'support_requests_eu_exit_business_readiness_request_url', with: '/some/base/path'
     user_submits_the_request_successfully
   end
 

--- a/spec/features/eu_exit_business_readiness_request_spec.rb
+++ b/spec/features/eu_exit_business_readiness_request_spec.rb
@@ -12,10 +12,10 @@ feature 'New EU Exit Business Readiness Finder request' do
 
   scenario 'sucessful request for adding content' do
     request = expect_zendesk_to_receive_ticket(
-      'subject' => 'EU Exit Business Readiness - /some/base/path',
+      'subject' => 'Brexit business finder - /some/base/path',
       'priority' => 'normal',
       'requester' => hash_including('name' => 'John Smith', 'email' => 'john.smith@agency.gov.uk'),
-      'tags' =>  %w[govt_form business_readiness dapper govt_form eu_exit],
+      'tags' =>  %w[govt_form business_readiness dapper govt_form eu_exit brexit],
       'comment' => {
         'body' =>
 "[Type]

--- a/spec/features/eu_exit_business_readiness_request_spec.rb
+++ b/spec/features/eu_exit_business_readiness_request_spec.rb
@@ -34,7 +34,7 @@ Buy products or goods from abroad
 Sell products or goods abroad
 
 [Employing eu citizens]
-Yes
+Employing EU or EEA citizens
 
 [Intellectual property]
 
@@ -73,7 +73,7 @@ private
       check 'Sell products or goods abroad'
     end
     within '#support_requests_eu_exit_business_readiness_request_employing_eu_citizens_input' do
-      choose 'Yes'
+      choose 'Employing EU or EEA citizens'
     end
     within '#support_requests_eu_exit_business_readiness_request_public_sector_procurement_input' do
       check 'Civil government contracts'

--- a/spec/features/eu_exit_business_readiness_request_spec.rb
+++ b/spec/features/eu_exit_business_readiness_request_spec.rb
@@ -58,7 +58,7 @@ Civil government contracts"
 private
 
   def user_requests_update(details)
-    page_title = 'Request updates to content in the EU Exit business readiness finder'
+    page_title = 'Request a change to the Brexit business finder'
     visit '/'
     click_on page_title
     expect(page).to have_content(page_title)


### PR DESCRIPTION
Trello: https://trello.com/c/VTQHxlfH
Related to: PR #636 

## Motivation

The rules for tagging to the Brexit business finder have changed. The support app is being updated to reflect those changes.

The requested changes are here: https://docs.google.com/document/d/1ZGrHqLb5vitCcc3I7Z5VzZFrcjm4AhLLXLrI-LM_Ubs/edit#

Pinning was removed in PR #636
The sector names (except for the Employing people question) are populated from the facet-group in publishing-api.

## Expected changes
### Before
#### Index page
![screenshot-support integration publishing service gov uk-2019 06 25-15-59-35](https://user-images.githubusercontent.com/5793815/60109438-4020ee80-9762-11e9-9b57-72119192a7bc.png)
#### Form
![screenshot-support integration publishing service gov uk-2019 06 25-16-04-30](https://user-images.githubusercontent.com/5793815/60109824-f258b600-9762-11e9-9f7b-346053c9b818.png)

### After
#### Index page
![screenshot-support dev gov uk-2019 06 25-15-58-33](https://user-images.githubusercontent.com/5793815/60109362-22ec2000-9762-11e9-8152-82d68b86db22.png)

#### Form
![screenshot-github com-2019 06 25-16-15-34](https://user-images.githubusercontent.com/5793815/60110741-7e1f1200-9764-11e9-994c-14a817d3a6fe.png)
