### PR TITLE
Add brexit checker support form

### DIFF
--- a/app/controllers/brexit_checker_requests_controller.rb
+++ b/app/controllers/brexit_checker_requests_controller.rb
@@ -26,6 +26,7 @@ protected
             :new_action_lead_time,
             :new_action_deadline,
             :new_action_comments,
+            :new_action_priority,
             requester_attributes: %i[email name collaborator_emails],
           )
           .to_h

--- a/app/controllers/brexit_checker_requests_controller.rb
+++ b/app/controllers/brexit_checker_requests_controller.rb
@@ -4,4 +4,22 @@ protected
   def new_request
     @get_ready_for_brexit_checker_request = Support::Requests::BrexitCheckerRequest.new
   end
+
+  def zendesk_ticket_class
+    Zendesk::Ticket::BrexitCheckerTicket
+  end
+
+  def parse_request_from_params
+    Support::Requests::BrexitCheckerRequest.new(brexit_checker_params)
+  end
+
+  def brexit_checker_params
+    params.require(:support_requests_brexit_checker_request)
+          .permit(
+            :action_to_change,
+            :description_of_change,
+            requester_attributes: %i[email name collaborator_emails],
+          )
+          .to_h
+  end
 end

--- a/app/controllers/brexit_checker_requests_controller.rb
+++ b/app/controllers/brexit_checker_requests_controller.rb
@@ -1,0 +1,7 @@
+class BrexitCheckerRequestsController < RequestsController
+protected
+
+  def new_request
+    @get_ready_for_brexit_checker_request = Support::Requests::BrexitCheckerRequest.new
+  end
+end

--- a/app/controllers/brexit_checker_requests_controller.rb
+++ b/app/controllers/brexit_checker_requests_controller.rb
@@ -18,6 +18,14 @@ protected
           .permit(
             :action_to_change,
             :description_of_change,
+            :new_action_users,
+            :new_action_title,
+            :new_action_consequence,
+            :new_action_service_link,
+            :new_action_guidance_link,
+            :new_action_lead_time,
+            :new_action_deadline,
+            :new_action_comments,
             requester_attributes: %i[email name collaborator_emails],
           )
           .to_h

