### PR TITLE
Fix support for local docker dev environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.hosts << "support.dev.gov.uk"
 end


### PR DESCRIPTION
Related: https://github.com/alphagov/link-checker-api/pull/284

Custom alias domains such as http://support.dev.gov.uk are not working
on any apps running Rails 6, due to the addition of "Host Authorisation"
middleware.

Without this fix you get this error when trying to access the support
app in browser.

> Blocked host: support.dev.gov.uk
> To allow requests to support.dev.gov.uk, add the following to your environment configuration:
> config.hosts << support.dev.gov.uk