### PR TITLE
Fix validation-related bugs for organisation field in "Create new user" request form

### DIFF
--- a/app/controllers/create_new_user_requests_controller.rb
+++ b/app/controllers/create_new_user_requests_controller.rb
@@ -4,10 +4,11 @@ require "zendesk_api/error"
 class CreateNewUserRequestsController < RequestsController
   include ExploreHelper
 
+  helper_method :organisation_options
+
 protected
 
   def new_request
-    @organisations_list = support_api.organisations_list.to_a.map { |o| organisation_title(o) }
     Support::Requests::CreateNewUserRequest.new
   end
 
@@ -36,6 +37,10 @@ protected
     GDS_ZENDESK_CLIENT.users.create_or_update_user(requested_user)
   rescue ZendeskAPI::Error::ClientError => e
     exception_notification_for(e)
+  end
+
+  def organisation_options
+    @organisation_options ||= support_api.organisations_list.to_a.map { |o| organisation_title(o) }
   end
 
 private

--- a/app/views/create_new_user_requests/_requested_user_details.html.erb
+++ b/app/views/create_new_user_requests/_requested_user_details.html.erb
@@ -28,7 +28,7 @@
       <% end %>
     </span>
     <span class="form-wrapper">
-      <%= r.select :organisation, options_for_select(organisation_options), { include_blank: true }, multiple: false, class: "select2 form-control", type: "organisation" %>
+      <%= r.select :organisation, options_for_select(organisation_options, r.object.organisation), { include_blank: true }, multiple: false, class: "select2 form-control", type: "organisation" %>
     </span>
   </div>
 <% end %>

--- a/app/views/create_new_user_requests/_requested_user_details.html.erb
+++ b/app/views/create_new_user_requests/_requested_user_details.html.erb
@@ -28,7 +28,7 @@
       <% end %>
     </span>
     <span class="form-wrapper">
-      <%= r.select :organisation, options_for_select(@organisations_list), { include_blank: true }, multiple: false, class: "select2 form-control", type: "organisation" %>
+      <%= r.select :organisation, options_for_select(organisation_options), { include_blank: true }, multiple: false, class: "select2 form-control", type: "organisation" %>
     </span>
   </div>
 <% end %>

--- a/spec/controllers/create_new_user_requests_controller_spec.rb
+++ b/spec/controllers/create_new_user_requests_controller_spec.rb
@@ -56,6 +56,12 @@ describe CreateNewUserRequestsController, type: :controller do
     expect(response.body).to have_css(".alert", text: /Additional comments can't be blank/)
   end
 
+  it "retains the previously selected organisation if validation fails" do
+    post :create, params: { "support_requests_create_new_user_request" => { "requested_user_attributes" => { "organisation" => "Cabinet Office (CO)" } } }
+
+    expect(response.body).to have_css("select option[selected='selected'][value='Cabinet Office (CO)']")
+  end
+
   it "doesn't expose an error to the user when automatic user creation goes wrong" do
     zendesk_is_unavailable
 


### PR DESCRIPTION
This fixes a couple of bugs:
* A `NoMethodError` was being raised for any server-side validation error for this form
* The selected organisation was not being retained after a server-side validation error

Luckily both of these were masked from most users by the client-side validation and this may explain why we haven't seen any `NoMethodError` exceptions in the wild.