### PR TITLE
Add form for people to report problems with new GOV.UK search

### DIFF
--- a/app/controllers/report_an_issue_with_govuk_search_results_requests_controller.rb
+++ b/app/controllers/report_an_issue_with_govuk_search_results_requests_controller.rb
@@ -1,0 +1,24 @@
+class ReportAnIssueWithGovukSearchResultsRequestsController < RequestsController
+protected
+
+  def new_request
+    Support::Requests::ReportAnIssueWithGovukSearchResultsRequest.new
+  end
+
+  def zendesk_ticket_class
+    Zendesk::Ticket::ReportAnIssueWithGovukSearchResultsRequestTicket
+  end
+
+  def parse_request_from_params
+    Support::Requests::ReportAnIssueWithGovukSearchResultsRequest.new(request_params)
+  end
+
+  def request_params
+    params.require(:support_requests_report_an_issue_with_govuk_search_results_request).permit(
+      :search_query,
+      :results_problem,
+      :change_requested,
+      :change_justification,
+    ).to_h
+  end
+end

--- a/app/models/support/navigation/section_groups.rb
+++ b/app/models/support/navigation/section_groups.rb
@@ -66,6 +66,7 @@ module Support
 
       def feedback_requests
         sections_for(
+          Support::Requests::ReportAnIssueWithGovukSearchResultsRequest,
           Support::Requests::ContentPublisherFeedbackRequest,
           Support::Requests::ContentDataFeedback,
         )

--- a/app/models/support/permissions/ability.rb
+++ b/app/models/support/permissions/ability.rb
@@ -11,6 +11,7 @@ module Support
         can :create, Support::Requests::AnalyticsRequest
         can :create, [Support::Requests::GeneralRequest, Support::Requests::TechnicalFaultReport, Support::Requests::Anonymous::Explore]
         can :create, [Support::Requests::TaxonomyNewTopicRequest, Support::Requests::TaxonomyChangeTopicRequest]
+        can :create, Support::Requests::ReportAnIssueWithGovukSearchResultsRequest
         can :create, Support::Requests::ContentPublisherFeedbackRequest
         can :create, Support::Requests::ContentDataFeedback
         can :create, :all if user.has_permission?("single_points_of_contact")

--- a/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
+++ b/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
@@ -1,0 +1,20 @@
+module Support
+  module Requests
+    class ReportAnIssueWithGovukSearchResultsRequest < Request
+      attr_accessor :search_query, :results_problem, :change_requested, :change_justification
+
+      validates :search_query, presence: true
+      validates :results_problem, presence: true
+      validates :change_requested, presence: true
+      validates :change_justification, presence: true
+
+      def self.label
+        "Report an issue with GOV.UK search results"
+      end
+
+      def self.description
+        "Report a problem with specific search results from the new GOV.UK search engine."
+      end
+    end
+  end
+end

--- a/app/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket.rb
+++ b/app/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket.rb
@@ -1,0 +1,24 @@
+module Zendesk
+  module Ticket
+    class ReportAnIssueWithGovukSearchResultsRequestTicket < Zendesk::ZendeskTicket
+      def subject
+        "Report an issue with GOV.UK search results"
+      end
+
+      def tags
+        super + %w[site_search]
+      end
+
+    protected
+
+      def comment_snippets
+        [
+          Zendesk::LabelledSnippet.new(on: @request, field: :search_query, label: "What search query did you use?"),
+          Zendesk::LabelledSnippet.new(on: @request, field: :results_problem, label: "What is the problem with the search results?"),
+          Zendesk::LabelledSnippet.new(on: @request, field: :change_requested, label: "What change do you want to make to the search results?"),
+          Zendesk::LabelledSnippet.new(on: @request, field: :change_justification, label: "Why is this change necessary?"),
+        ]
+      end
+    end
+  end
+end

--- a/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
+++ b/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
@@ -1,0 +1,55 @@
+<div class="alert alert-info">
+  <p>Only use this form to report problems with specific GOV.UK site search results. Do not use this form for general feedback on the new GOV.UK search engine.</p>
+  <p>
+    Use <%= link_to "this tool to give general feedback on search results", "https://try-new-search-engine.publishing.service.gov.uk" %>.
+    This uses the standard login details for GOV.UK product testing or contact <%= mail_to "try-new-search-engine@digital.cabinet-office.gov.uk" %> for a login.
+  </p>
+</div>
+
+<p>GOV.UK is introducing a new search engine to power <%= link_to "GOV.UK site search", "https://www.gov.uk/search/all" %>. The search engine will continue to learn and improve over time, making search results more relevant.</p>
+
+<div id="feedback-type">
+  <div class="form-group">
+    <span class="form-label">
+      <%= f.label :search_query do %>
+        What search query did you use, for example “Universal Credit”?
+      <% end %>
+    </span>
+    <span class="form-wrapper">
+      <%= f.text_area :search_query, required: true, aria: { required: true }, class: "input-md-6 form-control", rows: 6, cols: 50 %>
+    </span>
+  </div>
+
+  <div class="form-group">
+    <span class="form-label">
+      <%= f.label :results_problem do %>
+        What is the problem with the search results?
+      <% end %>
+    </span>
+    <span class="form-wrapper">
+      <%= f.text_area :results_problem, required: true, aria: { required: true }, class: "input-md-6 form-control", rows: 6, cols: 50 %>
+    </span>
+  </div>
+
+  <div class="form-group">
+    <span class="form-label">
+      <%= f.label :change_requested do %>
+        What change do you want to make to the search results? Include URLs for any pages you want the search to show.
+      <% end %>
+    </span>
+    <span class="form-wrapper">
+      <%= f.text_area :change_requested, required: true, aria: { required: true }, class: "input-md-6 form-control", rows: 6, cols: 50 %>
+    </span>
+  </div>
+
+  <div class="form-group">
+    <span class="form-label">
+      <%= f.label :change_justification do %>
+        Explain why this change is necessary, including the impact on users and the number of users affected.
+      <% end %>
+    </span>
+    <span class="form-wrapper">
+      <%= f.text_area :change_justification, required: true, aria: { required: true }, class: "input-md-6 form-control", rows: 6, cols: 50 %>
+    </span>
+  </div>
+</div>