--- a/app/models/support/navigation/section_groups.rb
+++ b/app/models/support/navigation/section_groups.rb
@@ -6,7 +6,7 @@ module Support
       def initialize(current_user = nil)
         @current_user = current_user
         @groups = [
-          Support::Navigation::SectionGroup.new("Content request", sections_for(Support::Requests::ContentAdviceRequest, Support::Requests::ContentChangeRequest, Support::Requests::UnpublishContentRequest, Support::Requests::EuExitBusinessReadinessRequest)),
+          Support::Navigation::SectionGroup.new("Content request", content_requests),
           Support::Navigation::SectionGroup.new("Technical support", sections_for(Support::Requests::ChangesToPublishingAppsRequest, Support::Requests::TechnicalFaultReport)),
           Support::Navigation::SectionGroup.new("User access", sections_for(Support::Requests::AccountsPermissionsAndTrainingRequest, Support::Requests::RemoveUserRequest)),
           Support::Navigation::SectionGroup.new("Campaigns", sections_for(Support::Requests::CampaignRequest, Support::Requests::LiveCampaignRequest)),
@@ -32,6 +32,14 @@ module Support
 
       def sections_for(*request_classes)
         request_classes.map { |request_class| Support::Navigation::RequestSection.new(request_class, @current_user) }
+      end
+
+      def content_requests
+        sections_for(Support::Requests::ContentAdviceRequest,
+                     Support::Requests::ContentChangeRequest,
+                     Support::Requests::UnpublishContentRequest,
+                     Support::Requests::EuExitBusinessReadinessRequest,
+                     Support::Requests::BrexitCheckerRequest)
       end
     end
   end

--- a/app/models/support/navigation/section_groups.rb
+++ b/app/models/support/navigation/section_groups.rb
@@ -7,12 +7,12 @@ module Support
         @current_user = current_user
         @groups = [
           Support::Navigation::SectionGroup.new("Content request", content_requests),
-          Support::Navigation::SectionGroup.new("Technical support", sections_for(Support::Requests::ChangesToPublishingAppsRequest, Support::Requests::TechnicalFaultReport)),
-          Support::Navigation::SectionGroup.new("User access", sections_for(Support::Requests::AccountsPermissionsAndTrainingRequest, Support::Requests::RemoveUserRequest)),
-          Support::Navigation::SectionGroup.new("Campaigns", sections_for(Support::Requests::CampaignRequest, Support::Requests::LiveCampaignRequest)),
-          Support::Navigation::SectionGroup.new("Feedback for tools in Beta", sections_for(Support::Requests::ContentPublisherFeedbackRequest, Support::Requests::ContentDataFeedback)),
-          Support::Navigation::SectionGroup.new("Taxonomy requests", sections_for(Support::Requests::TaxonomyNewTopicRequest, Support::Requests::TaxonomyChangeTopicRequest)),
-          Support::Navigation::SectionGroup.new("Other requests", sections_for(Support::Requests::AnalyticsRequest, Support::Requests::GeneralRequest)),
+          Support::Navigation::SectionGroup.new("Technical support", technical_support_requests),
+          Support::Navigation::SectionGroup.new("User access", user_access_requests),
+          Support::Navigation::SectionGroup.new("Campaigns", campaign_requests),
+          Support::Navigation::SectionGroup.new("Feedback for tools in Beta", feedback_requests),
+          Support::Navigation::SectionGroup.new("Taxonomy requests", taxonomy_requests),
+          Support::Navigation::SectionGroup.new("Other requests", other_requests),
         ]
       end
 
@@ -40,6 +40,36 @@ module Support
                      Support::Requests::UnpublishContentRequest,
                      Support::Requests::EuExitBusinessReadinessRequest,
                      Support::Requests::BrexitCheckerRequest)
+      end
+
+      def technical_support_requests
+        sections_for(Support::Requests::ChangesToPublishingAppsRequest,
+                     Support::Requests::TechnicalFaultReport)
+      end
+
+      def user_access_requests
+        sections_for(Support::Requests::AccountsPermissionsAndTrainingRequest,
+                     Support::Requests::RemoveUserRequest)
+      end
+
+      def campaign_requests
+        sections_for(Support::Requests::CampaignRequest,
+                     Support::Requests::LiveCampaignRequest)
+      end
+
+      def feedback_requests
+        sections_for(Support::Requests::ContentPublisherFeedbackRequest,
+                     Support::Requests::ContentDataFeedback)
+      end
+
+      def taxonomy_requests
+        sections_for(Support::Requests::TaxonomyNewTopicRequest,
+                     Support::Requests::TaxonomyChangeTopicRequest)
+      end
+
+      def other_requests
+        sections_for(Support::Requests::AnalyticsRequest,
+                     Support::Requests::GeneralRequest)
       end
     end
   end

--- a/app/models/support/permissions/ability.rb
+++ b/app/models/support/permissions/ability.rb
@@ -22,6 +22,7 @@ module Support
             Support::Requests::ContentAdviceRequest,
             Support::Requests::UnpublishContentRequest,
             Support::Requests::EuExitBusinessReadinessRequest,
+            Support::Requests::BrexitCheckerRequest,
           ]
         end
         can :create, [Support::Requests::AccountsPermissionsAndTrainingRequest, Support::Requests::RemoveUserRequest] if user.has_permission?('user_managers')

--- a/app/models/support/requests/brexit_checker_request.rb
+++ b/app/models/support/requests/brexit_checker_request.rb
@@ -3,6 +3,8 @@ require 'active_support/core_ext'
 module Support
   module Requests
     class BrexitCheckerRequest < Request
+      attr_accessor :action_to_change, :description_of_change
+
       def self.label
         "Get ready for Brexit checker: change request"
       end

