### PR TITLE
Revise tech docs in README to favour GOV.UK Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Support
 
-Forms that create tickets for requests coming from government agencies or from GOV.UK contact forms. Tickets are created using the [gds_zendesk gem](https://github.com/alphagov/gds_zendesk).
+This app:
+
+- Presents anonymous feedback about pages on GOV.UK in a "feedback explorer". Anonymous feedback is collected via the [Feedback app](https://github.com/alphagov/feedback) and retrieved from the [Support API](https://github.com/alphagov/support-api).
+
+- Exposes [internal APIs](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/support.rb) to create Zendesk tickets e.g. [via the Feedback app](https://github.com/alphagov/feedback/blob/7e6893c0e80d9c98f6cea27d1bd089621054b177/app/models/contact_ticket.rb#L35). Tickets are created using the [gds_zendesk gem](https://github.com/alphagov/gds_zendesk).
+
+- Hosts internal forms for publishers to create Zendesk tickets, as well as emergency contact info. Emergency contacts are secret and retrieved from an [environment variable](https://github.com/alphagov/govuk-puppet/blob/941373ab48ae50a9d1929caee73a52390004bf81/modules/govuk/manifests/apps/support.pp#L129) at runtime.
 
 ## Nomenclature
 
@@ -9,35 +15,11 @@ of some form or other and relates to pages published on GOV.UK.
 - **Anonymous Contact**: Part of the feedback collected by this app is anonymous, when it's
 submitted via an anonymous contact form in the [feedback app](https://github.com/alphagov/feedback).
 - **Named Contact**: In contrast with the `Anonymous Contact` feedback, this is submitted
-via a form that will require you to identify yourself. This data is sent directly
-to the `support` app.
+via a form that will require you to identify yourself.
 
 ## Technical documentation
 
-This is a Ruby on Rails application which collects feedback and creates tickets based on it.
-It collects data from two sources:
-- its own forms which can be accessed by [signon](https://github.com/alphagov/signon) users
-- contact forms from the [feedback app](https://github.com/alphagov/feedback)
-
-The data collected from either the `feedback` app or its own forms is then used to create
-and submit Zendesk tickets.
-
-Even though it is not public facing, the `support` app does receive data from the [feedback app](https://github.com/alphagov/feedback),
-which collects data via contact forms rendered on GOV.UK.
-
-#### Feedback explorer
-
-At the bottom of every page on GOV.UK we ask: “Is there anything wrong with this page?”.
-Users can leave comments on what they were doing and what went wrong. Feedback is anonymous
-and is collected via the `feedback` app.
-
-The Feedback explorer in the `support` app allows users to browse the feedback submitted from GOV.UK pages,
-and to export CSVs of the same for further analysis.
-
-### Dependencies
-
-- [alphagov/support-api](https://github.com/alphagov/support-api) - provides an API for storing
-and fetching anonymous feedback about pages on GOV.UK.
+This is a Ruby on Rails application.
 
 ### Running the test suite
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ To start the background worker:
 ```
 bundle exec rake jobs:work
 ```
+
+## Licence
+
+[MIT License](LICENCE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Support
 
-Forms that create tickets for requests coming from government agencies or from GOV.UK contact forms.
+Forms that create tickets for requests coming from government agencies or from GOV.UK contact forms. Tickets are created using the [gds_zendesk gem](https://github.com/alphagov/gds_zendesk).
 
 ## Nomenclature
 
@@ -33,11 +33,6 @@ and is collected via the `feedback` app.
 
 The Feedback explorer in the `support` app allows users to browse the feedback submitted from GOV.UK pages,
 and to export CSVs of the same for further analysis.
-
-#### Zendesk
-
-Currently we use Zendesk to register our support tickets, via the `gds_zendesk` gem which is
-a wrapper around the Zendesk API.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -25,27 +25,6 @@ and submit Zendesk tickets.
 Even though it is not public facing, the `support` app does receive data from the [feedback app](https://github.com/alphagov/feedback),
 which collects data via contact forms rendered on GOV.UK.
 
-#### Types of requests from the Support app forms
-
-The support app lets people who use the GOV.UK publishing tools ask for specific help from the GOV.UK team.
-
-The types of forms and their purpose are listed below:
-- "Content advice and help": Asking for help or advice on any content problems. Request short URLs, topical event pages, groups or manuals
-- "Content changes and new content requests": Request changes to GOV.UK content managed by GDS content designers
-- "Unpublish content": Request to unpublish content
-- "Changes to publishing applications or technical advice": Request for changes or new features for any publishing applications or ask for technical advice. Also used for transitioning new sites to GOV.UK.
-- "Report a technical fault to GDS": report something that is not working with any publishing application, eg Whitehall, finders or specialist publisher. Also used for urgent technical changes.
-- "Accounts, permissions and training": Request a new account, change an account or unlock an account
-- "Remove user": Request to remove user access
-- "Request a new campaign": Request GDS supoort for a new campaign
-- "Support for live campaign": Request GDS support for a live campaign
-- "Suggest a new topic": Suggest a new topic for the GOV.UK taxonomy
-- "Suggest a change to a topic": Suggest a change to a topic or the removal of a topic in the GOV.UK taxonomy
-- "Analytics access, reports and help": Request access to Google Analytics or help with analytics and reports
-- "General": Report a problem, request GDS support, or make a suggestion
-- "Feedback explorer": GOV.UK Anonymous Feedback
-- "Emergency contact details": Contact GOV.UK in an emergency
-
 #### Feedback explorer
 
 At the bottom of every page on GOV.UK we ask: “Is there anything wrong with this page?”.

--- a/README.md
+++ b/README.md
@@ -19,13 +19,17 @@ via a form that will require you to identify yourself.
 
 ## Technical documentation
 
-This is a Ruby on Rails application.
+This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
+
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
+
+**Use GOV.UK Docker to run any commands that follow.**
 
 ### Running the test suite
 
-To run the specs, execute:
-
-    bundle exec rake
+```
+bundle exec rake
+```
 
 ### Starting the background processing queues
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 bundle exec rake
 ```
 
-### Starting the background processing queues
+### Running the worker
 
-Zendesk tickets are raised in the background using a redis-backed queue called [sidekiq](http://sidekiq.org/).
+Zendesk tickets are raised in the background using a [Sidekiq](http://sidekiq.org/) worker.
 
-To start the background workers:
+To start the background worker:
 
-    rake jobs:work
+```
+bundle exec rake jobs:work
+```

--- a/startup.sh
+++ b/startup.sh
@@ -1,3 +1,0 @@
-bundle
-bundle exec rails s -p 3031
-


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

This follows the pattern established in [1].

Ideally this repo would also have docs to explain the
data model for support forms, but that's out-of-scope for
this PR. Please see the commit messages for more details.

[1]: alphagov/content-publisher#2257