### PR TITLE
Remove GOV.UK Verify non-urgent support and feedback contacts

### DIFF
--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -136,13 +136,6 @@
 
   <section class="add-bottom-padding add-top-padding">
     <h2 id="govuk-verify">GOV.UK Verify contacts</h2>
-    <h3>Non-urgent support and feedback</h3>
-    <div class="row">
-      <div class="col-md-6">
-        <p>IDA Support</p>
-        <p><%= mail_to @verify_contact_details[:ida_support_email] %></p>
-      </div>
-    </div>
     <h3>Emergency support</h3>
     <div class="row">
       <div class="col-md-6">


### PR DESCRIPTION
The team have agreed that there is no genuine user need for including this here and would like to minimise the risk of this email address being used incorrectly.

https://govuk.zendesk.com/agent/tickets/5181812

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