--- a/app/models/support/requests/brexit_checker_request.rb
+++ b/app/models/support/requests/brexit_checker_request.rb
@@ -1,0 +1,15 @@
+require 'active_support/core_ext'
+
+module Support
+  module Requests
+    class BrexitCheckerRequest < Request
+      def self.label
+        "Get ready for Brexit checker: change request"
+      end
+
+      def self.description
+        "Request a change to the Brexit checker"
+      end
+    end
+  end
+end

--- a/app/models/support/requests/brexit_checker_request.rb
+++ b/app/models/support/requests/brexit_checker_request.rb
@@ -6,7 +6,7 @@ module Support
       attr_accessor :action_to_change, :description_of_change, :new_action_users,
                     :new_action_title, :new_action_consequence, :new_action_service_link,
                     :new_action_guidance_link, :new_action_lead_time,
-                    :new_action_deadline, :new_action_comments
+                    :new_action_deadline, :new_action_comments, :new_action_priority
 
       def self.label
         "Get ready for Brexit checker: change request"

--- a/app/models/support/requests/brexit_checker_request.rb
+++ b/app/models/support/requests/brexit_checker_request.rb
@@ -3,7 +3,10 @@ require 'active_support/core_ext'
 module Support
   module Requests
     class BrexitCheckerRequest < Request
-      attr_accessor :action_to_change, :description_of_change
+      attr_accessor :action_to_change, :description_of_change, :new_action_users,
+                    :new_action_title, :new_action_consequence, :new_action_service_link,
+                    :new_action_guidance_link, :new_action_lead_time,
+                    :new_action_deadline, :new_action_comments
 
       def self.label
         "Get ready for Brexit checker: change request"

--- a/app/models/zendesk/ticket/brexit_checker_ticket.rb
+++ b/app/models/zendesk/ticket/brexit_checker_ticket.rb
@@ -4,6 +4,18 @@ module Zendesk
       def subject
         "Get ready for Brexit checker"
       end
+
+    private
+
+      def comment_snippets
+        fields.map do |field|
+          Zendesk::LabelledSnippet.new(on: @request, field: field)
+        end
+      end
+
+      def fields
+        %w(action_to_change description_of_change)
+      end
     end
   end
 end

--- a/app/models/zendesk/ticket/brexit_checker_ticket.rb
+++ b/app/models/zendesk/ticket/brexit_checker_ticket.rb
@@ -14,7 +14,16 @@ module Zendesk
       end
 
       def fields
-        %w(action_to_change description_of_change)
+        %w(action_to_change
+           description_of_change
+           new_action_users
+           new_action_title
+           new_action_consequence
+           new_action_service_link
+           new_action_guidance_link
+           new_action_lead_time
+           new_action_deadline
+           new_action_comments)
       end
     end
   end

--- a/app/models/zendesk/ticket/brexit_checker_ticket.rb
+++ b/app/models/zendesk/ticket/brexit_checker_ticket.rb
@@ -1,0 +1,9 @@
+module Zendesk
+  module Ticket
+    class BrexitCheckerTicket < Zendesk::ZendeskTicket
+      def subject
+        "Get ready for Brexit checker"
+      end
+    end
+  end
+end

--- a/app/models/zendesk/ticket/brexit_checker_ticket.rb
+++ b/app/models/zendesk/ticket/brexit_checker_ticket.rb
@@ -27,7 +27,8 @@ module Zendesk
            new_action_guidance_link
            new_action_lead_time
            new_action_deadline
-           new_action_comments)
+           new_action_comments
+           new_action_priority)
       end
     end
   end

--- a/app/models/zendesk/ticket/brexit_checker_ticket.rb
+++ b/app/models/zendesk/ticket/brexit_checker_ticket.rb
@@ -5,6 +5,10 @@ module Zendesk
         "Get ready for Brexit checker"
       end
 
+      def tags
+        super << "brexit_checker"
+      end
+
     private
 
       def comment_snippets

--- a/app/views/brexit_checker_requests/_request_details.html.erb
+++ b/app/views/brexit_checker_requests/_request_details.html.erb
@@ -29,4 +29,57 @@
   ) %>
 </div>
 
