### PR TITLE
Content change request form tidy up

### DIFF
--- a/app/models/support/requests/time_constraint.rb
+++ b/app/models/support/requests/time_constraint.rb
@@ -4,9 +4,7 @@ module Support
   module Requests
     class TimeConstraint
       include ActiveModel::Model
-      attr_accessor :not_before_date, :not_before_time, :needed_by_date, :needed_by_time, :time_constraint_reason, :is_legal_deadline
-
-      validates :is_legal_deadline, inclusion: %w[yes no], allow_blank: true
+      attr_accessor :not_before_date, :not_before_time, :needed_by_date, :needed_by_time, :time_constraint_reason
 
       validates_date :needed_by_date, allow_blank: true, on_or_after: :today
       validates_date :not_before_date, allow_blank: true, on_or_after: :today

--- a/app/models/zendesk/zendesk_tickets.rb
+++ b/app/models/zendesk/zendesk_tickets.rb
@@ -1,14 +1,16 @@
 module Zendesk
   class ZendeskTickets
     def raise_ticket(ticket_to_raise)
-      ZendeskTicketWorker.perform_async(
+      ticket_options = {
         subject: ticket_to_raise.subject,
         priority: ticket_to_raise.priority,
         requester: { "locale_id" => 1, "email" => ticket_to_raise.email, "name" => ticket_to_raise.name },
         collaborators: ticket_to_raise.collaborator_emails,
         tags: ticket_to_raise.tags,
         comment: { "body" => ticket_to_raise.comment },
-      )
+      }
+
+      ZendeskTicketWorker.perform_async(ticket_options.stringify_keys)
     end
   end
 end

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -66,21 +66,6 @@ Out of date XX YY",
     expect(request).to have_been_made
   end
 
-  scenario "successful 'Depts and Policy' content change request " do
-    request = expect_zendesk_to_receive_ticket(
-      "subject" => "Content change request",
-      "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
-      "tags" => %w[govt_form content_amend],
-    )
-
-    user_makes_a_content_change_request(
-      context: "Departments and policy",
-      details_of_change: "Out of date XX YY",
-    )
-
-    expect(request).to have_been_made
-  end
-
 private
 
   def user_makes_a_content_change_request(details)
@@ -91,8 +76,8 @@ private
     expect(page).to have_content("You'll get an automated response to confirm we've received your request. We'll then review your request within 2 working days.")
 
     fill_in "Title of request", with: details[:title] unless details[:title].nil?
-    select details[:reason_for_change], from: "What’s the reason for the request?" unless details[:reason_for_change].nil?
-    select details[:subject_area], from: "What’s the subject area?" unless details[:subject_area].nil?
+    select details[:reason_for_change], from: "What’s the reason for the request?"
+    select details[:subject_area], from: "What’s the subject area?"
     fill_in "Which URLs are affected?", with: details[:url]
     fill_in "Tell us about the content that needs to be created, updated or is causing a problem for users?", with: details[:details_of_change]
 


### PR DESCRIPTION
Part of the work of adding [Zendesk mappings](https://trello.com/c/9j3DslWM/3176-apply-zendesk-mapping-to-the-content-requests-form-5) but it can be separated from the new feature PR.

See commit messages for details.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
