### PR TITLE
Update copy for topic taxonomy requests

### DIFF
--- a/app/models/support/navigation/section_groups.rb
+++ b/app/models/support/navigation/section_groups.rb
@@ -11,7 +11,7 @@ module Support
           Support::Navigation::SectionGroup.new("User access", user_access_requests),
           Support::Navigation::SectionGroup.new("Campaigns", campaign_requests),
           Support::Navigation::SectionGroup.new("Feedback for tools in Beta", feedback_requests),
-          Support::Navigation::SectionGroup.new("Taxonomy requests", taxonomy_requests),
+          Support::Navigation::SectionGroup.new("Topic taxonomy requests", taxonomy_requests),
           Support::Navigation::SectionGroup.new("Other requests", other_requests),
         ]
       end

--- a/app/models/support/requests/taxonomy_change_topic_request.rb
+++ b/app/models/support/requests/taxonomy_change_topic_request.rb
@@ -19,7 +19,7 @@ module Support
       def type_of_change_options
         [
           ["Name of topic", "name_of_topic"],
-          ["Position of topic in the taxonomy (move it up a level, for example)", "position_of_topic"],
+          ["Position in the topic taxonomy (move it up a level, for example)", "position_of_topic"],
           ["Merge or split the topic", "merge_split_topic"],
           ["Remove the topic", "remove_topic"],
           ["Something else", "other"],
@@ -31,7 +31,7 @@ module Support
       end
 
       def self.description
-        "Suggest a change to a topic or the removal of a topic in the GOV.UK taxonomy."
+        "Suggest a change to a topic or the removal of a topic in the GOV.UK topic taxonomy."
       end
     end
   end

--- a/app/models/support/requests/taxonomy_new_topic_request.rb
+++ b/app/models/support/requests/taxonomy_new_topic_request.rb
@@ -16,7 +16,7 @@ module Support
       end
 
       def self.description
-        "Suggest a new topic for the GOV.UK taxonomy."
+        "Suggest a new topic for the GOV.UK topic taxonomy."
       end
     end
   end

--- a/app/views/taxonomy_new_topic_requests/_request_details.html.erb
+++ b/app/views/taxonomy_new_topic_requests/_request_details.html.erb
@@ -16,7 +16,7 @@
 <div class="form-group">
   <span class="form-label">
     <%= f.label :url do %>
-      URL(s) of page(s) you want to tag (provide as many as you can)<abbr title="required">*</abbr>
+      URL(s) of page(s) you want to tag to this topic (provide as many as you can)<abbr title="required">*</abbr>
     <% end %>
   </span>
   <span class="form-wrapper">
@@ -38,7 +38,7 @@
 <div class="form-group">
   <span class="form-label">
     <%= f.label :parent do %>
-      Where should this topic fit in the taxonomy? For example, a sub-topic of Early years curriculum<abbr title="required">*</abbr>
+      Where should this topic fit in the topic taxonomy? For example, a subtopic of Early years curriculum<abbr title="required">*</abbr>
     <% end %>
   </span>
   <span class="form-wrapper">

--- a/spec/features/taxonomy_change_topic_requests_spec.rb
+++ b/spec/features/taxonomy_change_topic_requests_spec.rb
@@ -50,7 +50,7 @@ private
 
     click_on "Suggest a change to a topic"
 
-    expect(page).to have_content("Suggest a change to a topic or the removal of a topic in the GOV.UK taxonomy.")
+    expect(page).to have_content("Suggest a change to a topic or the removal of a topic in the GOV.UK topic taxonomy.")
 
     fill_in "Name of topic you'd like changed", with: details[:title]
 

--- a/spec/features/taxonomy_new_topic_requests_spec.rb
+++ b/spec/features/taxonomy_new_topic_requests_spec.rb
@@ -50,13 +50,13 @@ private
 
     click_on "Suggest a new topic"
 
-    expect(page).to have_content("Suggest a new topic for the GOV.UK taxonomy.")
+    expect(page).to have_content("Suggest a new topic for the GOV.UK topic taxonomy.")
 
     fill_in "Preferred name of new topic", with: details[:title]
 
-    fill_in "URL(s) of page(s) you want to tag (provide as many as you can)", with: details[:url]
+    fill_in "URL(s) of page(s) you want to tag to this topic (provide as many as you can)", with: details[:url]
     fill_in "Why do you think this new topic is needed? Please provide any evidence you have", with: details[:details]
-    fill_in "Where should this topic fit in the taxonomy? For example, a sub-topic of Early years curriculum", with: details[:parent]
+    fill_in "Where should this topic fit in the topic taxonomy? For example, a subtopic of Early years curriculum", with: details[:parent]
 
     user_submits_the_request_successfully
   end


### PR DESCRIPTION
As part of the work to align terminology relating to topics, taxonomy and tagging in the publishing apps in June 2022, the Navigation & Presentation team updated microcopy in Whitehall, Publisher, Collections Publisher and Content Tagger.

This final task is to make relevant changes in the GOV.UK Support app.

[See the docs for the requests and before/after screenshots](https://docs.google.com/document/d/1clABq9P3M0FwcVElflKnXK3hCr4OXKkLcqIBVNTmCfY/edit#heading=h.ydtlgrzhd0c)

[Trello](https://trello.com/c/ERXoBxRL/1311-govuk-support-app-update-copy-based-on-jenns-doc-m)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
