### PR TITLE
Update emergency contact details page content

### DIFF
--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -4,153 +4,152 @@
 <% breadcrumb :emergency_contact_details %>
 
 <main class="add-bottom-padding">
-<section>
-  <blockquote class="bg-danger danger-callout">
-    <p>First read the guidance on <%= link_to "publishing procedures for national emergencies", "https://www.gov.uk/guidance/contact-the-government-digital-service/gov-uk-support-requests-processes-and-response-times" %> and <%= link_to "GOV.UK contact procedures", "https://www.gov.uk/guidance/contact-the-government-digital-service/how-to-contact-gds" %>.</p>
-  </blockquote>
-</section>
+  <section>
+    <blockquote class="bg-danger danger-callout">
+      <p>First read the guidance on <%= link_to "publishing procedures for national emergencies", "https://www.gov.uk/guidance/contact-the-government-digital-service/gov-uk-support-requests-processes-and-response-times" %> and <%= link_to "GOV.UK contact procedures", "https://www.gov.uk/guidance/contact-the-government-digital-service/how-to-contact-gds" %>.</p>
+    </blockquote>
+  </section>
 
-<section class="add-top-padding">
-  <div class="row">
-    <div class="col-md-6">
-      <p>What you need to do depends on whether you want to:</p>
-      <ul>
-        <li><%= link_to "request a change to GOV.UK content", anchor: "request-change" %></li>
-        <li><%= link_to "report a major technical problem" , anchor: "report-problem" %></li>
-        <li><%= link_to "update GOV.UK following a national emergency", anchor: "national-emergency" %></li>
-        <li><%= link_to "get help with GOV.UK Verify", anchor: "govuk-verify" %></li>
-      </ul>
+  <section class="add-top-padding">
+    <div class="row">
+      <div class="col-md-6">
+        <p>What you need to do depends on whether you want to:</p>
+        <ul>
+          <li><%= link_to "request a change to GOV.UK content", anchor: "request-change" %></li>
+          <li><%= link_to "report a major technical problem" , anchor: "report-problem" %></li>
+          <li><%= link_to "update GOV.UK following a national emergency", anchor: "national-emergency" %></li>
+          <li><%= link_to "get help with GOV.UK Verify", anchor: "govuk-verify" %></li>
+        </ul>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="add-bottom-padding add-top-padding">
-  <h2 id="request-change">Request a change to GOV.UK content</h2>
-  <div class="row">
-    <div class="col-md-6">
-      <p>Before you call, you must first:</p>
-      <ul>
-        <li><%= link_to "submit a support request", new_content_change_request_path %> before you phone</li>
-        <li><%= link_to "read the full guidelines", "https://www.gov.uk/government/publications/govuk-support-requests-our-processes-and-response-times" %></li>
-        <li>leave a message and a contact number if the phone is not answered - please do not text</li>
-      </ul>
-      <p>The phone number you need and what counts as an emergency depends on whether you are calling within office hours.</p>
-      <p>Both phone numbers will put you in contact with a member of the GOV.UK content team.</p>
+  <section class="add-bottom-padding add-top-padding">
+    <h2 id="request-change">Request a change to GOV.UK content</h2>
+    <div class="row">
+      <div class="col-md-6">
+        <p>Before you call, you must first:</p>
+        <ul>
+          <li><%= link_to "submit a support request", new_content_change_request_path %> before you phone</li>
+          <li><%= link_to "read the full guidelines", "https://www.gov.uk/government/publications/govuk-support-requests-our-processes-and-response-times" %></li>
+          <li>leave a message and a contact number if the phone is not answered - please do not text</li>
+        </ul>
+        <p>The phone number you need and what counts as an emergency depends on whether you are calling within office hours.</p>
+        <p>Both phone numbers will put you in contact with a member of the GOV.UK content team.</p>
+      </div>
     </div>
-  </div>
 
-  <h3>Office hours (Monday to Friday, 9am to 6pm)</h3>
-  <div class="row">
-    <div class="col-md-6">
-      <p>Use only if either:</p>
-      <ul>
-        <li>you’re unable to publish at a critical time</li>
-        <li>you need to make emergency changes to government content managed by GDS</li>
-      </ul>
+    <h3>Office hours (Monday to Friday, 9am to 6pm)</h3>
+    <div class="row">
+      <div class="col-md-6">
+        <p>Use only if either:</p>
+        <ul>
+          <li>you’re unable to publish at a critical time</li>
+          <li>you need to make emergency changes to government content managed by GDS</li>
+        </ul>
+      </div>
     </div>
