### PR TITLE
Update content on request new campaign page

### DIFF
--- a/app/models/zendesk/ticket/campaign_request_ticket.rb
+++ b/app/models/zendesk/ticket/campaign_request_ticket.rb
@@ -21,7 +21,7 @@ module Zendesk
           Zendesk::LabelledSnippet.new(
             on: @request.campaign,
             field: :signed_campaign,
-            label: "Name of the head of digital who signed off the campaign website application",
+            label: "Name of the Head of Digital Communications who signed off the campaign website application",
           ),
           Zendesk::LabelledSnippet.new(
             on: @request.campaign,

--- a/app/views/campaign_requests/_request_details.html.erb
+++ b/app/views/campaign_requests/_request_details.html.erb
@@ -32,7 +32,7 @@
                 as: :boolean,
                 input_html: {:class => "input-md-6"} %>
     <%= r.input :signed_campaign,
-                label: "Name of the head of digital who signed off the campaign website application",
+                label: "Name of the Head of Digital Communications who signed off the campaign website application",
                 required: true,
                 input_html: {:class => "input-md-6"} %>
     <%= r.input :start_date,

--- a/spec/features/campaign_requests_spec.rb
+++ b/spec/features/campaign_requests_spec.rb
@@ -23,7 +23,7 @@ feature "Campaign requests" do
 "[Are you applying for the campaign platform or a bespoke microsite?]
 Campaign platform
 
-[Name of the head of digital who signed off the campaign website application]
+[Name of the Head of Digital Communications who signed off the campaign website application]
 John Smith
 
 [Start date of campaign site]
@@ -106,7 +106,7 @@ private
     choose details[:type_of_site]
     check "Have you read the the GCS guidance on campaign websites and accept the requirements for a Campaign Platform website?" if details[:has_read_guidance]
     check "Have you followed the GCS guidance for OASIS planning and are using the mandatory GCS OASIS template?" if details[:has_read_oasis_guidance]
-    fill_in "Name of the head of digital who signed off the campaign website application*", with: details[:signed_campaign]
+    fill_in "Name of the Head of Digital Communications who signed off the campaign website application*", with: details[:signed_campaign]
     fill_in "Start date of campaign site*", with: details[:start_date]
     fill_in "Proposed end date of campaign site*", with: details[:end_date]
     fill_in "Site build to commence on", with: details[:development_start_date]


### PR DESCRIPTION
This is a content change to update the new campaign request form

We are changing the old content:
"Name of the head of digital who signed off the campaign website application"

To:
"Name of the Head of Digital Communications who signed off the campaign website application"


<img width="952" alt="Screenshot 2020-09-10 at 11 35 45" src="https://user-images.githubusercontent.com/41922771/92719751-8b212480-f35b-11ea-94f8-a9808e4ccb3a.png">
