### PR TITLE
Bump redis from 4.5.1 to 5.0.5 (manually)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.5.1)
+    redis (4.8.0)
     redis-namespace (1.10.0)
       redis (>= 4)
     regexp_parser (2.6.1)

--- a/app/models/support/requests/anonymous/paths.rb
+++ b/app/models/support/requests/anonymous/paths.rb
@@ -1,4 +1,4 @@
-require "redis_client"
+require "govuk_redis_client"
 
 class Support::Requests::Anonymous::Paths
   EXPIRATION_TTL = 7.days
@@ -28,6 +28,6 @@ class Support::Requests::Anonymous::Paths
   end
 
   def self.redis
-    RedisClient.instance.connection
+    GovukRedisClient.instance.connection
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 require "gds-sso/user"
 require "json"
-require "redis_client"
+require "govuk_redis_client"
 
 class User < OpenStruct
   class Store
@@ -21,7 +21,7 @@ class User < OpenStruct
       end
 
       def redis
-        RedisClient.instance.connection
+        GovukRedisClient.instance.connection
       end
     end
   end

--- a/lib/govuk_redis_client.rb
+++ b/lib/govuk_redis_client.rb
@@ -1,6 +1,6 @@
 require "redis"
 
-class RedisClient
+class GovukRedisClient
   include Singleton
 
   attr_reader :connection

--- a/lib/volatile_lock.rb
+++ b/lib/volatile_lock.rb
@@ -1,4 +1,4 @@
-require "redis_client"
+require "govuk_redis_client"
 
 class VolatileLock
   class FailedToSetExpiration < StandardError; end
@@ -34,7 +34,7 @@ private
   end
 
   def redis
-    RedisClient.instance.connection
+    GovukRedisClient.instance.connection
   end
 
   def hostname

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-require "redis_client"
+require "govuk_redis_client"
 
 require "gds-sso/lint/user_spec"
 

--- a/spec/models/volatile_lock_spec.rb
+++ b/spec/models/volatile_lock_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 require "volatile_lock"
-require "redis_client"
+require "govuk_redis_client"
 
 describe VolatileLock do
-  let(:redis) { RedisClient.instance.connection }
+  let(:redis) { GovukRedisClient.instance.connection }
 
   def volatile_lock(key, expiration_time = 1.second)
     VolatileLock.new(key, expiration_time)

--- a/spec/support/redis.rb
+++ b/spec/support/redis.rb
@@ -1,7 +1,7 @@
-require "redis_client"
+require "govuk_redis_client"
 
 RSpec.configure do |config|
   config.before do
-    RedisClient.instance.connection.flushall
+    GovukRedisClient.instance.connection.flushall
   end
 end


### PR DESCRIPTION
Replaces #1017, which is a bit fiddly to unpick (conflicts). Since that PR was raised, [govuk_sidekiq has been bumped](https://github.com/alphagov/support/pull/1069), so we can drop 8cb0f4187f89ea09d544019b3decd08fc174aec2 and 9005b531b6c4db0932c6c827ad74d64638b24cc2.

-----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
