### PR TITLE
Update request new campaign page

### DIFF
--- a/app/controllers/campaign_requests_controller.rb
+++ b/app/controllers/campaign_requests_controller.rb
@@ -18,7 +18,6 @@ protected
       :additional_comments,
       requester_attributes: %i[email name collaborator_emails],
       campaign_attributes: %i[
-        type_of_site
         signed_campaign
         has_read_guidance_confirmation
         has_read_oasis_guidance_confirmation
@@ -33,7 +32,6 @@ protected
         site_title
         site_tagline
         site_metadescription
-        cost_of_campaign
         ga_contact_email
       ],
     ).to_h

--- a/app/models/support/gds/campaign.rb
+++ b/app/models/support/gds/campaign.rb
@@ -4,8 +4,7 @@ module Support
   module GDS
     class Campaign
       include ActiveModel::Model
-      attr_accessor :type_of_site,
-                    :has_read_guidance_confirmation,
+      attr_accessor :has_read_guidance_confirmation,
                     :has_read_oasis_guidance_confirmation,
                     :signed_campaign,
                     :start_date,
@@ -19,11 +18,9 @@ module Support
                     :site_title,
                     :site_tagline,
                     :site_metadescription,
-                    :cost_of_campaign,
                     :ga_contact_email
 
-      validates :type_of_site,
-                :signed_campaign,
+      validates :signed_campaign,
                 :start_date,
                 :end_date,
                 :development_start_date,
@@ -35,12 +32,10 @@ module Support
                 :site_title,
                 :site_tagline,
                 :site_metadescription,
-                :cost_of_campaign,
                 :ga_contact_email,
                 presence: true
 
       validates :has_read_guidance_confirmation, :has_read_oasis_guidance_confirmation, acceptance: { allow_nil: false }
-      validates :type_of_site, inclusion: { in: ["Single page campaign platform site", "Multi page site"] }
 
       validates_date :start_date, on_or_after: :today
       validates_date :end_date, after: :start_date

