### PR TITLE
Relax authorized host domains in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,5 +52,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.hosts << "support.dev.gov.uk"
+  # Allow requests for all domains e.g. <app>.dev.gov.uk
+  config.hosts.clear
 end


### PR DESCRIPTION
https://github.com/alphagov/govuk-docker/issues/176

This changes the development configuration to allow requests from
any domain. While this will include *.dev.gov.uk, this reduces the
coupling to that specific domain without any extra effort, thus
supporting more use cases like Docker training.