### PR TITLE
Update contact details

### DIFF
--- a/app/controllers/authorisation_controller.rb
+++ b/app/controllers/authorisation_controller.rb
@@ -1,4 +1,6 @@
 class AuthorisationController < ApplicationController
+  before_action :emergency_contact_details
+
   check_authorization
 
   rescue_from CanCan::AccessDenied do |_exception|
@@ -6,6 +8,14 @@ class AuthorisationController < ApplicationController
       format.html { render "support/forbidden", status: :forbidden }
       format.json { render json: { "error" => "You have not been granted permission to make these requests." }, status: :forbidden }
     end
+  end
+
+  def emergency_contact_details
+    emergency_contact_details = EmergencyContactDetails.fetch
+    @primary_contact_details = emergency_contact_details[:primary_contacts]
+    @secondary_contact_details = emergency_contact_details[:secondary_contacts]
+    @verify_contact_details = emergency_contact_details[:verify_contacts]
+    @current_at = Date.parse(emergency_contact_details[:current_at])
   end
 
 protected

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -9,14 +9,6 @@ class SupportController < AuthorisationController
     @accessible_sections, @inaccessible_sections = all_sections.partition(&:accessible?)
   end
 
-  def emergency_contact_details
-    emergency_contact_details = EmergencyContactDetails.fetch
-    @primary_contact_details = emergency_contact_details[:primary_contacts]
-    @secondary_contact_details = emergency_contact_details[:secondary_contacts]
-    @verify_contact_details = emergency_contact_details[:verify_contacts]
-    @current_at = Date.parse(emergency_contact_details[:current_at])
-  end
-
   def acknowledge
     respond_to do |format|
       format.html { render :acknowledge }

--- a/app/lib/emergency_contact_details.rb
+++ b/app/lib/emergency_contact_details.rb
@@ -1,7 +1,7 @@
 class EmergencyContactDetails
   def self.fetch
-    config = JSON.parse(ENV["EMERGENCY_CONTACT_DETAILS"]) ||
-      JSON.parse(File.load(Rails.root.join("config/emergency_contact_details.json")))
+    config_str = ENV["EMERGENCY_CONTACT_DETAILS"] || File.read(Rails.root.join("config/emergency_contact_details.json"))
+    config = JSON.parse(config_str)
     ActiveSupport::HashWithIndifferentAccess.new(config)
   end
 end

--- a/app/views/content_change_requests/_request_details.html.erb
+++ b/app/views/content_change_requests/_request_details.html.erb
@@ -55,7 +55,7 @@
 <%= render partial: "support/time_constraint", locals: { f: f } %>
 
 <div class="alert alert-info alert-block">
-  <p>If your request is urgent, please fill in this form and call 07810 750 834 during office hours, or 07827 992603 out of hours. (It's ONLY urgent when the public or the government is facing immediate and significant financial, legal or physical risk.)</p>
+  <p>If your request is urgent, please fill in this form and call <%= @primary_contact_details[:urgent_department_content_change][:phone] %> during office hours, or <%= @primary_contact_details[:urgent_mainstream_content_change][:phone] %> out of hours. (It's ONLY urgent when the public or the government is facing immediate and significant financial, legal or physical risk.)</p>
 </div>
 
 <%= render partial: "support/collaborators", locals: { f: f } %>


### PR DESCRIPTION
We should be using the same approach as the 'emergency contact
details' page: https://github.com/alphagov/support/blob/2780b2e30306ab21647abd4db4b7d6809f81144a/app/views/support/emergency_contact_details.html.erb#L54

The phone number values are set here:
https://github.com/alphagov/govuk-secrets/pull/1443

I've had to move the `emergency_contact_details` method definition
into `AuthorisationController` as we now need to make it
available to `RequestsController`, which inherits from it.
`SupportController` (where I've taken the method definition from)
also inherits from `AuthorisationController`, so it should
continue to work for both scenarios.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
