### PR TITLE
Remove redundant GDS SSO initializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
+/coverage
 !/log/.keep
 !/tmp/.keep
 

--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -1,10 +1,3 @@
-GDS::SSO.config do |config|
-  config.user_model   = "User"
-  config.oauth_id     = ENV["OAUTH_ID"] || "abcdefghjasndjkasndsupport"
-  config.oauth_secret = ENV["OAUTH_SECRET"] || "secret"
-  config.oauth_root_url = Plek.new.external_url_for("signon")
-end
-
 if Rails.env.development? && ENV["GDS_SSO_STRATEGY"] != "real"
   GDS::SSO.test_user = User.upsert!(
     "uid" => "dummy-user",


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

This was made redundant in [1].

[1]: https://github.com/alphagov/gds-sso/pull/241