### PR TITLE
Add fields to the 'Request a new campaign' form

### DIFF
--- a/app/controllers/campaign_requests_controller.rb
+++ b/app/controllers/campaign_requests_controller.rb
@@ -36,6 +36,8 @@ protected
         site_tagline
         site_metadescription
         cost_of_campaign
+        hmg_code
+        strategic_planning_code
         ga_contact_email
       ],
     ).to_h

--- a/app/models/support/gds/campaign.rb
+++ b/app/models/support/gds/campaign.rb
@@ -22,6 +22,8 @@ module Support
                     :site_tagline,
                     :site_metadescription,
                     :cost_of_campaign,
+                    :hmg_code,
+                    :strategic_planning_code,
                     :ga_contact_email
 
       validates :signed_campaign,
@@ -37,6 +39,8 @@ module Support
                 :site_tagline,
                 :site_metadescription,
                 :cost_of_campaign,
+                :hmg_code,
+                :strategic_planning_code,
                 :ga_contact_email,
                 presence: true
 

--- a/app/models/zendesk/ticket/campaign_request_ticket.rb
+++ b/app/models/zendesk/ticket/campaign_request_ticket.rb
@@ -85,6 +85,16 @@ module Zendesk
           ),
           Zendesk::LabelledSnippet.new(
             on: @request.campaign,
+            field: :hmg_code,
+            label: "HMG code: from approved AMC technical cases. Format: HMGXX-XXX (If not applicable enter n/a)",
+          ),
+          Zendesk::LabelledSnippet.new(
+            on: @request.campaign,
+            field: :strategic_planning_code,
+            label: "Strategic Planning Code: from strategic planning phase. Format: CSBXX-XXX (If not applicable enter n/a)",
+          ),
+          Zendesk::LabelledSnippet.new(
+            on: @request.campaign,
             field: :ga_contact_email,
             label: "Contact details for Google Analytics leads (Gmail accounts only)",
           ),

--- a/app/views/campaign_requests/_request_details.html.erb
+++ b/app/views/campaign_requests/_request_details.html.erb
@@ -222,6 +222,28 @@
 
     <div class="form-group">
       <span class="form-label">
+        <%= r.label :hmg_code do %>
+          HMG code: from approved AMC technical cases. Format: HMGXX-XXX (If not applicable enter n/a)
+        <% end %>
+      </span>
+      <span class="form-wrapper">
+        <%= r.text_field :hmg_code, required: false, aria: { required: false }, class: "input-md-6 form-control" %>
+      </span>
+    </div>
+
+    <div class="form-group">
+      <span class="form-label">
+        <%= r.label :strategic_planning_code do %>
+          Strategic Planning Code: from strategic planning phase. Format: CSBXX-XXX (If not applicable enter n/a)
+        <% end %>
+      </span>
+      <span class="form-wrapper">
+        <%= r.text_field :strategic_planning_code, required: false, aria: { required: false }, class: "input-md-6 form-control" %>
+      </span>
+    </div>
+
+    <div class="form-group">
+      <span class="form-label">
         <%= r.label :ga_contact_email do %>
           Cabinet Office/No10 only : Contact details for Google Analytics leads (Gmail accounts only)
         <% end %>

--- a/spec/features/campaign_requests_spec.rb
+++ b/spec/features/campaign_requests_spec.rb
@@ -59,6 +59,12 @@ pensions, campaign, newcampaign
 [Site build budget / costs (and overall campaign cost, if applicable)]
 £1200 and tuppence
 
+[HMG code: from approved AMC technical cases. Format: HMGXX-XXX (If not applicable enter n/a)]
+HMGXX-XXX
+
+[Strategic Planning Code: from strategic planning phase. Format: CSBXX-XXX (If not applicable enter n/a)]
+CSBXX-XXX
+
 [Contact details for Google Analytics leads (Gmail accounts only)]
 ga.contact@example.com
 
@@ -101,6 +107,8 @@ Yes",
       site_tagline: "A new one about a new thing",
       site_metadescription: "pensions, campaign, newcampaign",
       cost_of_campaign: "£1200 and tuppence",
+      hmg_code: "HMGXX-XXX",
+      strategic_planning_code: "CSBXX-XXX",
       ga_contact_email: "ga.contact@example.com",
       additional_comments: "Some comment",
     )
@@ -136,6 +144,8 @@ private
     fill_in "Site tagline*", with: details[:site_tagline]
     fill_in "Site metadescription (appears in search results)*", with: details[:site_metadescription]
     fill_in "Site build budget / costs (and overall campaign cost, if applicable)*", with: details[:cost_of_campaign]
+    fill_in "HMG code: from approved AMC technical cases. Format: HMGXX-XXX (If not applicable enter n/a)", with: details[:hmg_code]
+    fill_in "Strategic Planning Code: from strategic planning phase. Format: CSBXX-XXX (If not applicable enter n/a)", with: details[:strategic_planning_code]
     fill_in "Cabinet Office/No10 only : Contact details for Google Analytics leads (Gmail accounts only)", with: details[:ga_contact_email]
     fill_in "Additional comments", with: details[:additional_comments]
 

--- a/spec/models/support/gds/campaign_spec.rb
+++ b/spec/models/support/gds/campaign_spec.rb
@@ -25,6 +25,8 @@ module Support
           proposed_url: "example.campaign.gov.uk",
           site_metadescription: "tag1, tag2",
           cost_of_campaign: 1200,
+          hmg_code: "HMGXX-XXX",
+          strategic_planning_code: "CSBXX-XXX",
           ga_contact_email: "ga_test@digital.cabinet-office.gov.uk",
         )
       end
@@ -42,6 +44,8 @@ module Support
       it { should validate_presence_of(:site_tagline) }
       it { should validate_presence_of(:site_metadescription) }
       it { should validate_presence_of(:cost_of_campaign) }
+      it { should validate_presence_of(:hmg_code) }
+      it { should validate_presence_of(:strategic_planning_code) }
       it { should validate_presence_of(:ga_contact_email) }
 
       it { should validate_acceptance_of(:has_read_guidance_confirmation) }


### PR DESCRIPTION
Add HMG code and strategic planning code fields to the request a new campaign form.

https://trello.com/c/NoFOCDwj/3320-add-fields-to-the-request-a-new-campaign-form-in-support-app-2