### PR TITLE
Don't fall back to fixture data in production

### DIFF
--- a/app/lib/emergency_contact_details.rb
+++ b/app/lib/emergency_contact_details.rb
@@ -1,7 +1,11 @@
 class EmergencyContactDetails
   def self.fetch
-    config_str = ENV["EMERGENCY_CONTACT_DETAILS"] || File.read(Rails.root.join("config/emergency_contact_details.json"))
+    config_str = ENV["EMERGENCY_CONTACT_DETAILS"]
+    raise MissingEnvVar if config_str.nil?
+
     config = JSON.parse(config_str)
     ActiveSupport::HashWithIndifferentAccess.new(config)
   end
+
+  class MissingEnvVar < StandardError; end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,4 +64,6 @@ Rails.application.configure do
   config.hosts += [
     "support.dev.gov.uk",
   ]
+
+  ENV["EMERGENCY_CONTACT_DETAILS"] = ENV["EMERGENCY_CONTACT_DETAILS"] || File.read(Rails.root.join("config/emergency_contact_details.json"))
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,4 +54,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  ENV["EMERGENCY_CONTACT_DETAILS"] = ENV["EMERGENCY_CONTACT_DETAILS"] || File.read(Rails.root.join("config/emergency_contact_details.json"))
 end

--- a/spec/lib/emergency_contact_details_spec.rb
+++ b/spec/lib/emergency_contact_details_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe EmergencyContactDetails do
+  describe ".fetch" do
+    it "returns a HashWithIndifferentAccess derived from `ENV['EMERGENCY_CONTACT_DETAILS']`" do
+      contact_details = {
+        "current_at": "2014-07-01",
+        "primary_contacts": {
+          "national_emergencies": {
+            "phone": "0555 555 555",
+          },
+        },
+        "secondary_contacts": [
+          {
+            "name": "Billy Director",
+            "role": "Director",
+            "phone": "05555 555 555",
+            "email": "billy.director@email.uk",
+          },
+        ],
+        "verify_contacts": {
+          "ida_support_email": "idasupport@email.uk",
+          "out_of_hours_email": "outofhours@email.uk",
+        },
+      }
+
+      allow(ENV).to receive(:[]).with(anything)
+      allow(ENV).to receive(:[]).with("EMERGENCY_CONTACT_DETAILS").and_return(contact_details.to_json)
+      expect(described_class.fetch).to eq(contact_details.to_h.with_indifferent_access)
+      expect(described_class.fetch[:verify_contacts][:ida_support_email]).to eq("idasupport@email.uk")
+    end
+
+    it "raises an exception if `ENV['EMERGENCY_CONTACT_DETAILS']` is not defined" do
+      allow(ENV).to receive(:[]).with(anything)
+      allow(ENV).to receive(:[]).with("EMERGENCY_CONTACT_DETAILS").and_return(nil)
+
+      expect { described_class.fetch }.to raise_exception(EmergencyContactDetails::MissingEnvVar)
+    end
+  end
+end


### PR DESCRIPTION
The `EmergencyContactDetails` class relies on a `EMERGENCY_CONTACT_DETAILS` ENV variable to define sensitive information such as phone numbers and email addresses, which we then display in the Support app.

If the ENV variable is missing, then it falls back to the nonsense data in `config/emergency_contact_details.json`, potentially displaying incorrect information to publishers. It would be better for the application to crash.

The fallback behaviour has instead been moved to
`config/environments`, in `development.rb` and `test.rb` only. This is so that the app can be started up without having to define the ENV var (`development.rb`) and so that all of the unrelated tests continue to pass (`test.rb`).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
