### PR TITLE
Add platforms to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,9 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.1)
+    google-protobuf (3.25.1-aarch64-linux)
+    google-protobuf (3.25.1-arm64-darwin)
+    google-protobuf (3.25.1-x86_64-linux)
     googleapis-common-protos-types (1.11.0)
       google-protobuf (~> 3.18)
     govuk_admin_template (6.10.0)
@@ -282,6 +285,12 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.0)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.0-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.0-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     null_logger (0.0.1)
     oauth2 (2.0.9)
@@ -734,7 +743,10 @@ GEM
       multipart-post (~> 2.0)
 
 PLATFORMS
+  aarch64-linux
+  arm64-darwin
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
c.f. https://github.com/alphagov/whitehall/pull/6934

We ran the following commands:

    bundle lock --add-platform ruby
    bundle lock --add-platform aarch64-linux
    bundle lock --add-platform arm64-darwin
    bundle lock --add-platform x86_64-linux

We've been seeing discrepancies in the `Gemfile.lock` when adding new gems with native extensions to this app whereby the new gem only gets added for the current bundler platform. We're hoping that making this change which has been made in a bunch of other GOV.UK apps will avoid that happening in future PRs.
