### PR TITLE
[DO NOT MERGE]Update Whitehall account training and access options

### DIFF
--- a/app/controllers/accounts_permissions_and_training_requests_controller.rb
+++ b/app/controllers/accounts_permissions_and_training_requests_controller.rb
@@ -32,13 +32,7 @@ protected
       :content_data,
       :feedex,
       requester_attributes: %i[email name collaborator_emails],
-      requested_user_attributes: [
-        :name,
-        :email,
-        :job,
-        :other_training,
-        training: [],
-      ],
+      requested_user_attributes: %i[name email job other_training],
     ).to_h
   end
 

--- a/app/controllers/accounts_permissions_and_training_requests_controller.rb
+++ b/app/controllers/accounts_permissions_and_training_requests_controller.rb
@@ -26,6 +26,11 @@ protected
       :become_organisation_admin,
       :become_super_organisation_admin,
       :other_details,
+      :manuals_publisher,
+      :specialist_publisher,
+      :travel_advice_publisher,
+      :content_data,
+      :feedex,
       requester_attributes: %i[email name collaborator_emails],
       requested_user_attributes: [
         :name,

--- a/app/controllers/accounts_permissions_and_training_requests_controller.rb
+++ b/app/controllers/accounts_permissions_and_training_requests_controller.rb
@@ -36,7 +36,6 @@ protected
         :name,
         :email,
         :job,
-        :phone,
         :other_training,
         training: [],
       ],

--- a/app/controllers/whitehall_accounts_permissions_and_training_requests_controller.rb
+++ b/app/controllers/whitehall_accounts_permissions_and_training_requests_controller.rb
@@ -1,0 +1,13 @@
+class WhitehallAccountsPermissionsAndTrainingRequestsController < RequestsController
+protected
+
+  def new_request
+    redirect_to whitehall_signup_form_url
+  end
+
+private
+
+  def whitehall_signup_form_url
+    "https://docs.google.com/forms/d/e/1FAIpQLSfejhUERzSzYKhdGBVE8Ktf1s2UCa1FHD-IvABQVFqsBqVfPw/viewform"
+  end
+end

--- a/app/models/support/gds/requested_user.rb
+++ b/app/models/support/gds/requested_user.rb
@@ -5,33 +5,9 @@ module Support
     class RequestedUser
       include ActiveModel::Model
       attr_accessor :name, :email, :job, :phone, :other_training
-      attr_writer :training
-
-      TRAINING_OPTIONS = {
-        "Writing for GOV.UK" => "writing",
-        "Using Whitehall Publisher" => "using_publisher",
-      }.freeze
 
       validates :name, :email, presence: true
       validates :email, format: { with: /@/ }
-      validates :other_training, presence: true, if: -> { training.empty? }
-      validate :validate_training_options
-
-      def formatted_training
-        training.map { |k| TRAINING_OPTIONS.key(k) }.to_sentence
-      end
-
-      def training
-        Array(@training).reject(&:empty?)
-      end
-
-    private
-
-      def validate_training_options
-        unless (training - TRAINING_OPTIONS.values).empty?
-          errors.add(:training, "must be one of the provided options")
-        end
-      end
     end
   end
 end

--- a/app/models/support/navigation/section_groups.rb
+++ b/app/models/support/navigation/section_groups.rb
@@ -53,6 +53,7 @@ module Support
       def user_access_requests
         sections_for(
           Support::Requests::AccountsPermissionsAndTrainingRequest,
+          Support::Requests::WhitehallAccountsPermissionsAndTrainingRequest,
           Support::Requests::RemoveUserRequest,
         )
       end

--- a/app/models/support/requests/accounts_permissions_and_training_request.rb
+++ b/app/models/support/requests/accounts_permissions_and_training_request.rb
@@ -40,8 +40,8 @@ module Support
 
       def self.action_options
         @action_options ||= {
-          "Create a new user account" => "create_new_user",
           "Change an existing user's account" => "change_user",
+          "Create a new user account (non-Whitehall only)" => "create_new_user",
         }
       end
 

--- a/app/models/support/requests/accounts_permissions_and_training_request.rb
+++ b/app/models/support/requests/accounts_permissions_and_training_request.rb
@@ -90,11 +90,19 @@ module Support
       end
 
       def self.label