-  </div>
-  <div class="row add-bottom-padding add-top-padding">
-    <div class="col-md-12">
-      <p class="remove-bottom-margin"><%= @primary_contact_details[:urgent_department_content_change][:phone] %></p>
-      <p>Monday to Friday, 9am to 6pm<br>(excluding bank holidays)</p>
+    <div class="row add-bottom-padding add-top-padding">
+      <div class="col-md-12">
+        <p class="remove-bottom-margin"><%= @primary_contact_details[:urgent_department_content_change][:phone] %></p>
+        <p>Monday to Friday, 9am to 6pm<br>(excluding bank holidays)</p>
+      </div>
     </div>
-  </div>
 
-  <h3>Outside office hours, including bank holidays</h3>
-  <div class="row">
-    <div class="col-md-6">
-      <p>Use only if the public or government is facing immediate and significant financial, legal or physical risk.</p>
+    <h3>Outside office hours, including bank holidays</h3>
+    <div class="row">
+      <div class="col-md-6">
+        <p>Use only if the public or government is facing immediate and significant financial, legal or physical risk.</p>
+      </div>
     </div>
-  </div>
-  <div class="row add-bottom-padding add-top-padding">
-    <div class="col-md-12">
-      <p class="remove-bottom-margin"><%= @primary_contact_details[:urgent_mainstream_content_change][:phone] %></p>
-      <p>Monday to Friday, 6pm to 9am<br>Weekends and bank holidays, 24 hours</p>
+    <div class="row add-bottom-padding add-top-padding">
+      <div class="col-md-12">
+        <p class="remove-bottom-margin"><%= @primary_contact_details[:urgent_mainstream_content_change][:phone] %></p>
+        <p>Monday to Friday, 6pm to 9am<br>Weekends and bank holidays, 24 hours</p>
+      </div>
     </div>
-  </div>
 
-  <h2 id="report-problem">Report a major technical problem with GOV.UK</h2>
-  <div class="row">
-    <div class="col-md-6">
-      <p>Use only for critical, high-profile technical issues with the GOV.UK site - such as pages not loading or search not working.</p>
+    <h2 id="report-problem">Report a major technical problem with GOV.UK</h2>
+    <div class="row">
+      <div class="col-md-6">
+        <p>Use only for critical, high-profile technical issues with the GOV.UK site - such as pages not loading or search not working.</p>
+      </div>
     </div>
-  </div>
-  <div class="row add-bottom-padding add-top-padding">
-    <div class="col-md-12">
-      <p class="remove-bottom-margin"><%= @primary_contact_details[:major_technical_problems][:phone] %></p>
-      <p>24 hours, 7 days a week</p>
+    <div class="row add-bottom-padding add-top-padding">
+      <div class="col-md-12">
+        <p class="remove-bottom-margin"><%= @primary_contact_details[:major_technical_problems][:phone] %></p>
+        <p>24 hours, 7 days a week</p>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-md-6">
-      <p>This number will put you in contact with a member of the GOV.UK escalations team, who will advise on next steps.</p>
+    <div class="row">
+      <div class="col-md-6">
+        <p>This number will put you in contact with a member of the GOV.UK escalations team, who will advise on next steps.</p>
+      </div>
     </div>
-  </div>
 
-  <h2 id="national-emergency">Update GOV.UK following a national emergency</h3>
-  <div class="row">
-    <div class="col-md-6">
-      <p>Use only if both:</p>
-      <ul>
-        <li>there’s been a sudden, critical national emergency such as a terrorist attack</li>
-        <li>you’re the communications coordinator in the lead crisis response department for sudden, critical national emergencies such as terrorist attacks
-        </li>
-      </ul>
+    <h2 id="national-emergency">Update GOV.UK following a national emergency</h3>
+    <div class="row">
+      <div class="col-md-6">
+        <p>Use only if both:</p>
+        <ul>
+          <li>there’s been a sudden, critical national emergency such as a terrorist attack</li>
+          <li>you’re the communications coordinator in the lead crisis response department for sudden, critical national emergencies such as terrorist attacks</li>
+        </ul>
+      </div>
     </div>