+<div id="new_action_title">
+  <h2>Add a new action</h2>
+  <%= f.input(
+    :new_action_users,
+    label: "Who needs to know?",
+    hint: "Specify who, where they are, and what they’re doing. For example, an Irish citizen who lives in the UK taking a pet to the EU.",
+  ) %>
+
+  <%= f.input(
+    :new_action_title,
+    label: "What is the action?",
+    hint: "What does the user need to do to prepare for no deal Brexit?",
+    ) %>
+
+  <%= f.input(
+    :new_action_consequence,
+    label: "Consequence",
+    hint: "What is the problem for the user if they don’t act?",
+    ) %>
+
+  <%= f.input(
+    :new_action_service_link,
+    label: "Service link",
+    hint: "Provide a link to any application process or service, if there is one.",
+    ) %>
+
+  <%= f.input(
+    :new_action_guidance_link,
+    label: "Guidance link",
+    hint: "Provide a link to the page that explains things in detail. It does not have to be on GOV.UK.",
+    ) %>
+
+  <%= f.input(
+    :new_action_lead_time,
+    label: "Lead time",
+    hint: "How long does the process take, if applicable?",
+    ) %>
+
+  <%= f.input(
+    :new_action_deadline,
+    label: "Deadline",
+    hint: "Does the user need to act before a certain date?",
+    ) %>
+
+  <%= f.input(
+    :new_action_comments,
+    as: :text,
+    label: "Other comments",
+    hint: "Explain any concerns or complications.",
+    input_html: { class: "input-md-6", rows: 6, cols: 50 }
+  ) %>
+</div>
+
 <%= render partial: "support/collaborators", locals: { f: f } %>

--- a/app/views/brexit_checker_requests/_request_details.html.erb
+++ b/app/views/brexit_checker_requests/_request_details.html.erb
@@ -18,6 +18,7 @@
     :action_to_change,
     label: "Action title",
     hint: "What content are you referring to? It helps to paste the action title from the checker and a link to the results where it appears.",
+    input_html: { class: "input-md-6" },
   ) %>
 
   <%= f.input(
@@ -35,42 +36,49 @@
     :new_action_users,
     label: "Who needs to know?",
     hint: "Specify who, where they are, and what they’re doing. For example, an Irish citizen who lives in the UK taking a pet to the EU.",
+    input_html: { class: "input-md-6" },
   ) %>
 
   <%= f.input(
     :new_action_title,
     label: "What is the action?",
     hint: "What does the user need to do to prepare for no deal Brexit?",
+    input_html: { class: "input-md-6" },
     ) %>
 
   <%= f.input(
     :new_action_consequence,
     label: "Consequence",
     hint: "What is the problem for the user if they don’t act?",
+    input_html: { class: "input-md-6" },
     ) %>
 
   <%= f.input(
     :new_action_service_link,
     label: "Service link",
     hint: "Provide a link to any application process or service, if there is one.",
+    input_html: { class: "input-md-6" },
     ) %>
 
   <%= f.input(
     :new_action_guidance_link,
     label: "Guidance link",
     hint: "Provide a link to the page that explains things in detail. It does not have to be on GOV.UK.",
+    input_html: { class: "input-md-6" },
     ) %>
 
   <%= f.input(
     :new_action_lead_time,
     label: "Lead time",
     hint: "How long does the process take, if applicable?",
+    input_html: { class: "input-md-6" },
     ) %>
 
   <%= f.input(
     :new_action_deadline,
     label: "Deadline",
     hint: "Does the user need to act before a certain date?",
+    input_html: { class: "input-md-6" },
     ) %>
 
   <%= f.input(

--- a/app/views/brexit_checker_requests/_request_details.html.erb
+++ b/app/views/brexit_checker_requests/_request_details.html.erb
@@ -88,6 +88,15 @@
     hint: "Explain any concerns or complications.",
     input_html: { class: "input-md-6", rows: 6, cols: 50 }
   ) %>
