### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "gretel"
 gem "jc-validates_timeliness"
 gem "jquery-ui-rails"
 gem "kaminari"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "plek"
 gem "redis"
 gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -520,6 +520,7 @@ DEPENDENCIES
   jquery-ui-rails
   kaminari
   listen
+  mail (~> 2.7.1)
   plek
   pry-byebug
   rails (= 7.0.4)


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