--- a/spec/controllers/report_an_issue_with_govuk_search_results_requests_controller_spec.rb
+++ b/spec/controllers/report_an_issue_with_govuk_search_results_requests_controller_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe ReportAnIssueWithGovukSearchResultsRequestsController, type: :controller do
+  render_views
+
+  before do
+    login_as create(:user)
+  end
+
+  it "re-displays the form with error messages if validation fails" do
+    post :create, params: { "support_requests_report_an_issue_with_govuk_search_results_request" => {
+      search_query: "",
+    } }
+
+    expect(controller).to have_rendered(:new)
+    expect(response.body).to have_css(".alert", text: /Search query can't be blank/)
+    expect(response.body).to have_css(".alert", text: /Results problem can't be blank/)
+    expect(response.body).to have_css(".alert", text: /Change requested can't be blank/)
+    expect(response.body).to have_css(".alert", text: /Change justification can't be blank/)
+  end
+end

--- a/spec/features/report_an_issue_with_govuk_search_results_spec.rb
+++ b/spec/features/report_an_issue_with_govuk_search_results_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+feature "Report an issue with GOV.UK search results" do
+  let(:user) { create(:user, name: "John Smith", email: "john.smith@email.co.uk") }
+
+  background do
+    login_as user
+    zendesk_has_no_user_with_email(user.email)
+  end
+
+  scenario "successful request" do
+    request = expect_zendesk_to_receive_ticket(
+      "subject" => "Report an issue with GOV.UK search results",
+      "requester" => hash_including("name" => "John Smith", "email" => "john.smith@email.co.uk"),
+      "tags" => %w[govt_form site_search],
+      "comment" => {
+        "body" =>
+"[What search query did you use?]
+search-query
+
+[What is the problem with the search results?]
+search-result-problem
+
+[What change do you want to make to the search results?]
+improve-search-results
+
+[Why is this change necessary?]
+improvement-justification",
+      },
+    )
+
+    user_reports_issue_with_search_results(
+      search_query: "search-query",
+      results_problem: "search-result-problem",
+      change_requested: "improve-search-results",
+      change_justification: "improvement-justification",
+    )
+
+    expect(request).to have_been_made
+  end
+
+private
+
+  def user_reports_issue_with_search_results(details)
+    visit "/"
+    click_on "Report an issue with GOV.UK search results"
+    expect(page).to have_content("Report an issue with GOV.UK search results")
+    fill_in "What search query did you use, for example “Universal Credit”?", with: details[:search_query]
+    fill_in "What is the problem with the search results?", with: details[:results_problem]
+    fill_in "What change do you want to make to the search results? Include URLs for any pages you want the search to show.", with: details[:change_requested]
+    fill_in "Explain why this change is necessary, including the impact on users and the number of users affected.", with: details[:change_justification]
+    user_submits_the_request_successfully
+  end
+end

--- a/spec/models/support/permissions/ability_spec.rb
+++ b/spec/models/support/permissions/ability_spec.rb
@@ -5,6 +5,12 @@ module Support
     describe Ability do
       subject { Ability.new(User.new(permissions: user_permissions)) }
 
+      context "for all users" do
+        let(:user_permissions) { [] }
+
+        it { should be_able_to(:create, Support::Requests::ReportAnIssueWithGovukSearchResultsRequest) }
+      end
+
       context "for a user with multiple permissions" do
         let(:user_permissions) { %w[content_requesters campaign_requesters] }
 

--- a/spec/models/support/requests/report_an_issue_with_govuk_search_results_request_spec.rb
+++ b/spec/models/support/requests/report_an_issue_with_govuk_search_results_request_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+module Support
+  module Requests
+    describe ReportAnIssueWithGovukSearchResultsRequest do
+      it { should validate_presence_of(:search_query) }
+      it { should validate_presence_of(:results_problem) }
+      it { should validate_presence_of(:change_requested) }
+      it { should validate_presence_of(:change_justification) }
+    end
+  end
+end

--- a/spec/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket_spec.rb
+++ b/spec/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+module Zendesk
+  module Ticket
+    describe ReportAnIssueWithGovukSearchResultsRequestTicket do
+      subject { described_class.new(double(requester: nil)) }
+
+      its(:tags) { should include("site_search") }
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/odKZPy7o

GOV.UK are trialling a new search engine. This new form allows people to report problems they encounter with this new search engine.