### PR TITLE
Remove `lint` Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,5 @@ Support::Application.load_tasks
 Rake::Task['default'].clear
 
 task :default do
-  Rake::Task['lint'].invoke
   Rake::Task['spec'].invoke
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,0 @@
-desc "Run rubocop on all files"
-task lint: :environment do
-  system "rubocop --parallel app spec lib Gemfile"
-end


### PR DESCRIPTION
- This `lint` task is not very useful as it hides the directories that
  it operates on, and we're trying to move away from wrappers.
- Instead, I think we can leave people to run `bundle exec rubocop` on
  their own - it's less typing than `bundle exec rake lint` and
  `rubocop --help` works for options.
- With `lint` in the default Rake task, on CI we were running the
  linting twice - once as part of the Jenkins config itself, and once as
  part of `bundle exec rake`.

https://trello.com/c/IEUuFOVa/129-remove-the-lint-rake-task-from-apps-that-have-it
as part of the developer tooling group.