### PR TITLE
Incorrect URL validation regex

### DIFF
--- a/app/models/support/gds/live_campaign.rb
+++ b/app/models/support/gds/live_campaign.rb
@@ -8,7 +8,7 @@ module Support
 
       validates :title, :description, presence: true
 
-      validates :proposed_url, format: /(http:\/\/|https:\/\/)?(www.)?([a-zA-Z0-9]+).[a-zA-Z0-9]*.[a-z]{3}.?([a-z]+)?/
+      validates :proposed_url, format: /(http:\/\/|https:\/\/)?(www\.)?([a-zA-Z0-9]+)\.[a-zA-Z0-9]*\.[a-z]{3}\.?([a-z]+)?/
     end
   end
 end


### PR DESCRIPTION

The URL validation for `proposed_url` does not properly escape periods, resulting in URLs being incorrectly validated. The following example demonstrates that a malicious or incorrectly-formatted URL (`http://a.b%com.com`) will pass the validation:
https://rubular.com/r/heAGkQXCd6Hy9o

https://github.com/alphagov/support/blob/a38a7383368d173b57f520d328263cb9e0ff5d1e/app/models/support/gds/live_campaign.rb#L11

This pull requests escapes the periods inside this regex to ensure that we are testing for string literals. 