### PR TITLE
Ensure Feedback Export requests have a valid `path_prefixes` param

### DIFF
--- a/app/views/anonymous_feedback/index.html.erb
+++ b/app/views/anonymous_feedback/index.html.erb
@@ -12,6 +12,7 @@
     <%= hidden_field_tag :from, @dates.from if @dates.from.present? %>
     <%= hidden_field_tag :to, @dates.to if @dates.to.present? %>
     <%= hidden_field_tag :path_set_id, @filtered_by.path_set_id if @filtered_by.path_set_id.present? %>
+    <%= hidden_field_tag :paths, @filtered_by.paths if @filtered_by.paths.present? %>
     <%= hidden_field_tag :organisation, @filtered_by.organisation_slug if @filtered_by.organisation_slug.present? %>
     <%= submit_tag "Export as CSV", class: "btn-sm btn btn-default add-left-margin", data: { confirm: confirmation_message(@feedback.total_count, @feedback.results_limited) } %>
   </p>

--- a/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/export_requests_controller_spec.rb
@@ -50,6 +50,33 @@ describe AnonymousFeedback::ExportRequestsController, type: :controller do
       end
     end
 
+    context "with a 'paths' parameter" do
+      let(:path_prefixes) { "/foo" }
+      let(:path_set_id)   { "id123" }
+      let!(:stub_request) do
+        stub_support_api_feedback_export_request_creation(notification_email: "foo.bar@example.gov.uk",
+                                                      path_prefixes: [path_prefixes],
+                                                      from: "2015-05-01",
+                                                      to: "2015-06-01",
+                                                      organisation: nil)
+      end
+
+      let(:do_request) { post :create, params: { paths: path_prefixes, from: "2015-05-01", to: "2015-06-01" } }
+
+      it_behaves_like "a successful create request"
+
+      it "redirects back to the list" do
+        allow_any_instance_of(Support::Requests::Anonymous::Paths).to receive(:id).and_return(path_set_id)
+
+        do_request
+
+        expect(response).to redirect_to(anonymous_feedback_index_path(path_set_id: path_set_id,
+                                                                      paths: path_prefixes,
+                                                                      from: "2015-05-01",
+                                                                      to: "2015-06-01"))
+      end
+    end
+
     context "with an organisation" do
       let!(:stub_request) do
         stub_support_api_feedback_export_request_creation(notification_email: "foo.bar@example.gov.uk",


### PR DESCRIPTION
Recently we refactored feedback CSV exports so that post requests are
sent with a Redis `path_set_id` rather than a large list of URLs.
https://github.com/alphagov/support/pull/672

Whilst it no longer possible with the Support app itself to access the `anonymous_feedback` path without first generating a `path_set_id`, direct links do exist within the GOV.UK Chrome extension and the Content-Data app. This causes the ExportRequestsController to send through a request to the Support-API with an invalid `path_prefixes: scope_filters.paths_for_api`

This PR ensures that when directly accessing this controller with a string URL `path` or `paths` param, clicking the `Export as CSV` button will cause the ExportRequestsController to create a valid Redis `path_set_id` if one is not set. This is in turn used to look up the correct `path_prefixes`

[trello](https://trello.com/c/oy8WqDlD/1909-5-support-export-request-doesnt-send-email)