### PR TITLE
Changes to Accounts, Permissions and Training form

### DIFF
--- a/app/models/support/requests/accounts_permissions_and_training_request.rb
+++ b/app/models/support/requests/accounts_permissions_and_training_request.rb
@@ -89,7 +89,11 @@ module Support
       end
 
       def self.description
-        "Request a new account, change an account or unlock an account"
+        "Request a new Whitehall account or change permissions."
+      end
+
+      def self.suspension
+        "If your account is suspended, speak to your organisation’s content lead or managing editor to unsuspend your account."
       end
     end
   end

--- a/app/views/accounts_permissions_and_training_requests/_request_details.html.erb
+++ b/app/views/accounts_permissions_and_training_requests/_request_details.html.erb
@@ -6,6 +6,10 @@
    <%= f.input :action, as: :radio, required: true, label: "What would you like to do?", collection: f.object.action_options, input_html: { :"aria-required" => true } %>
 </div>
 
+<div class="alert alert-info">
+  <p><%= f.object.class.suspension %></p>
+</div>
+
 <%= render partial: 'user_needs', locals: { f: f } %>
 
 <div id="user_details">

--- a/app/views/accounts_permissions_and_training_requests/_user_needs.html.erb
+++ b/app/views/accounts_permissions_and_training_requests/_user_needs.html.erb
@@ -21,7 +21,7 @@
       As an organisation admin you can:
       <ul>
         <li>grant and revoke permissions for some applications to users in your organisation</li>
-        <li>unsuspend or unlock your organisation's accounts</li>
+        <li>unsuspend your organisation's accounts</li>
       </ul>
     </div>
     <%= f.input :become_super_organisation_admin, as: :boolean, label: f.object.other_permissions_options.key('become_super_organisation_admin') %>

--- a/spec/features/accounts_permissions_and_training_requests_spec.rb
+++ b/spec/features/accounts_permissions_and_training_requests_spec.rb
@@ -241,7 +241,7 @@ private
 
     click_on "Accounts, permissions and training"
 
-    expect(page).to have_content("Request a new account, change an account or unlock an account")
+    expect(page).to have_content("Request a new Whitehall account or change permissions.")
 
     within "#action" do
       choose details[:action]
@@ -271,7 +271,7 @@ private
 
     click_on "Accounts, permissions and training"
 
-    expect(page).to have_content("Request a new account, change an account or unlock an account")
+    expect(page).to have_content("Request a new Whitehall account or change permissions.")
 
     within "#action" do
       choose details[:action]


### PR DESCRIPTION
Trello: https://trello.com/c/cipBS5VE/1454-2-small-changes-to-a-support-form

Just some quick changes to remove mentions of unsuspending accounts.