### PR TITLE
Bump redis to version 4.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,7 +341,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.5.1)
+    redis (4.8.0)
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
     regexp_parser (2.6.1)


### PR DESCRIPTION
This is the latest version before 5.x.x, and should make it easier to upgrade to the next major version should we choose to.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