+
+  <%= f.input(
+    :new_action_priority,
+    as: :select,
+    collection: %w(High Medium Low),
+    label: "Priority",
+    hint: "How high up the list of results this action should appear.",
+    input_html: { class: "input-md-6" },
+  ) %>
 </div>
 
 <%= render partial: "support/collaborators", locals: { f: f } %>

--- a/app/views/brexit_checker_requests/_request_details.html.erb
+++ b/app/views/brexit_checker_requests/_request_details.html.erb
@@ -1,0 +1,32 @@
+<div class="alert alert-info">
+  <p>
+    Use this form to request an update to the Brexit checker.
+    https://www.gov.uk/get-ready-brexit-check
+  </p>
+  <p>
+    The checker tells users actions they may need to take.
+    You can request a change to an existing action or suggest where a new action is needed.
+  </p>
+  <p>
+    Once a request is made GDS will agree any changes directly with the nominated policy expert and DExEU.
+  </p>
+</div>
+
+<div id="change_action">
+  <h2>Change an action</h2>
+  <%= f.input(
+    :action_to_change,
+    label: "Action title",
+    hint: "What content are you referring to? It helps to paste the action title from the checker and a link to the results where it appears.",
+  ) %>
+
+  <%= f.input(
+    :description_of_change,
+    as: :text,
+    label: "Describe the change",
+    hint: "Explain the user need and who the users are, what the problem is for the user, and suggest how we could improve.",
+    input_html: { class: "input-md-6", rows: 6, cols: 50 }
+  ) %>
+</div>
+
+<%= render partial: "support/collaborators", locals: { f: f } %>

--- a/spec/features/brexit_checker_request_spec.rb
+++ b/spec/features/brexit_checker_request_spec.rb
@@ -11,7 +11,21 @@ feature "Brexit checker request" do
   end
 
   scenario "sucessful request for changing a result" do
+    request = expect_zendesk_to_receive_ticket(
+      "subject" => "Get ready for Brexit checker",
+      "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
+      "comment" => {
+        "body" =>
+"[Action to change]
+Action title
+
+[Description of change]
+Action description"
+      }
+    )
     user_requests_change_to_result
+
+    expect(request).to have_been_made
   end
 
 private
@@ -24,5 +38,7 @@ private
 
     fill_in "support_requests_brexit_checker_request_action_to_change", with: "Action title"
     fill_in "support_requests_brexit_checker_request_description_of_change", with: "Action description"
+
+    user_submits_the_request_successfully
   end
 end

--- a/spec/features/brexit_checker_request_spec.rb
+++ b/spec/features/brexit_checker_request_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+feature "Brexit checker request" do
+  let(:user) do
+    create(:content_requester, name: "John Smith", email: "john.smith@agency.gov.uk")
+  end
+
+  background do
+    login_as user
+    zendesk_has_no_user_with_email(user.email)
+  end
+
+  scenario "sucessful request for changing a result" do
+    user_requests_change_to_result
+  end
+
+private
+
+  def user_requests_change_to_result
+    page_title = "Get ready for Brexit checker: change request"
+    visit "/"
+    click_on page_title
+  end
+end

--- a/spec/features/brexit_checker_request_spec.rb
+++ b/spec/features/brexit_checker_request_spec.rb
@@ -28,17 +28,72 @@ Action description"
     expect(request).to have_been_made
   end
 
+  scenario "sucessful request for adding a result" do
+    request = expect_zendesk_to_receive_ticket(
+      "subject" => "Get ready for Brexit checker",
+      "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
+      "comment" => {
+        "body" =>
+"[New action users]
+Audience
+
+[New action title]
+Action
+
+[New action consequence]
+Consequence
+
+[New action service link]
+https://www.gov.uk/service-link
+
+[New action guidance link]
+https://www.gov.uk/guidance-link
+
+[New action lead time]
+Four weeks
+
+[New action deadline]
+End of October
+
+[New action comments]
+Comments"
+      }
+    )
+    user_requests_to_add_a_result
+
+    expect(request).to have_been_made
+  end
+
 private
 
   def user_requests_change_to_result