-        "Accounts, permissions and training"
+        "New accounts (non-Whitehall) and changing permissions"
       end
 
       def self.description
-        "Request a new Whitehall account or change permissions."
+        "Request a change to existing accounts and new accounts (non-Whitehall)."
+      end
+
+      def self.detailed_description
+        <<~TEXT
+          Request a change of permissions for an existing account, or a new account for a non-Whitehall user.
+          New Whitehall users must first complete training.
+          If this is what you need, please go back a step and select the ‘New accounts (Whitehall) and training’ option.
+        TEXT
       end
 
       def self.suspension

--- a/app/models/support/requests/accounts_permissions_and_training_request.rb
+++ b/app/models/support/requests/accounts_permissions_and_training_request.rb
@@ -9,7 +9,12 @@ module Support
                     :maslow,
                     :other_details,
                     :become_organisation_admin,
-                    :become_super_organisation_admin
+                    :become_super_organisation_admin,
+                    :manuals_publisher,
+                    :specialist_publisher,
+                    :travel_advice_publisher,
+                    :content_data,
+                    :feedex
 
       validate do |request|
         if request.requested_user && !request.requested_user.valid?
@@ -57,6 +62,9 @@ module Support
         needs_list << other_permissions_options.key("become_organisation_admin") if become_organisation_admin == "1"
         needs_list << other_permissions_options.key("become_super_organisation_admin") if become_super_organisation_admin == "1"
         needs_list << "Other: #{other_details}" if other_details.present?
+        new_account_options.each do |account_name, account_code|
+          needs_list << account_name if send(account_code) == "1"
+        end
         needs_list.reject(&:blank?).compact.join("\n")
       end
 
@@ -85,8 +93,22 @@ module Support
         }
       end
 
+      def self.new_account_options
+        @new_account_options ||= {
+          "Manuals Publisher" => "manuals_publisher",
+          "Specialist Publisher" => "specialist_publisher",
+          "Travel Advice Publisher (FCO)" => "travel_advice_publisher",
+          "Content Data" => "content_data",
+          "Feedex" => "feedex",
+        }
+      end
+
       def other_permissions_options
         self.class.other_permissions_options
+      end
+
+      def new_account_options
+        self.class.new_account_options
       end
 
       def self.label

--- a/app/models/support/requests/whitehall_accounts_permissions_and_training_request.rb
+++ b/app/models/support/requests/whitehall_accounts_permissions_and_training_request.rb
@@ -1,0 +1,17 @@
+module Support
+  module Requests
+    class WhitehallAccountsPermissionsAndTrainingRequest < Request
+      def initialize(opts = {})
+        super
+      end
+
+      def self.label
+        "New accounts (Whitehall) and training"
+      end
+
+      def self.description
+        "Request training and new accounts (Whitehall)"
+      end
+    end
+  end
+end

--- a/app/models/zendesk/ticket/accounts_permissions_and_training_request_ticket.rb
+++ b/app/models/zendesk/ticket/accounts_permissions_and_training_request_ticket.rb
@@ -40,11 +40,6 @@ module Zendesk
           ),
           Zendesk::LabelledSnippet.new(
             on: @request.requested_user,
-            field: :phone,
-            label: "Requested user's phone number",
-          ),
-          Zendesk::LabelledSnippet.new(
-            on: @request.requested_user,
             field: :formatted_training,
             label: "Requested user's training",
           ),

--- a/app/models/zendesk/ticket/accounts_permissions_and_training_request_ticket.rb
+++ b/app/models/zendesk/ticket/accounts_permissions_and_training_request_ticket.rb
@@ -40,11 +40,6 @@ module Zendesk
           ),
           Zendesk::LabelledSnippet.new(
             on: @request.requested_user,
-            field: :formatted_training,
-            label: "Requested user's training",
-          ),
-          Zendesk::LabelledSnippet.new(
-            on: @request.requested_user,
             field: :other_training,
             label: "Requested user's other training",
           ),