-  </div>
-  <div class="row add-bottom-padding add-top-padding">
-    <div class="col-md-12">
-      <p class="remove-bottom-margin"><%= @primary_contact_details[:national_emergencies][:phone] %></p>
-      <p>24 hours, 7 days a week</p>
+    <div class="row add-bottom-padding add-top-padding">
+      <div class="col-md-12">
+        <p class="remove-bottom-margin"><%= @primary_contact_details[:national_emergencies][:phone] %></p>
+        <p>24 hours, 7 days a week</p>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-md-6">
-      <p>This number will put you in contact with GOV.UK, who will establish your identity and put the GOV.UK site into ‘emergency’ mode.</p>
-      <p>Find out more about the <%= link_to "national emergency publishing process", "https://www.gov.uk/guidance/contact-the-government-digital-service/national-emergency-publishing-guidelines" %>.</p>
+    <div class="row">
+      <div class="col-md-6">
+        <p>This number will put you in contact with GOV.UK, who will establish your identity and put the GOV.UK site into ‘emergency’ mode.</p>
+        <p>Find out more about the <%= link_to "national emergency publishing process", "https://www.gov.uk/guidance/contact-the-government-digital-service/national-emergency-publishing-guidelines" %>.</p>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<% if @secondary_contact_details %>
+  <% if @secondary_contact_details %>
     <section class="add-bottom-padding add-top-padding">
-    <h3>Backup contact</h3>
-    <div class="row">
+      <h3>Backup contact</h3>
+      <div class="row">
         <div class="col-md-6">
-        <p>If you cannot get through on the other numbers, you can call the Head of GOV.UK.</p>
+          <p>If you cannot get through on the other numbers, you can call the Head of GOV.UK.</p>
         </div>
-    </div>
-    <div class="row">
+      </div>
+      <div class="row">
         <% @secondary_contact_details.each do |details| %>
-        <div class="col-md-6 add-bottom-padding">
+          <div class="col-md-6 add-bottom-padding">
             <p>
             <%= details[:name] %><br>
             <%= details[:role] %>
             </p>
             <%= mail_to details[:email] %>
             <p><%= details[:phone] %></p>
-        </div>
+          </div>
         <% end %>
-    </div>
+      </div>
     </section>
-<% end %>
+  <% end %>
 
-<section class="add-bottom-padding add-top-padding">
-  <h2 id="govuk-verify">GOV.UK Verify contacts</h2>
-  <h3>Non-urgent support and feedback</h3>
-  <div class="row">
-    <div class="col-md-6">
-      <p>IDA Support</p>
-      <p><%= mail_to @verify_contact_details[:ida_support_email] %></p>
+  <section class="add-bottom-padding add-top-padding">
+    <h2 id="govuk-verify">GOV.UK Verify contacts</h2>
+    <h3>Non-urgent support and feedback</h3>
+    <div class="row">
+      <div class="col-md-6">
+        <p>IDA Support</p>
+        <p><%= mail_to @verify_contact_details[:ida_support_email] %></p>
+      </div>
     </div>
-  </div>
-  <h3>Emergency support</h3>
-  <div class="row">
-    <div class="col-md-6">
-      <p><a href="https://verifystatus.digital.cabinet-office.gov.uk/">Check the GOV.UK Verify status page</a> to see if the issue has already been reported.</p>
-      <p>Out of hours GOV.UK Verify support</p>
-      <p><%= mail_to @verify_contact_details[:out_of_hours_email] %></p>
+    <h3>Emergency support</h3>
+    <div class="row">
+      <div class="col-md-6">
+        <p><a href="https://verifystatus.digital.cabinet-office.gov.uk/">Check the GOV.UK Verify status page</a> to see if the issue has already been reported.</p>
+        <p>Out of hours GOV.UK Verify support</p>
+        <p><%= mail_to @verify_contact_details[:out_of_hours_email] %></p>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 </main>

--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -10,22 +10,22 @@
   </blockquote>
 </section>
 
