### PR TITLE
Revert "Temporarily add content request fields into the ticket body"

### DIFF
--- a/app/models/zendesk/ticket/content_change_request_ticket.rb
+++ b/app/models/zendesk/ticket/content_change_request_ticket.rb
@@ -30,20 +30,6 @@ module Zendesk
         snippets = [
           Zendesk::LabelledSnippet.new(
             on: @request,
-            field: :reason_for_change,
-            label: "Reason for request",
-          ),
-          Zendesk::LabelledSnippet.new(
-            on: @request,
-            field: :subject_area,
-            label: "Subject area",
-          ),
-          Zendesk::LabelledSnippet.new(on: self, field: :needed_by_date, label: "Deadline date"),
-          Zendesk::LabelledSnippet.new(on: self, field: :needed_by_time, label: "Deadline time"),
-          Zendesk::LabelledSnippet.new(on: self, field: :not_before_date, label: "Do not publish before date"),
-          Zendesk::LabelledSnippet.new(on: self, field: :not_before_time, label: "Do not publish before time"),
-          Zendesk::LabelledSnippet.new(
-            on: @request,
             field: :url,
             label: "URLs to be changed",
           ),

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -20,25 +20,7 @@ feature "Content change requests" do
       "tags" => %w[govt_form content_amend],
       "comment" => {
         "body" =>
-"[Reason for request]
-Factual inaccuracy
-
-[Subject area]
-Benefits
-
-[Deadline date]
-31-12-#{next_year}
-
-[Deadline time]
-13:00
-
-[Do not publish before date]
-01-12-#{next_year}
-
-[Do not publish before time]
-18:00
-
-[URLs to be changed]
+"[URLs to be changed]
 http://gov.uk/X
 
 [Details of what should be added, amended or removed]


### PR DESCRIPTION
This reverts commit bcd9984967f70e5338b21455debb3ecd72684de3.  

[Trello](https://trello.com/c/9j3DslWM/3176-apply-zendesk-mapping-to-the-content-requests-form-5)

## Don't deploy until

- [ ] Content team (Antoni Devlin) confirmed that Zappier is working as expected and it's ok to remove custom fields information from the ticket body. 

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