--- a/app/views/accounts_permissions_and_training_requests/_request_details.html.erb
+++ b/app/views/accounts_permissions_and_training_requests/_request_details.html.erb
@@ -1,6 +1,4 @@
-<div class="alert alert-info">
-  <p><%= f.object.class.description %></p>
-</div>
+<p><%= f.object.class.detailed_description %></p>
 
 <div id="action">
    <%= f.input :action, as: :radio, required: true, label: "What would you like to do?", collection: f.object.action_options, input_html: { :"aria-required" => true } %>

--- a/app/views/accounts_permissions_and_training_requests/_request_details.html.erb
+++ b/app/views/accounts_permissions_and_training_requests/_request_details.html.erb
@@ -8,6 +8,8 @@
   <p><%= f.object.class.suspension %></p>
 </div>
 
+<h2 class="add-bottom-margin">For changes to existing accounts, what permissions are you adding?</h2>
+
 <%= render partial: 'user_needs', locals: { f: f } %>
 
 <div id="user_details">

--- a/app/views/accounts_permissions_and_training_requests/_requested_user_details.html.erb
+++ b/app/views/accounts_permissions_and_training_requests/_requested_user_details.html.erb
@@ -3,7 +3,6 @@
     <%= r.input :name, label: "Name", required: true, input_html: { :"aria-required" => true, :class => "input-md-6" } %>
     <%= r.input :email, label: "Email", as: :email, required: true, input_html: { :"aria-required" => true, :class => "input-md-6" } %>
     <%= r.input :job, label: "Job title", input_html: { class: "input-md-6" } %>
-    <%= r.input :training, as: :check_boxes, collection: Support::GDS::RequestedUser::TRAINING_OPTIONS, label: "Which GOV.UK training has this user had?" %>
-    <%= r.input :other_training, label: "Other, give details", input_html: { class: "input-md-6" }, required: false %>
+    <%= r.input :other_training, label: "Which GOV.UK training has this user had?", input_html: { class: "input-md-6" }, required: false %>
   <% end %>
 <% end %>

--- a/app/views/accounts_permissions_and_training_requests/_requested_user_details.html.erb
+++ b/app/views/accounts_permissions_and_training_requests/_requested_user_details.html.erb
@@ -3,7 +3,6 @@
     <%= r.input :name, label: "Name", required: true, input_html: { :"aria-required" => true, :class => "input-md-6" } %>
     <%= r.input :email, label: "Email", as: :email, required: true, input_html: { :"aria-required" => true, :class => "input-md-6" } %>
     <%= r.input :job, label: "Job title", input_html: { class: "input-md-6" } %>
-    <%= r.input :phone, label: "Phone number", as: :phone, required: false, input_html: { class: "input-md-6" } %>
     <%= r.input :training, as: :check_boxes, collection: Support::GDS::RequestedUser::TRAINING_OPTIONS, label: "Which GOV.UK training has this user had?" %>
     <%= r.input :other_training, label: "Other, give details", input_html: { class: "input-md-6" }, required: false %>
   <% end %>

--- a/app/views/accounts_permissions_and_training_requests/_user_needs.html.erb
+++ b/app/views/accounts_permissions_and_training_requests/_user_needs.html.erb
@@ -32,7 +32,16 @@
         <li>for all related organisations that are modelled under your organisation</li>
       </ul>
     </div>
-    <%= f.input :other_details, label: "Other, give details", input_html: { class: "input-md-6" } %>
+    <%= f.input :other_details, label: "Any other permissions, give details", input_html: { class: "input-md-6" } %>
+    <div id="new_accounts">
+      <h2 class="add-bottom-margin"> Requesting new accounts for non-Whitehall users</h2>
+      <%= f.label :new_accounts, "Account permissions", class: "control-label" %>
+      <%= f.input :manuals_publisher, as: :boolean, label: f.object.new_account_options.key('manuals_publisher') %>
+      <%= f.input :specialist_publisher, as: :boolean, label: f.object.new_account_options.key('specialist_publisher') %>
+      <%= f.input :travel_advice_publisher, as: :boolean, label: f.object.new_account_options.key('travel_advice_publisher') %>
+      <%= f.input :content_data, as: :boolean, label: f.object.new_account_options.key('content_data') %>
+      <%= f.input :feedex, as: :boolean, label: f.object.new_account_options.key('feedex') %>
+    </div>
   </div>
   <% if f.object.errors[:formatted_user_needs].any? %>
     <span class="help-block">