-<section class="add-bottom-padding add-top-padding">
+<section class="add-top-padding">
   <div class="row">
     <div class="col-md-6">
       <p>What you need to do depends on whether you want to:</p>
       <ul>
-        <li>request a change to GOV.UK content</li>
-        <li>report a major technical problem</li>
-        <li>update GOV.UK following a national emergency</li>
-        <li>get help with GOV.UK Verify</li>
+        <li><%= link_to "request a change to GOV.UK content", anchor: "request-change" %></li>
+        <li><%= link_to "report a major technical problem" , anchor: "report-problem" %></li>
+        <li><%= link_to "update GOV.UK following a national emergency", anchor: "national-emergency" %></li>
+        <li><%= link_to "get help with GOV.UK Verify", anchor: "govuk-verify" %></li>
       </ul>
     </div>
   </div>
 </section>
 
 <section class="add-bottom-padding add-top-padding">
-  <h2>Request a change to GOV.UK content</h2>
+  <h2 id="request-change">Request a change to GOV.UK content</h2>
   <div class="row">
     <div class="col-md-6">
       <p>Before you call, you must first:</p>
@@ -37,8 +37,8 @@
       <p>The phone number you need and what counts as an emergency depends on whether you are calling within office hours.</p>
       <p>Both phone numbers will put you in contact with a member of the GOV.UK content team.</p>
     </div>
+  </div>
 
-    
   <h3>Office hours (Monday to Friday, 9am to 6pm)</h3>
   <div class="row">
     <div class="col-md-6">
@@ -56,7 +56,6 @@
     </div>
   </div>
 
-  
   <h3>Outside office hours, including bank holidays</h3>
   <div class="row">
     <div class="col-md-6">
@@ -70,8 +69,7 @@
     </div>
   </div>
 
-  
-  <h2>Report a major technical problem with GOV.UK</h2>
+  <h2 id="report-problem">Report a major technical problem with GOV.UK</h2>
   <div class="row">
     <div class="col-md-6">
       <p>Use only for critical, high-profile technical issues with the GOV.UK site - such as pages not loading or search not working.</p>
@@ -89,15 +87,14 @@
     </div>
   </div>
 
-
-  <h3>Update GOV.UK following a national emergency</h3>
+  <h2 id="national-emergency">Update GOV.UK following a national emergency</h3>
   <div class="row">
     <div class="col-md-6">
       <p>Use only if both:</p>
       <ul>
         <li>there’s been a sudden, critical national emergency such as a terrorist attack</li>
         <li>you’re the communications coordinator in the lead crisis response department for sudden, critical national emergencies such as terrorist attacks
-</li>
+        </li>
       </ul>
     </div>
   </div>
@@ -113,8 +110,6 @@
       <p>Find out more about the <%= link_to "national emergency publishing process", "https://www.gov.uk/guidance/contact-the-government-digital-service/national-emergency-publishing-guidelines" %>.</p>
     </div>
   </div>
-
-
 </section>
 
 <% if @secondary_contact_details %>
@@ -141,7 +136,7 @@
 <% end %>
 
 <section class="add-bottom-padding add-top-padding">
-  <h2>GOV.UK Verify contacts</h2>
+  <h2 id="govuk-verify">GOV.UK Verify contacts</h2>
   <h3>Non-urgent support and feedback</h3>
   <div class="row">
     <div class="col-md-6">
@@ -158,5 +153,4 @@
     </div>
   </div>
 </section>
-
 </main>

--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -9,70 +9,78 @@
     <p>First read the guidance on <%= link_to "publishing procedures for national emergencies", "https://www.gov.uk/guidance/contact-the-government-digital-service/gov-uk-support-requests-processes-and-response-times" %> and <%= link_to "GOV.UK contact procedures", "https://www.gov.uk/guidance/contact-the-government-digital-service/how-to-contact-gds" %>.</p>
   </blockquote>
 </section>
+
 <section class="add-bottom-padding add-top-padding">
-
-  <h3>GOV.UK content support: office hours</h3>
   <div class="row">
     <div class="col-md-6">