--- a/app/models/zendesk/ticket/campaign_request_ticket.rb
+++ b/app/models/zendesk/ticket/campaign_request_ticket.rb
@@ -15,11 +15,6 @@ module Zendesk
         [
           Zendesk::LabelledSnippet.new(
             on: @request.campaign,
-            field: :type_of_site,
-            label: "Are you applying for the single page campaign platform or a bespoke multi page site?",
-          ),
-          Zendesk::LabelledSnippet.new(
-            on: @request.campaign,
             field: :signed_campaign,
             label: "Name of the Head of Digital Communications who signed off the campaign website application",
           ),
@@ -66,7 +61,7 @@ module Zendesk
           Zendesk::LabelledSnippet.new(
             on: @request.campaign,
             field: :proposed_url,
-            label: "Proposed URL (in the form of xxxxx.campaign.gov.uk or xxxxx.gov.uk)",
+            label: "Proposed URL (in the form of xxxxx.campaign.gov.uk)",
           ),
           Zendesk::LabelledSnippet.new(
             on: @request.campaign,
@@ -82,11 +77,6 @@ module Zendesk
             on: @request.campaign,
             field: :site_metadescription,
             label: "Site metadescription (appears in search results)",
-          ),
-          Zendesk::LabelledSnippet.new(
-            on: @request.campaign,
-            field: :cost_of_campaign,
-            label: "Site build budget / costs (and overall campaign cost, if applicable)",
           ),
           Zendesk::LabelledSnippet.new(
             on: @request.campaign,

--- a/app/views/campaign_requests/_request_details.html.erb
+++ b/app/views/campaign_requests/_request_details.html.erb
@@ -3,10 +3,10 @@
 </div>
 
 <p>
-  Use this form for: Wordpress “single page” Campaign Platform site, or bespoke “multi page” site
+  Use this for: A single or multi page site on the GOV.UK Campaigns Platform
 </p>
 <p>
-  For either type of site, please answer the questions below.
+  Please answer the questions below.
 </p>
 
 <%= f.fields_for :campaign do |r| %>
@@ -15,29 +15,11 @@
       <span>Campaign details</span>
     </legend>
 
-    <div class="form-group">
-      <span class="form-label control-label">
-        <%= r.label :type_of_site do %>
-          Are you applying for the single page campaign platform or a bespoke multi page site?<abbr title="required">*</abbr>
-        <% end %>
-      </span>
-      <span class="form-wrapper">
-        <%= r.collection_radio_buttons :type_of_site, ["Single page campaign platform site", "Multi page site"], :itself, :itself, required: true, aria: { required: true } do |builder| %>
-          <div class="radio">
-            <%= builder.label(class: "custom-control-label") do %>
-              <%= builder.radio_button(class: "custom-control-input") %>
-              <%= builder.value %>
-            <% end %>
-          </div>
-        <% end %>
-      </span>
-    </div>
-
     <div class="form-group checkbox">
       <span class="form-wrapper">
         <%= r.label :has_read_guidance_confirmation, class: "control-label" do %>
           <%= r.check_box :has_read_guidance_confirmation %>
-          <b>Have you read the the <%= link_to('GCS guidance on campaign websites', 'https://gcs.civilservice.gov.uk/guidance/campaigns/websites-government-campaigns/') %> and accept the requirements for a Campaign Platform website?</b>
+          <b>Have you read the <%= link_to('GCS guidance on campaign websites', 'https://gcs.civilservice.gov.uk/guidance/campaigns/websites-government-campaigns/') %> and accepted the requirements for a Campaign Platform website?</b>
         <% end %>
       </span>
     </div>
@@ -54,7 +36,7 @@
     <div class="form-group">
       <span class="form-label control-label">
         <%= r.label :signed_campaign do %>
-          Name of the Head of Digital Communications who signed off the campaign website application<abbr title="required">*</abbr>
+          Name of the Head of Communications who signed off the campaign website application<abbr title="required">*</abbr>
         <% end %>
       </span>
       <span class="form-wrapper">
@@ -194,31 +176,13 @@
     <div class="form-group">
       <span class="form-label">
         <%= r.label :proposed_url do %>
-          Proposed URL (in the form of xxxxx.campaign.gov.uk or xxxxx.gov.uk)<abbr title="required">*</abbr>
+          Proposed URL (in the form of xxxxx.campaign.gov.uk)<abbr title="required">*</abbr>
         <% end %>
       </span>
       <span class="form-wrapper">
         <%= r.text_field :proposed_url, required: true, aria: { required: true, describedby: "urlHelpBlock" }, class: "input-md-6 form-control" %>
       </span>
     </div>
-    <p class="help-block">
-      If applying for Campaigns Platform it is in the form of xxxxx.campaign.gov.uk, or otherwise
-      if a bespoke multi page site, standard format is in the form of xxxxxx.gov.uk.
-    </p>
-
-    <div class="form-group">
-      <span class="form-label">
-        <%= r.label :cost_of_campaign do %>
-          Site build budget / costs (and overall campaign cost, if applicable)<abbr title="required">*</abbr>
-        <% end %>
-      </span>
-      <span class="form-wrapper">
-        <%= r.text_field :cost_of_campaign, required: true, aria: { required: true }, class: "input-md-6 form-control" %>
-      </span>
-    </div>
-    <p class="help-block">
-      If you are applying for the Campaign Platform page, this is free of any build charge
-    </p>
 
     <div class="form-group">
       <span class="form-label">
@@ -233,11 +197,6 @@
     <p class="help-block">
       GCS centralise and coordinate access to Google Analytics, although departments will themselves
       be responsible for analysing their site’s performance.
-    </p>
-    <p class="help-block">
-      If you need to set up a bespoke analytics package independent of centralised/GCS GA for the purposes
-      of your marketing, please provide the following with access webmaster@cabinetoffice.gov.uk and
-      microsites@cabinetoffice.gov.uk.
     </p>
   </fieldset>
 <% end %>

--- a/spec/features/campaign_requests_spec.rb
+++ b/spec/features/campaign_requests_spec.rb
@@ -20,10 +20,7 @@ feature "Campaign requests" do
       "tags" => %w[govt_form campaign],
       "comment" => {
         "body" =>
-"[Are you applying for the single page campaign platform or a bespoke multi page site?]
-Single page campaign platform site
-
-[Name of the Head of Digital Communications who signed off the campaign website application]
+"[Name of the Head of Digital Communications who signed off the campaign website application]
 John Smith
 
 [Start date of campaign site]
@@ -47,7 +44,7 @@ Pensions
 [Call to action]
 Join us in this campaign for pensions
 
-[Proposed URL (in the form of xxxxx.campaign.gov.uk or xxxxx.gov.uk)]
+[Proposed URL (in the form of xxxxx.campaign.gov.uk)]
 newcampaign.campaign.gov.uk
 
 [Site title]
@@ -59,9 +56,6 @@ A new one about a new thing
 [Site metadescription (appears in search results)]
 pensions, campaign, newcampaign
 
-[Site build budget / costs (and overall campaign cost, if applicable)]
-£1200 and tuppence
-
 [Contact details for Google Analytics leads (Gmail accounts only)]
 ga.contact@example.com
 
@@ -71,7 +65,6 @@ Some comment",
     )
 
     user_makes_a_campaign_request(
-      type_of_site: "Single page campaign platform site",
       has_read_guidance: true,
       has_read_oasis_guidance: true,
       signed_campaign: "John Smith",
@@ -86,7 +79,6 @@ Some comment",
       site_title: "New campaign",
       site_tagline: "A new one about a new thing",
       site_metadescription: "pensions, campaign, newcampaign",
-      cost_of_campaign: "£1200 and tuppence",
       ga_contact_email: "ga.contact@example.com",
       additional_comments: "Some comment",
     )
@@ -103,10 +95,9 @@ private
 
     expect(page).to have_content("Request GDS support for a new campaign")
 
-    choose details[:type_of_site]
-    check "Have you read the the GCS guidance on campaign websites and accept the requirements for a Campaign Platform website?" if details[:has_read_guidance]
+    check "Have you read the GCS guidance on campaign websites and accepted the requirements for a Campaign Platform website?" if details[:has_read_guidance]
     check "Have you followed the GCS guidance for OASIS planning and are using the mandatory GCS OASIS template?" if details[:has_read_oasis_guidance]
-    fill_in "Name of the Head of Digital Communications who signed off the campaign website application*", with: details[:signed_campaign]
+    fill_in "Name of the Head of Communications who signed off the campaign website application*", with: details[:signed_campaign]
     fill_in "Start date of campaign site*", with: details[:start_date]
     fill_in "Proposed end date of campaign site*", with: details[:end_date]
     fill_in "Site build to commence on", with: details[:development_start_date]
@@ -114,11 +105,10 @@ private
     fill_in "Which of the current Government Communications Plan priority themes does this campaign website support and how?*", with: details[:government_theme]
     fill_in "Campaign description*", with: details[:description]
     fill_in "Call to action*", with: details[:call_to_action]
-    fill_in "Proposed URL (in the form of xxxxx.campaign.gov.uk or xxxxx.gov.uk)*", with: details[:proposed_url]
+    fill_in "Proposed URL (in the form of xxxxx.campaign.gov.uk)*", with: details[:proposed_url]
     fill_in "Site title*", with: details[:site_title]
     fill_in "Site tagline*", with: details[:site_tagline]
     fill_in "Site metadescription (appears in search results)*", with: details[:site_metadescription]
-    fill_in "Site build budget / costs (and overall campaign cost, if applicable)*", with: details[:cost_of_campaign]
     fill_in "Contact details for Google Analytics leads (Gmail accounts only)*", with: details[:ga_contact_email]
     fill_in "Additional comments", with: details[:additional_comments]
 

--- a/spec/models/support/gds/campaign_spec.rb
+++ b/spec/models/support/gds/campaign_spec.rb
@@ -9,7 +9,6 @@ module Support
 
       subject do
         Campaign.new(
-          type_of_site: "Single page campaign platform site",
           signed_campaign: "Test Signer",
           has_read_guidance_confirmation: "1",
           has_read_oasis_guidance_confirmation: "1",
@@ -22,12 +21,10 @@ module Support
           call_to_action: "Test Call to Action",
           proposed_url: "example.campaign.gov.uk",
           site_metadescription: "tag1, tag2",
-          cost_of_campaign: 1200,
           ga_contact_email: "ga_test@digital.cabinet-office.gov.uk",
         )
       end
 
-      it { should validate_presence_of(:type_of_site) }
       it { should validate_presence_of(:signed_campaign) }
       it { should validate_presence_of(:start_date) }
       it { should validate_presence_of(:end_date) }
@@ -40,13 +37,10 @@ module Support
       it { should validate_presence_of(:site_title) }
       it { should validate_presence_of(:site_tagline) }
       it { should validate_presence_of(:site_metadescription) }
-      it { should validate_presence_of(:cost_of_campaign) }
       it { should validate_presence_of(:ga_contact_email) }
 
       it { should validate_acceptance_of(:has_read_guidance_confirmation) }
       it { should validate_acceptance_of(:has_read_oasis_guidance_confirmation) }
-
-      it { should validate_inclusion_of(:type_of_site).in?(["Single page campaign platform site", "Multi page site"]) }
 
       it { should validate_acceptance_of(:has_read_guidance_confirmation) }
       it { should validate_acceptance_of(:has_read_oasis_guidance_confirmation) }


### PR DESCRIPTION
The advice in the campaigns section of the content design manual is being updated due to a change in processes.

https://trello.com/c/8cSxyJH2/2932-3-changes-to-request-a-new-campaign-form

**BEFORE**
![BEFORE](https://user-images.githubusercontent.com/15057104/177975827-31031625-78b7-4d5b-86f6-50af8f1a1675.png)

**AFTER**
![AFTER](https://user-images.githubusercontent.com/15057104/178503841-3651bf2c-979e-4bd1-958a-28012ee398c4.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
