### PR TITLE
Update campaign form

### DIFF
--- a/app/models/support/gds/campaign.rb
+++ b/app/models/support/gds/campaign.rb
@@ -40,7 +40,7 @@ module Support
                 presence: true
 
       validates :has_read_guidance_confirmation, :has_read_oasis_guidance_confirmation, acceptance: { allow_nil: false }
-      validates :type_of_site, inclusion: { in: ["Campaign platform", "Bespoke microsite"] }
+      validates :type_of_site, inclusion: { in: ["Single page campaign platform site", "Multi page site"] }
 
       validates_date :start_date, on_or_after: :today
       validates_date :end_date, after: :start_date

--- a/app/models/zendesk/ticket/campaign_request_ticket.rb
+++ b/app/models/zendesk/ticket/campaign_request_ticket.rb
@@ -16,7 +16,7 @@ module Zendesk
           Zendesk::LabelledSnippet.new(
             on: @request.campaign,
             field: :type_of_site,
-            label: "Are you applying for the campaign platform or a bespoke microsite?",
+            label: "Are you applying for the single page campaign platform or a bespoke multi page site?",
           ),
           Zendesk::LabelledSnippet.new(
             on: @request.campaign,

--- a/app/views/campaign_requests/_request_details.html.erb
+++ b/app/views/campaign_requests/_request_details.html.erb
@@ -3,15 +3,9 @@
 </div>
 
 <p>
-  Use this form for : Campaign Platform site or microsite
-<ul>
-  <li>A campaign platform site is a one page website on campaign.gov.uk</li>
-  <li>Microsite websites are not built on GOV.UK and may or may not have
-    a gov.uk url.
-    Microsite websites <%= link_to 'fall under Cabinet Office digital service expenditure', 'https://www.google.com/url?q=https://www.gov.uk/service-manual/agile-delivery/spend-controls-check-if-you-need-approval-to-spend-money-on-a-service%23when-your-service-is-considered-a-digital-service&sa=D&ust=1518444538536000&usg=AFQjCNFvnZ81hn7cqJnGHgcgQ0V0bdwCBQ'%>
-    therefore GDS spend approval must be sought following approval from GCS to develop a campaign microsite.
-  </li>
-</ul>
+  Use this form for: Wordpress “single page” Campaign Platform site, or bespoke “multi page” site
+</p>
+<p>
   For either type of site, please answer the questions below.
 </p>
 
@@ -24,11 +18,11 @@
     <div class="form-group">
       <span class="form-label control-label">
         <%= r.label :type_of_site do %>
-          Are you applying for the campaign platform or a bespoke microsite?<abbr title="required">*</abbr>
+          Are you applying for the single page campaign platform or a bespoke multi page site?<abbr title="required">*</abbr>
         <% end %>
       </span>
       <span class="form-wrapper">
-        <%= r.collection_radio_buttons :type_of_site, ["Campaign platform", "Bespoke microsite"], :itself, :itself, required: true, aria: { required: true } do |builder| %>
+        <%= r.collection_radio_buttons :type_of_site, ["Single page campaign platform site", "Multi page site"], :itself, :itself, required: true, aria: { required: true } do |builder| %>
           <div class="radio">
             <%= builder.label(class: "custom-control-label") do %>
               <%= builder.radio_button(class: "custom-control-input") %>
@@ -209,7 +203,7 @@
     </div>
     <p class="help-block">
       If applying for Campaigns Platform it is in the form of xxxxx.campaign.gov.uk, or otherwise
-      if a microsite, standard format is  in the form of xxxxxx.gov.uk.
+      if a bespoke multi page site, standard format is in the form of xxxxxx.gov.uk.
     </p>
 
     <div class="form-group">

--- a/spec/features/campaign_requests_spec.rb
+++ b/spec/features/campaign_requests_spec.rb
@@ -20,8 +20,8 @@ feature "Campaign requests" do
       "tags" => %w[govt_form campaign],
       "comment" => {
         "body" =>
-"[Are you applying for the campaign platform or a bespoke microsite?]
-Campaign platform
+"[Are you applying for the single page campaign platform or a bespoke multi page site?]
+Single page campaign platform site
 
 [Name of the Head of Digital Communications who signed off the campaign website application]
 John Smith
@@ -71,7 +71,7 @@ Some comment",
     )
 
     user_makes_a_campaign_request(
-      type_of_site: "Campaign platform",
+      type_of_site: "Single page campaign platform site",
       has_read_guidance: true,
       has_read_oasis_guidance: true,
       signed_campaign: "John Smith",

--- a/spec/models/support/gds/campaign_spec.rb
+++ b/spec/models/support/gds/campaign_spec.rb
@@ -9,7 +9,7 @@ module Support
 
       subject do
         Campaign.new(
-          type_of_site: "Campaign platform",
+          type_of_site: "Single page campaign platform site",
           signed_campaign: "Test Signer",
           has_read_guidance_confirmation: "1",
           has_read_oasis_guidance_confirmation: "1",
@@ -46,7 +46,7 @@ module Support
       it { should validate_acceptance_of(:has_read_guidance_confirmation) }
       it { should validate_acceptance_of(:has_read_oasis_guidance_confirmation) }
 
-      it { should validate_inclusion_of(:type_of_site).in?(["Campaign platform", "Bespoke microsite"]) }
+      it { should validate_inclusion_of(:type_of_site).in?(["Single page campaign platform site", "Multi page site"]) }
 
       it { should validate_acceptance_of(:has_read_guidance_confirmation) }
       it { should validate_acceptance_of(:has_read_oasis_guidance_confirmation) }


### PR DESCRIPTION
We want to update the campaigns application form in the Support app to reflect changes in the way campaigns are applied for.

To this end we want to remove the existing text from the current form 

 • A campaign platform site is a one page website on campaign.gov.uk
 • Microsite websites are not built on GOV.UK and may or may not have a gov.uk url. Microsite websites fall under Cabinet 
    Office digital service expenditure therefore GDS spend approval must be sought following approval from GCS to 
    develop a campaign microsite.*

We also want to remove any reference to microsites. 

**BEFORE**
<img width="1181" alt="Screenshot 2021-04-16 at 13 35 05" src="https://user-images.githubusercontent.com/41922771/115024956-ab4c2f80-9eb8-11eb-88c2-9b17694efabd.png">

**AFTER**
<img width="1187" alt="Screenshot 2021-04-27 at 10 02 12" src="https://user-images.githubusercontent.com/41922771/116215964-0c3cf880-a740-11eb-973c-7603eb86664b.png">

[Trello](https://trello.com/c/C7maXqA2/324-non-covid-update-campaigns-application-form-in-support-app)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