-      <p>Use this number if you’re unable to publish at a critical time, or to make changes to government content managed by GDS.</p>
-    </div>
-  </div>
-  <div class="row add-bottom-padding add-top-padding">
-    <div class="col-md-12">
-      <p class="remove-bottom-margin"><strong><%= @primary_contact_details[:urgent_department_content_change][:phone] %></strong></p>
-      <p class="text-muted">Monday to Friday, 9am to 6pm<br>(excluding bank holidays)</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-6">
-      <p>This number will put you in touch with a GOV.UK content designer. You must:</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-6">
+      <p>What you need to do depends on whether you want to:</p>
       <ul>
-        <li><%= link_to "submit a support request", new_content_change_request_path %> before you phone</li>
-        <li><%= link_to "read the full guidelines", "https://www.gov.uk/government/publications/govuk-support-requests-our-processes-and-response-times" %></li>
-        <li>leave a message and a contact number if the phone isn't answered</li>
+        <li>request a change to GOV.UK content</li>
+        <li>report a major technical problem</li>
+        <li>update GOV.UK following a national emergency</li>
+        <li>get help with GOV.UK Verify</li>
       </ul>
     </div>
   </div>
+</section>
 
-
-  <h3>Emergency GOV.UK content support: out of hours</h3>
+<section class="add-bottom-padding add-top-padding">
+  <h2>Request a change to GOV.UK content</h2>
   <div class="row">
     <div class="col-md-6">
-      <p>Use this only if the public or government is facing immediate and significant financial, legal or physical risk, to request emergency GOV.UK content updates.</p>
-    </div>
-  </div>
-  <div class="row add-bottom-padding add-top-padding">
-    <div class="col-md-12">
-      <p class="remove-bottom-margin"><strong><%= @primary_contact_details[:urgent_mainstream_content_change][:phone] %></strong></p>
-      <p class="text-muted">Monday to Friday, 6pm to 9am<br>Weekends and bank holidays, 24 hours</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-6">
-      <p>Call this number to get in touch with a senior member of the content team, please don't text. You must:</p>
+      <p>Before you call, you must first:</p>
       <ul>
         <li><%= link_to "submit a support request", new_content_change_request_path %> before you phone</li>
         <li><%= link_to "read the full guidelines", "https://www.gov.uk/government/publications/govuk-support-requests-our-processes-and-response-times" %></li>
-        <li>leave a message and a contact number if the phone isn't answered</li>
+        <li>leave a message and a contact number if the phone is not answered - please do not text</li>
       </ul>
+      <p>The phone number you need and what counts as an emergency depends on whether you are calling within office hours.</p>
+      <p>Both phone numbers will put you in contact with a member of the GOV.UK content team.</p>
     </div>
-  </div>
 
-
-  <h3>Major technical problems with GOV.UK site</h3>
+    
+  <h3>Office hours (Monday to Friday, 9am to 6pm)</h3>
   <div class="row">
     <div class="col-md-6">
-      <p>Use for critical, high-profile technical issues with the GOV.UK site - such as pages not loading or search not working.</p>
+      <p>Use only if either:</p>
+      <ul>
+        <li>you’re unable to publish at a critical time</li>
+        <li>you need to make emergency changes to government content managed by GDS</li>
+      </ul>
     </div>
   </div>
   <div class="row add-bottom-padding add-top-padding">
     <div class="col-md-12">
-      <p class="remove-bottom-margin"><strong><%= @primary_contact_details[:major_technical_problems][:phone] %></strong></p>
-      <p class="text-muted">24 hours, 7 days a week</p>
+      <p class="remove-bottom-margin"><%= @primary_contact_details[:urgent_department_content_change][:phone] %></p>
+      <p>Monday to Friday, 9am to 6pm<br>(excluding bank holidays)</p>
+    </div>
+  </div>
+
+  
+  <h3>Outside office hours, including bank holidays</h3>
+  <div class="row">
+    <div class="col-md-6">
+      <p>Use only if the public or government is facing immediate and significant financial, legal or physical risk.</p>
+    </div>
+  </div>
+  <div class="row add-bottom-padding add-top-padding">
+    <div class="col-md-12">
+      <p class="remove-bottom-margin"><%= @primary_contact_details[:urgent_mainstream_content_change][:phone] %></p>
+      <p>Monday to Friday, 6pm to 9am<br>Weekends and bank holidays, 24 hours</p>
+    </div>
+  </div>
+
+  
+  <h2>Report a major technical problem with GOV.UK</h2>
+  <div class="row">
+    <div class="col-md-6">
+      <p>Use only for critical, high-profile technical issues with the GOV.UK site - such as pages not loading or search not working.</p>
+    </div>
+  </div>
+  <div class="row add-bottom-padding add-top-padding">
+    <div class="col-md-12">
+      <p class="remove-bottom-margin"><%= @primary_contact_details[:major_technical_problems][:phone] %></p>
+      <p>24 hours, 7 days a week</p>
     </div>
   </div>
   <div class="row">