-    page_title = "Get ready for Brexit checker: change request"
-    visit "/"
-    click_on page_title
-    expect(page).to have_content(page_title)
+    visit_brexit_checker_request_page
 
     fill_in "support_requests_brexit_checker_request_action_to_change", with: "Action title"
     fill_in "support_requests_brexit_checker_request_description_of_change", with: "Action description"
 
     user_submits_the_request_successfully
+  end
+
+  def user_requests_to_add_a_result
+    visit_brexit_checker_request_page
+
+    fill_in "support_requests_brexit_checker_request_new_action_users", with: "Audience"
+    fill_in "support_requests_brexit_checker_request_new_action_title", with: "Action"
+    fill_in "support_requests_brexit_checker_request_new_action_consequence", with: "Consequence"
+    fill_in "support_requests_brexit_checker_request_new_action_service_link", with: "https://www.gov.uk/service-link"
+    fill_in "support_requests_brexit_checker_request_new_action_guidance_link", with: "https://www.gov.uk/guidance-link"
+    fill_in "support_requests_brexit_checker_request_new_action_lead_time", with: "Four weeks"
+    fill_in "support_requests_brexit_checker_request_new_action_deadline", with: "End of October"
+    fill_in "support_requests_brexit_checker_request_new_action_comments", with: "Comments"
+
+    user_submits_the_request_successfully
+  end
+
+  def visit_brexit_checker_request_page
+    page_title = "Get ready for Brexit checker: change request"
+    visit "/"
+    click_on page_title
+    expect(page).to have_content(page_title)
   end
 end

--- a/spec/features/brexit_checker_request_spec.rb
+++ b/spec/features/brexit_checker_request_spec.rb
@@ -58,7 +58,10 @@ Four weeks
 End of October
 
 [New action comments]
-Comments"
+Comments
+
+[New action priority]
+High"
       }
     )
     user_requests_to_add_a_result
@@ -88,6 +91,7 @@ private
     fill_in "support_requests_brexit_checker_request_new_action_lead_time", with: "Four weeks"
     fill_in "support_requests_brexit_checker_request_new_action_deadline", with: "End of October"
     fill_in "support_requests_brexit_checker_request_new_action_comments", with: "Comments"
+    select "High", from: "support_requests_brexit_checker_request_new_action_priority"
 
     user_submits_the_request_successfully
   end

--- a/spec/features/brexit_checker_request_spec.rb
+++ b/spec/features/brexit_checker_request_spec.rb
@@ -20,5 +20,9 @@ private
     page_title = "Get ready for Brexit checker: change request"
     visit "/"
     click_on page_title
+    expect(page).to have_content(page_title)
+
+    fill_in "support_requests_brexit_checker_request_action_to_change", with: "Action title"
+    fill_in "support_requests_brexit_checker_request_description_of_change", with: "Action description"
   end
 end

--- a/spec/features/brexit_checker_request_spec.rb
+++ b/spec/features/brexit_checker_request_spec.rb
@@ -14,6 +14,7 @@ feature "Brexit checker request" do
     request = expect_zendesk_to_receive_ticket(
       "subject" => "Get ready for Brexit checker",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
+      "tags" => %w(govt_form brexit_checker),
       "comment" => {
         "body" =>
 "[Action to change]
@@ -32,6 +33,7 @@ Action description"
     request = expect_zendesk_to_receive_ticket(
       "subject" => "Get ready for Brexit checker",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
+      "tags" => %w(govt_form brexit_checker),
       "comment" => {
         "body" =>
 "[New action users]


### PR DESCRIPTION
For https://trello.com/c/bgtCMkNP/243-zendesk-content-change-request-form

This creates a request form for departments to request a change to an existing action or creating a new action for the Get Ready For Brexit Checker.  Once submitted, a request is made to the Zendesk API to create a ticket.

![brexit_check_form](https://user-images.githubusercontent.com/13434452/65238501-b2406f80-dad4-11e9-89ce-c6e877417f41.png)

