### PR TITLE
Simplify RequestedUser by using latest gds_zendesk

### DIFF
--- a/app/models/support/gds/requested_user.rb
+++ b/app/models/support/gds/requested_user.rb
@@ -8,9 +8,6 @@ module Support
 
       validates :name, :email, presence: true
       validates :email, format: { with: /@/ }
-
-      def job; end
-      def phone; end
     end
   end
 end

--- a/spec/controllers/create_new_user_requests_controller_spec.rb
+++ b/spec/controllers/create_new_user_requests_controller_spec.rb
@@ -36,8 +36,6 @@ describe CreateNewUserRequestsController, type: :controller do
     stub_user_creation = stub_zendesk_user_creation(
       email: "subject@digital.cabinet-office.gov.uk",
       name: "subject",
-      details: "Job title: ",
-      phone: nil,
       verified: true,
     )
 

--- a/spec/features/create_new_user_requests_spec.rb
+++ b/spec/features/create_new_user_requests_spec.rb
@@ -51,8 +51,6 @@ XXXX",
     user_creation_request = stub_zendesk_user_creation(
       email: "bob@gov.uk",
       name: "Bob Fields",
-      details: "Job title: ",
-      phone: nil,
       verified: true,
     )
 

--- a/spec/models/support/gds/requested_user_spec.rb
+++ b/spec/models/support/gds/requested_user_spec.rb
@@ -13,14 +13,6 @@ module Support
         subject.organisation = "Cabinet Office (CO)"
         expect(subject.organisation).to eq("Cabinet Office (CO)")
       end
-
-      it "responds to #job, because the GDSZendesk::Users#create_or_update_user expects it to" do
-        expect(subject).to respond_to(:job)
-      end
-
-      it "responds to #phone, because the GDSZendesk::Users#create_or_update_user expects it to" do
-        expect(subject).to respond_to(:phone)
-      end
     end
   end
 end


### PR DESCRIPTION
Previously the `reqested_user` argument passed to `GDSZendesk::Users#create_or_update_user` had to respond to both `#job` and `#phone` methods so that it could set the `details` and `phone` on the Zendesk user it created or updated.

However, since `gds_zendesk` v3.6.0 the `requested_user` no longer has to respond to those methods, so we can simplify `Support::GDS::RequestedUser` accordingly.