### PR TITLE
Run RuboCop as part of `bundle exec rake` defaults

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,11 +6,3 @@ inherit_gem:
 inherit_mode:
   merge:
     - Exclude
-
-Metrics/BlockLength:
-  Enabled: true
-  Exclude:
-    - test/**/*
-    - spec/**/*
-Style/FormatStringToken:
-  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -9,5 +9,6 @@ Support::Application.load_tasks
 Rake::Task["default"].clear
 
 task :default do
+  Rake::Task["lint"].invoke
   Rake::Task["spec"].invoke
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run RuboCop"
+task lint: :environment do
+  sh "bundle exec rubocop --format clang"
+end


### PR DESCRIPTION
- This is a prerequisite for being able to move more of our apps to
  GitHub Actions. We want one single step bundle exec rake that runs
  everything. This ensures parity between local dev and what CI runs
  (something that we don't always have now).
- Also tidy up the contents of `.rubocop.yml` - the disabled cops here
  are all disabled in the gem configs these days.

https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks
