### PR TITLE
Permit apostrophe in email address

### DIFF
--- a/app/models/support/requests/requester.rb
+++ b/app/models/support/requests/requester.rb
@@ -7,7 +7,7 @@ module Support
       attr_accessor :name
       attr_reader :email
 
-      VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+      VALID_EMAIL_REGEX = /\A[\w+\-.']+@[a-z\d\-.]+\.[a-z]+\z/i
 
       validates :email, presence: true
 

--- a/spec/models/support/requests/requester_spec.rb
+++ b/spec/models/support/requests/requester_spec.rb
@@ -12,10 +12,12 @@ module Support
       it { should allow_value("ab @c.com").for(:email) }
       it { should allow_value("ab@c.com ").for(:email) }
       it { should allow_value(" ab@c.com").for(:email) }
+      it { should allow_value("a'b@c.com ").for(:email) }
       it { should_not allow_value("ab").for(:email) }
 
       it { should allow_value("").for(:collaborator_emails) }
       it { should allow_value("ab@c.com").for(:collaborator_emails) }
+      it { should allow_value("a'b@c.com").for(:collaborator_emails) }
       it { should allow_value("ab@c.com, de@f.com").for(:collaborator_emails) }
       it { should_not allow_value("ab, de@f.com").for(:collaborator_emails) }
       it { should_not allow_value("ab@c.com111").for(:collaborator_emails) }


### PR DESCRIPTION
Some email addresses contain an apostrophe in the person's name before the `@` symbol, but we are currently disallowing them.

This adds that character into the validation for email addresses.

Resolved https://govuk.zendesk.com/agent/tickets/5548904.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
