### PR TITLE
Fix flaky test caused by Timecop and Time.current

### DIFF
--- a/spec/features/user_satisfaction_survey_spec.rb
+++ b/spec/features/user_satisfaction_survey_spec.rb
@@ -12,6 +12,10 @@ feature "User satisfaction survey submissions" do
     Timecop.travel Date.parse("2013-02-28")
   end
 
+  after do
+    Timecop.return
+  end
+
   scenario "submission with comment" do
     stub_support_api_anonymous_feedback(
       { path_prefixes: ["/done/find-court-tribunal"] },


### PR DESCRIPTION
Timecop freezes time to 2013, which causes another subsequent test
(spec/features/campaign_requests_spec.rb:16), which uses Time.current,
to fail.

https://ci.integration.publishing.service.gov.uk/job/support/job/update-brexit-checker/8/console

Resetting the time after this test has run fixes the issue.