--- a/app/views/accounts_permissions_and_training_requests/_user_needs.html.erb
+++ b/app/views/accounts_permissions_and_training_requests/_user_needs.html.erb
@@ -1,6 +1,6 @@
 <div id="user-needs"<%= ' class="has-error"'.html_safe if f.object.errors[:formatted_user_needs].any? %>>
   <div id="whitehall">
-    <%= f.input :user_needs, as: :radio, label: "Whitehall user accounts", collection: f.object.whitehall_account_options %>
+    <%= f.input :user_needs, as: :radio, label: "Whitehall permissions", collection: f.object.whitehall_account_options %>
     <div class="request-permissions-note">
       A managing editor can also:
       <ul>
@@ -15,7 +15,7 @@
     <%= f.input :mainstream_changes, as: :boolean, label: f.object.other_permissions_options.key('mainstream_changes') %>
     <%= f.input :maslow, as: :boolean, label: f.object.other_permissions_options.key('maslow') %>
 
-    <%= f.label :sigon_permissions, "Signon permissions", class: "control-label" %>
+    <%= f.label :sigon_permissions, "Admin permissions", class: "control-label" %>
     <%= f.input :become_organisation_admin, as: :boolean, label: f.object.other_permissions_options.key('become_organisation_admin') %>
     <div class="request-permissions-note">
       As an organisation admin you can:

--- a/spec/controllers/accounts_permissions_and_training_requests_controller_spec.rb
+++ b/spec/controllers/accounts_permissions_and_training_requests_controller_spec.rb
@@ -7,7 +7,6 @@ describe AccountsPermissionsAndTrainingRequestsController, type: :controller do
       "email" => "subject@digital.cabinet-office.gov.uk",
       "job" => "editor",
       "phone" => nil,
-      "training" => %w[writing using_publisher],
       "other_training" => "Various other forms of training",
     }
   end
@@ -31,7 +30,6 @@ describe AccountsPermissionsAndTrainingRequestsController, type: :controller do
         "requested_user_attributes" => {
           "name" => "subject",
           "email" => "subject@digital.cabinet-office.gov.uk",
-          "training" => %w[writing using_publisher],
           "other_training" => "Various other forms of training",
         },
         "action" => "change_user",

--- a/spec/controllers/accounts_permissions_and_training_requests_controller_spec.rb
+++ b/spec/controllers/accounts_permissions_and_training_requests_controller_spec.rb
@@ -6,7 +6,7 @@ describe AccountsPermissionsAndTrainingRequestsController, type: :controller do
       "name" => "subject",
       "email" => "subject@digital.cabinet-office.gov.uk",
       "job" => "editor",
-      "phone" => "12345",
+      "phone" => nil,
       "training" => %w[writing using_publisher],
       "other_training" => "Various other forms of training",
     }
@@ -55,8 +55,8 @@ describe AccountsPermissionsAndTrainingRequestsController, type: :controller do
       stub_user_creation = stub_zendesk_user_creation(
         email: "subject@digital.cabinet-office.gov.uk",
         name: "subject",
+        phone: nil,
         details: "Job title: editor",
-        phone: "12345",
         verified: true,
       )
 

--- a/spec/controllers/whitehall_accounts_permissions_and_training_requests_controller_spec.rb
+++ b/spec/controllers/whitehall_accounts_permissions_and_training_requests_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe WhitehallAccountsPermissionsAndTrainingRequestsController, type: :controller do
+  context "submitting request to create or train with a Whitehall account" do
+    let(:google_form_url) { "www.googledocs.com/sign_up_to_whitehall" }
+
+    before do
+      login_as create(:user_who_can_access_everything)
+    end
+
+    it "redirects to Whitehall form" do
+      allow_any_instance_of(described_class).to receive(:whitehall_signup_form_url).and_return(google_form_url)
+
+      get :new
+
+      expect(response).to redirect_to(google_form_url)
+    end
+  end
+end

