### PR TITLE
Update Content change request ticket subject and temporarily add fields into body

### DIFF
--- a/app/models/zendesk/ticket/content_change_request_ticket.rb
+++ b/app/models/zendesk/ticket/content_change_request_ticket.rb
@@ -30,6 +30,20 @@ module Zendesk
         snippets = [
           Zendesk::LabelledSnippet.new(
             on: @request,
+            field: :reason_for_change,
+            label: "Reason for request",
+          ),
+          Zendesk::LabelledSnippet.new(
+            on: @request,
+            field: :subject_area,
+            label: "Subject area",
+          ),
+          Zendesk::LabelledSnippet.new(on: self, field: :needed_by_date, label: "Deadline date"),
+          Zendesk::LabelledSnippet.new(on: self, field: :needed_by_time, label: "Deadline time"),
+          Zendesk::LabelledSnippet.new(on: self, field: :not_before_date, label: "Do not publish before date"),
+          Zendesk::LabelledSnippet.new(on: self, field: :not_before_time, label: "Do not publish before time"),
+          Zendesk::LabelledSnippet.new(
+            on: @request,
             field: :url,
             label: "URLs to be changed",
           ),

--- a/app/models/zendesk/ticket/content_change_request_ticket.rb
+++ b/app/models/zendesk/ticket/content_change_request_ticket.rb
@@ -4,11 +4,7 @@ module Zendesk
       TICKET_FORM_ID = 7_949_329_694_108
 
       def subject
-        if @request.title.present?
-          "#{@request.title} - Content change request"
-        else
-          "Content change request"
-        end
+        @request.title.presence || "Content change request"
       end
 
       def tags

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -15,7 +15,7 @@ feature "Content change requests" do
 
   scenario "successful mainstream content change request " do
     request = expect_zendesk_to_receive_ticket(
-      "subject" => "Update X - Content change request",
+      "subject" => "Update X",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form content_amend],
       "comment" => {

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -20,7 +20,25 @@ feature "Content change requests" do
       "tags" => %w[govt_form content_amend],
       "comment" => {
         "body" =>
-"[URLs to be changed]
+"[Reason for request]
+Factual inaccuracy
+
+[Subject area]
+Benefits
+
+[Deadline date]
+31-12-#{next_year}
+
+[Deadline time]
+13:00
+
+[Do not publish before date]
+01-12-#{next_year}
+
+[Do not publish before time]
+18:00
+
+[URLs to be changed]
 http://gov.uk/X
 
 [Details of what should be added, amended or removed]

--- a/spec/models/zendesk/ticket/content_change_request_ticket_spec.rb
+++ b/spec/models/zendesk/ticket/content_change_request_ticket_spec.rb
@@ -12,8 +12,8 @@ module Zendesk
         { time_constraint: OpenStruct.new(attributes) }
       end
 
-      it "contains the title in the subject, if one is provided" do
-        expect(ticket(title: "Abc").subject).to eq("Abc - Content change request")
+      it "has the title in the subject, if one is provided" do
+        expect(ticket(title: "Abc").subject).to eq("Abc")
       end
 
       it "has a default subject" do


### PR DESCRIPTION
- **Remove "Content change request" suffix from the Zendesk ticket subject** 
These tickets default to "Content Request" form so there's no need to add an extra
suffix to the subject.

- **Temporarily add content request fields into the ticket body** 
There is an issue with Zapier integration the content teams use to create
Trello cards from Zendesk tickets.  Deadlines/not-before dates aren’t pulling
through on cards because this data is now in different fields. This was
anticipated however colleagues with with login details to the Zapier account
are not available today to make a change.  We will temporarily add this
information to the ticket body so it's copied over to Trello with Zapier.
Once Zapier is updated we can revert this change.

https://trello.com/c/9j3DslWM/3176-apply-zendesk-mapping-to-the-content-requests-form-5


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
