### PR TITLE
Add text-break class to feedback explorer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,11 @@ thead {
   white-space: nowrap;
 }
 
+.text-break {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
 .feedback-response-count {
   margin-top: - ($default-vertical-margin * 1.5);
   font-size: $font-size-h3;

--- a/app/views/anonymous_feedback/_anonymous-contact.html.erb
+++ b/app/views/anonymous_feedback/_anonymous-contact.html.erb
@@ -2,7 +2,7 @@
   <th scope="row" class="table-header-secondary no-wrap">
     <%= anonymous_contact.created_at.to_date.to_fs(:govuk_date_short) %>
   </th>
-  <td>
+  <td class="text-break">
     <%= render partial: "/anonymous_feedback/feedback", locals: { anonymous_contact: anonymous_contact } %>
   </td>
   <td>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Add class `text-break` to `application.css` to cause text wrapped to break words as it is defined in later versions of bootstrap.
Use this class in the feedback explorer table.

## Why

Users including URLs or horizontal rules in their feedback would back the formatting of the page as the column width with increase to cover the full table

## Screenshots
### After

![support publishing service gov uk_anonymous_feedback_paths=8c63dc22cca543af5298(iPad Pro) (1)](https://user-images.githubusercontent.com/9594455/203092314-74dc4b12-bf1a-484c-8a9d-2588e476b1f3.png)

### Before

![support publishing service gov uk_anonymous_feedback_paths=8c63dc22cca543af5298(iPad Pro)](https://user-images.githubusercontent.com/9594455/203092340-d7a7e4c1-46cd-470c-89cb-7e0aa1a8f5ba.png)
