### PR TITLE
Remove whitespace between two lines of emergency contact

### DIFF
--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -48,8 +48,7 @@
   <div class="row add-bottom-padding add-top-padding">
     <div class="col-md-12">
       <p class="remove-bottom-margin"><strong><%= @primary_contact_details[:urgent_mainstream_content_change][:phone] %></strong></p>
-      <p class="text-muted">Monday to Friday, 6pm to 9am</p>
-      <p class="text-muted">Weekends and bank holidays, 24 hours</p>
+      <p class="text-muted">Monday to Friday, 6pm to 9am<br>Weekends and bank holidays, 24 hours</p>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
The whitespace created by two `<p>` tags is inconsistent with the rest
of the page. Remove it and replace it with a `<br>` instead.