### PR TITLE
Update bundler to fix warning about deprecated method.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,4 +553,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.4.9


### PR DESCRIPTION
Fixes this error on `bundle install`:

    Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name =>
    spell_checker)' has been deprecated. Please call
    `DidYouMean.correct_error(error_name, spell_checker)' instead.