--- a/spec/features/accounts_permissions_and_training_requests_spec.rb
+++ b/spec/features/accounts_permissions_and_training_requests_spec.rb
@@ -85,9 +85,6 @@ bob@gov.uk
 [Requested user's job title]
 Editor
 
-[Requested user's phone number]
-12345
-
 [Requested user's training]
 Writing for GOV.UK and Using Whitehall Publisher
 
@@ -103,7 +100,7 @@ XXXX",
         email: "bob@gov.uk",
         name: "Bob Fields",
         details: "Job title: Editor",
-        phone: "12345",
+        phone: nil,
         verified: true,
       )
 
@@ -113,7 +110,6 @@ XXXX",
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
         user_job_title: "Editor",
-        user_phone: "12345",
         writing: true,
         using_publisher: true,
         other_training: "Other training",
@@ -196,9 +192,6 @@ bob@gov.uk
 [Requested user's job title]
 Editor
 
-[Requested user's phone number]
-12345
-
 [Requested user's training]
 Writing for GOV.UK and Using Whitehall Publisher
 
@@ -214,7 +207,7 @@ XXXX",
         email: "bob@gov.uk",
         name: "Bob Fields",
         details: "Job title: Editor",
-        phone: "12345",
+        phone: nil,
         verified: true,
       )
 
@@ -224,7 +217,6 @@ XXXX",
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
         user_job_title: "Editor",
-        user_phone: "12345",
         writing: true,
         using_publisher: true,
         other_training: "Other training",
@@ -257,7 +249,6 @@ private
       fill_in "Name", with: details[:user_name]
       fill_in "Email", with: details[:user_email]
       fill_in "Job title", with: details[:user_job_title] if details[:user_job_title]
-      fill_in "Phone number", with: details[:user_phone] if details[:user_phone]
       check "Writing for GOV.UK" if details[:writing]
       check "Using Whitehall Publisher" if details[:using_publisher]
       fill_in "Other, give details", with: details[:other_training]
@@ -289,7 +280,6 @@ private
       fill_in "Name", with: details[:user_name]
       fill_in "Email", with: details[:user_email]
       fill_in "Job title", with: details[:user_job_title] if details[:user_job_title]
-      fill_in "Phone number", with: details[:user_phone] if details[:user_phone]
       check "Writing for GOV.UK" if details[:writing]
       check "Using Whitehall Publisher" if details[:using_publisher]
       fill_in "Other, give details", with: details[:other_training]
@@ -321,7 +311,6 @@ private
       fill_in "Name", with: details[:user_name]
       fill_in "Email", with: details[:user_email]
       fill_in "Job title", with: details[:user_job_title] if details[:user_job_title]
-      fill_in "Phone number", with: details[:user_phone] if details[:user_phone]
       check "Writing for GOV.UK" if details[:writing]
       check "Using Whitehall Publisher" if details[:using_publisher]
       fill_in "Other, give details", with: details[:other_training]

--- a/spec/features/accounts_permissions_and_training_requests_spec.rb
+++ b/spec/features/accounts_permissions_and_training_requests_spec.rb
@@ -239,9 +239,9 @@ private
   def user_requests_a_change_to_whitehall_user_accounts(details)
     visit "/"
 
-    click_on "Accounts, permissions and training"
+    click_on "New accounts (non-Whitehall) and changing permissions"
 
-    expect(page).to have_content("Request a new Whitehall account or change permissions.")
+    expect(page).to have_content("Request a change of permissions for an existing account, or a new account for a non-Whitehall user.")
 
     within "#action" do
       choose details[:action]
@@ -269,9 +269,9 @@ private
   def user_requests_a_change_to_other_user_accounts(details)
     visit "/"
 
-    click_on "Accounts, permissions and training"
+    click_on "New accounts (non-Whitehall) and changing permissions"
 
-    expect(page).to have_content("Request a new Whitehall account or change permissions.")
+    expect(page).to have_content("Request a change of permissions for an existing account, or a new account for a non-Whitehall user.")
 
     within "#action" do
       choose details[:action]

--- a/spec/features/accounts_permissions_and_training_requests_spec.rb
+++ b/spec/features/accounts_permissions_and_training_requests_spec.rb
@@ -34,9 +34,6 @@ Bob Fields
 [Requested user's email]
 bob@gov.uk
 
-[Requested user's training]
-Writing for GOV.UK and Using Whitehall Publisher
-
 [Requested user's other training]
 Other training
 
@@ -50,8 +47,6 @@ XXXX",
         user_needs: "Writer - can create content",
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
-        writing: true,
-        using_publisher: true,
         other_training: "Other training",
         additional_comments: "XXXX",
       )
@@ -85,9 +80,6 @@ bob@gov.uk
 [Requested user's job title]
 Editor
 
-[Requested user's training]
-Writing for GOV.UK and Using Whitehall Publisher
-
 [Requested user's other training]
 Other training
 
@@ -110,8 +102,6 @@ XXXX",
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
         user_job_title: "Editor",
-        writing: true,
-        using_publisher: true,
         other_training: "Other training",
         additional_comments: "XXXX",
       )
@@ -141,9 +131,6 @@ Bob Fields
 [Requested user's email]
 bob@gov.uk
 
-[Requested user's training]
-Writing for GOV.UK and Using Whitehall Publisher
-
 [Requested user's other training]
 Other training
 
@@ -157,8 +144,6 @@ XXXX",
         user_needs: ["Request changes to your organisation’s mainstream content", "Access to Maslow database of user needs", "Request permission to be a super organisation admin"],
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
-        writing: true,
-        using_publisher: true,
         other_training: "Other training",
         additional_comments: "XXXX",
       )
@@ -192,9 +177,6 @@ bob@gov.uk
 [Requested user's job title]
 Editor
 
-[Requested user's training]
-Writing for GOV.UK and Using Whitehall Publisher
-
 [Requested user's other training]
 Other training
 
@@ -217,8 +199,6 @@ XXXX",
         user_name: "Bob Fields",
         user_email: "bob@gov.uk",
         user_job_title: "Editor",
-        writing: true,
-        using_publisher: true,
         other_training: "Other training",
         additional_comments: "XXXX",
       )
@@ -249,9 +229,7 @@ private
       fill_in "Name", with: details[:user_name]
       fill_in "Email", with: details[:user_email]
       fill_in "Job title", with: details[:user_job_title] if details[:user_job_title]
-      check "Writing for GOV.UK" if details[:writing]
-      check "Using Whitehall Publisher" if details[:using_publisher]
-      fill_in "Other, give details", with: details[:other_training]
+      fill_in "Which GOV.UK training has this user had?", with: details[:other_training]
     end
 
     fill_in "Additional comments", with: details[:additional_comments]
@@ -280,9 +258,7 @@ private
       fill_in "Name", with: details[:user_name]
       fill_in "Email", with: details[:user_email]
       fill_in "Job title", with: details[:user_job_title] if details[:user_job_title]
-      check "Writing for GOV.UK" if details[:writing]
-      check "Using Whitehall Publisher" if details[:using_publisher]
-      fill_in "Other, give details", with: details[:other_training]
+      fill_in "Which GOV.UK training has this user had?", with: details[:other_training]
     end
 
     fill_in "Additional comments", with: details[:additional_comments]
@@ -311,9 +287,7 @@ private
       fill_in "Name", with: details[:user_name]
       fill_in "Email", with: details[:user_email]
       fill_in "Job title", with: details[:user_job_title] if details[:user_job_title]
-      check "Writing for GOV.UK" if details[:writing]
-      check "Using Whitehall Publisher" if details[:using_publisher]
-      fill_in "Other, give details", with: details[:other_training]
+      fill_in "Which GOV.UK training has this user had?", with: details[:other_training]
     end
 
     fill_in "Additional comments", with: details[:additional_comments]

--- a/spec/features/accounts_permissions_and_training_requests_spec.rb
+++ b/spec/features/accounts_permissions_and_training_requests_spec.rb
@@ -17,13 +17,13 @@ feature "Accounts, permissions and training requests" do
       zendesk_has_no_user_with_email("bob@gov.uk")
 
       ticket_request = expect_zendesk_to_receive_ticket(
-        "subject" => "Create a new user account",
+        "subject" => "Create a new user account (non-Whitehall only)",
         "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
         "tags" => %w[govt_form create_new_user inside_government],
         "comment" => {
           "body" =>
 "[Action]
-Create a new user account
+Create a new user account (non-Whitehall only)
 
 [User needs]
 Editor - can create, review and publish content
@@ -128,13 +128,13 @@ XXXX",
       zendesk_has_no_user_with_email("bob@gov.uk")
 
       ticket_request = expect_zendesk_to_receive_ticket(
-        "subject" => "Create a new user account",
+        "subject" => "Create a new user account (non-Whitehall only)",
         "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
         "tags" => %w[govt_form create_new_user],
         "comment" => {
           "body" =>
 "[Action]
-Create a new user account
+Create a new user account (non-Whitehall only)
 
 [User needs]
 Request changes to your organisation’s mainstream content

--- a/spec/models/support/gds/requested_user_spec.rb
+++ b/spec/models/support/gds/requested_user_spec.rb
@@ -9,32 +9,8 @@ module Support
       it { should allow_value("director").for(:job) }
       it { should allow_value("07911111").for(:phone) }
       it { should allow_value("ab@c.com").for(:email) }
-      it { should allow_value("writing").for(:training) }
-      it { should allow_value("using_publisher").for(:training) }
-      it { should_not allow_value("derp").for(:training) }
+      it { should allow_value("some training").for(:other_training) }
       it { should_not allow_value("ab").for(:email) }
-
-      describe "training validation" do
-        context "when no options were provided" do
-          subject { described_class.new }
-
-          it "requires 'other' to be specified" do
-            subject.validate
-
-            expect(subject).to have(1).errors_on(:other_training)
-          end
-        end
-
-        context "when one or more options were provided" do
-          subject { described_class.new(training: %w[using_publisher]) }
-
-          it "does not require 'other' to be specified" do
-            subject.validate
-
-            expect(subject).to have(0).errors_on(:other_training)
-          end
-        end
-      end
     end
   end
 end

--- a/spec/models/support/requests/accounts_permissions_and_training_request_spec.rb
+++ b/spec/models/support/requests/accounts_permissions_and_training_request_spec.rb
@@ -114,6 +114,34 @@ module Support
             end
           end
         end
+
+        context "for new account permissions" do
+          context "when one is ticked" do
+            it "returns the name of the application" do
+              expect(request(manuals_publisher: "1").formatted_user_needs)
+                .to eq("Manuals Publisher")
+
+              expect(request(specialist_publisher: "1").formatted_user_needs)
+                  .to eq("Specialist Publisher")
+
+              expect(request(travel_advice_publisher: "1").formatted_user_needs)
+                  .to eq("Travel Advice Publisher (FCO)")
+
+              expect(request(content_data: "1").formatted_user_needs)
+                  .to eq("Content Data")
+
+              expect(request(feedex: "1").formatted_user_needs)
+              .to eq("Feedex")
+            end
+          end
+
+          context "when several are ticked" do
+            it "returns the name of each application, with one per line" do
+              expect(request(manuals_publisher: "1", travel_advice_publisher: "1").formatted_user_needs)
+                .to eq("Manuals Publisher\nTravel Advice Publisher (FCO)")
+            end
+          end
+        end
       end
     end
   end

--- a/spec/models/support/requests/accounts_permissions_and_training_request_spec.rb
+++ b/spec/models/support/requests/accounts_permissions_and_training_request_spec.rb
@@ -23,7 +23,7 @@ module Support
       end
 
       it "provides formatted action" do
-        expect(request(action: "create_new_user").formatted_action).to eq("Create a new user account")
+        expect(request(action: "create_new_user").formatted_action).to eq("Create a new user account (non-Whitehall only)")
         expect(request(action: "change_user").formatted_action).to eq("Change an existing user's account")
       end
 


### PR DESCRIPTION
This PR alters the process for users requesting account access and training.

Previously all account access was managed through submitting a single form to Zendesk.

Access to Whitehall is now managed through a separate GoogleDocs form, so a specific entry for this is now included on the homepage.

The labels and titles on the homepage are changed to draw attention to the new process.

The current form has undergone various changes:
 * Removing reference to Whitehall account access, and instructions to instead use the GoogleDoc
* Adding options to request access to additional applications
* Removing preset training options
* Removing option to submit phone number

[Trello](https://trello.com/c/NQVGTJ6b/1968-2-changes-to-support-home-page)