### PR TITLE
Correct campaign request validations

### DIFF
--- a/app/models/support/gds/campaign.rb
+++ b/app/models/support/gds/campaign.rb
@@ -18,7 +18,7 @@ module Support
       validates :has_read_guidance_confirmation, :has_read_oasis_guidance_confirmation, acceptance: { allow_nil: false }
       validates :type_of_site, inclusion: { in: ["Campaign platform", "Bespoke microsite"] }
 
-      validates_date :start_date, on_or_after: :today, before: :end_date
+      validates_date :start_date, on_or_after: :today
       validates_date :end_date, after: :start_date
       validates_date :development_start_date, on_or_before: :start_date
       validates :proposed_url, format: /((http|https):\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.(campaign\.)?gov.uk?/

--- a/app/models/support/gds/campaign.rb
+++ b/app/models/support/gds/campaign.rb
@@ -20,10 +20,8 @@ module Support
 
       validates_date :start_date, on_or_after: :today, before: :end_date
       validates_date :end_date, after: :start_date
-      validates_date :development_start_date, on_or_after: :start_date
+      validates_date :development_start_date, on_or_before: :start_date
       validates :proposed_url, format: /((http|https):\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.(campaign\.)?gov.uk?/
-
-      validates :cost_of_campaign, numericality: true
 
       VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
       validates :performance_review_contact_email, :ga_contact_email, format: { with: VALID_EMAIL_REGEX }

--- a/app/views/campaign_requests/_request_details.html.erb
+++ b/app/views/campaign_requests/_request_details.html.erb
@@ -88,14 +88,14 @@
                required: true,
                input_html: {class: 'input-md-6', 'aria-required': true} %>
     <p class="help-block">
-        The short campaign title, approx 1 - 3 words, eg "Action Counters Terrorism"
+        The short campaign title, as appears in (for example) Google Search
     </p>
     <%= r.input :site_tagline,
                 label: 'Site tagline',
                 required: true,
                 input_html: {class: 'input-md-6', 'aria-required': true} %>
     <p class="help-block">
-        Explain what this site is about, approx 7 - 8 words, eg "Report terrorist or extremist content online"
+        Explain what this site is about, as appears in (for example) Google Search
     </p>
 
     <%= r.input :site_metadescription,
@@ -108,9 +108,7 @@
                   :"aria-required" => true,
                   :"aria-describedby" => "seoHelpBlock" } %>
     <p class="help-block">
-        Approx 20-30 words. A more detailed description or call to action,
-        e.g. "Report terrorism activity online. If you've seen or heard something
-        that is suspicious and may be terrorism related - report it anonymously."
+        Approx 20-30 words, as appears in (for example) Google Search
     </p>
 
     <%= r.input :description,

--- a/spec/features/campaign_requests_spec.rb
+++ b/spec/features/campaign_requests_spec.rb
@@ -32,7 +32,7 @@ John Smith
 01-02-2020
 
 [Site build to commence on]
-02-01-2020
+31-12-2019
 
 [Contact email/s for website performance review every 6 months]
 john.smith@example.com
@@ -59,7 +59,7 @@ A new one about a new thing
 pensions, campaign, newcampaign
 
 [Site build budget / costs (and overall campaign cost, if applicable)]
-1200
+£1200 and tuppence
 
 [Contact details for Google Analytics leads (Gmail accounts only)]
 ga.contact@example.com
@@ -76,7 +76,7 @@ Some comment",
       signed_campaign: "John Smith",
       start_date: "01-01-2020",
       end_date: "01-02-2020",
-      development_start_date: "02-01-2020",
+      development_start_date: "31-12-2019",
       performance_review_contact_email: "john.smith@example.com",
       government_theme: "Example government theme",
       description: "Pensions",
@@ -85,7 +85,7 @@ Some comment",
       site_title: "New campaign",
       site_tagline: "A new one about a new thing",
       site_metadescription: "pensions, campaign, newcampaign",
-      cost_of_campaign: "1200",
+      cost_of_campaign: "£1200 and tuppence",
       ga_contact_email: "ga.contact@example.com",
       additional_comments: "Some comment",
       )

--- a/spec/models/support/gds/campaign_spec.rb
+++ b/spec/models/support/gds/campaign_spec.rb
@@ -60,8 +60,9 @@ module Support
       it { should_not allow_value("test").for(:performance_review_contact_email) }
       it { should_not allow_value("test@").for(:performance_review_contact_email) }
 
-      it { should_not allow_value(as_str(Date.tomorrow)).for(:start_date) }
+      it { should allow_value(as_str(Date.tomorrow)).for(:start_date) }
       it { should allow_value(as_str(Time.zone.today)).for(:start_date) }
+      it { should_not allow_value(as_str(Time.zone.today - 1)).for(:start_date) }
 
       it { should allow_value(as_str(Date.tomorrow)).for(:end_date) }
       it { should_not(allow_value(as_str(Time.zone.today)).for(:end_date)) }

--- a/spec/models/support/gds/campaign_spec.rb
+++ b/spec/models/support/gds/campaign_spec.rb
@@ -66,10 +66,9 @@ module Support
       it { should allow_value(as_str(Date.tomorrow)).for(:end_date) }
       it { should_not(allow_value(as_str(Time.zone.today)).for(:end_date)) }
 
-      it { should allow_value(as_str(Date.tomorrow)).for(:development_start_date) }
+      it { should_not allow_value(as_str(Date.tomorrow)).for(:development_start_date) }
+      it { should allow_value(as_str(Time.zone.today - 1)).for(:development_start_date) }
       it { should allow_value(as_str(Time.zone.today)).for(:development_start_date) }
-
-      it { should validate_numericality_of(:cost_of_campaign) }
 
       it { should allow_value("test@digital.cabinet-office.gov.uk").for(:ga_contact_email) }
       it { should allow_value("test@test.com").for(:ga_contact_email) }


### PR DESCRIPTION
This PR updates the validations on the campaign request form.

Previously campaign site development start dates were validated to be `on_or_after` the campaign start date. This corrects this validation to ensure that site development must begin `on_or_before` the campaign start date.

The cost of campaign numericality validation has been removed to allow users to use text as well as numbers.

Additionally some description contents have been updated.

**Before**
Incorrect validation: build date AFTER start date
<img width="272" alt="Screenshot 2020-01-22 at 14 12 24" src="https://user-images.githubusercontent.com/13475227/72902131-de8a2800-3d22-11ea-89ec-29e72c908549.png">

Outdated validation: text disallowed
<img width="580" alt="Screenshot 2020-01-22 at 14 12 32" src="https://user-images.githubusercontent.com/13475227/72902139-e1851880-3d22-11ea-87e5-503aadb22258.png">
**After**
Correct validation: Build date must be on or BEFORE start date

<img width="263" alt="Screenshot 2020-01-22 at 14 13 07" src="https://user-images.githubusercontent.com/13475227/72902179-efd33480-3d22-11ea-9d80-7776a868559c.png">

Successful submission with text and numbers, and build date
<img width="346" alt="Screenshot 2020-01-22 at 14 12 46" src="https://user-images.githubusercontent.com/13475227/72902201-f82b6f80-3d22-11ea-9ad8-05d598b0f71b.png">

[Trello](https://trello.com/c/NvpqqaTw/1690-3-changes-to-fields-in-apply-for-a-campaign-form)
