### PR TITLE
Create .govuk_dependabot_merger.yml

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,0 +1,30 @@
+api_version: 1
+auto_merge:
+  - dependency: gds-api-adapters
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: gds-sso
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: gds_zendesk
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_admin_template
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_app_config
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_test
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: rubocop-govuk
+    allowed_semver_bumps:
+      - patch
+      - minor


### PR DESCRIPTION
Allow internal GDS dependencies to be auto-merged.

https://trello.com/c/c2KqD9Fu/3328-review-effectiveness-of-version-1-of-the-govuk-dependabot-merger