@@ -82,24 +90,27 @@
   </div>
 
 
-  <h3>National emergencies</h3>
+  <h3>Update GOV.UK following a national emergency</h3>
   <div class="row">
     <div class="col-md-6">
-      <p>Use for sudden, critical national emergencies such as terrorist attacks.<br>For use only by the communications coordinator in the lead crisis response department.</p>
+      <p>Use only if both:</p>
+      <ul>
+        <li>there’s been a sudden, critical national emergency such as a terrorist attack</li>
+        <li>you’re the communications coordinator in the lead crisis response department for sudden, critical national emergencies such as terrorist attacks
+</li>
+      </ul>
     </div>
   </div>
   <div class="row add-bottom-padding add-top-padding">
     <div class="col-md-12">
-      <p class="remove-bottom-margin"><strong><%= @primary_contact_details[:national_emergencies][:phone] %></strong></p>
-      <p class="text-muted">24 hours, 7 days a week</p>
+      <p class="remove-bottom-margin"><%= @primary_contact_details[:national_emergencies][:phone] %></p>
+      <p>24 hours, 7 days a week</p>
     </div>
   </div>
   <div class="row">
     <div class="col-md-6">
       <p>This number will put you in contact with GOV.UK, who will establish your identity and put the GOV.UK site into ‘emergency’ mode.</p>
-      <ul>
-        <li><%= link_to "National emergency publishing process", "https://www.gov.uk/guidance/contact-the-government-digital-service/national-emergency-publishing-guidelines" %></li>
-      </ul>
+      <p>Find out more about the <%= link_to "national emergency publishing process", "https://www.gov.uk/guidance/contact-the-government-digital-service/national-emergency-publishing-guidelines" %>.</p>
     </div>
   </div>
 
@@ -111,7 +122,7 @@
     <h3>Backup contact</h3>
     <div class="row">
         <div class="col-md-6">
-        <p>If you can’t get through on the other numbers, you can call the Head of GOV.UK.</p>
+        <p>If you cannot get through on the other numbers, you can call the Head of GOV.UK.</p>
         </div>
     </div>
     <div class="row">
@@ -119,10 +130,10 @@
         <div class="col-md-6 add-bottom-padding">
             <p>
             <%= details[:name] %><br>
-            <span class="text-muted"><%= details[:role] %></span>
+            <%= details[:role] %>
             </p>
             <%= mail_to details[:email] %>
-            <p><strong><%= details[:phone] %></strong></p>
+            <p><%= details[:phone] %></p>
         </div>
         <% end %>
     </div>

--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -31,7 +31,7 @@
         <p>Before you call, you must first:</p>
         <ul>
           <li><%= link_to "submit a support request", new_content_change_request_path %> before you phone</li>
-          <li><%= link_to "read the full guidelines", "https://www.gov.uk/government/publications/govuk-support-requests-our-processes-and-response-times" %></li>
+          <li><%= link_to "read the full guidelines", "https://www.gov.uk/guidance/contact-the-government-digital-service/how-to-contact-gds" %></li>
           <li>leave a message and a contact number if the phone is not answered - please do not text</li>
         </ul>
         <p>The phone number you need and what counts as an emergency depends on whether you are calling within office hours.</p>

--- a/spec/features/emergency_contact_details_spec.rb
+++ b/spec/features/emergency_contact_details_spec.rb
@@ -42,7 +42,7 @@ feature "Emergency contact details" do
 
       click_on "Emergency contact details"
 
-      expect(page).to have_content("National emergency publishing")
+      expect(page).to have_content("national emergency publishing")
       expect(page).not_to have_content("05555 555 556") # Bob Manager
     end
   end


### PR DESCRIPTION
This pull request makes content and structural changes to the emergency contact details page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
