### PR TITLE
Remove "inside government" logic

### DIFF
--- a/app/controllers/technical_fault_reports_controller.rb
+++ b/app/controllers/technical_fault_reports_controller.rb
@@ -21,7 +21,7 @@ protected
       :what_happened,
       :what_should_have_happened,
       requester_attributes: %i[email name collaborator_emails],
-      fault_context_attributes: %i[name id inside_government_related],
+      fault_context_attributes: %i[name id],
     ).to_h
   end
 end

--- a/app/models/support/gds/user_facing_component.rb
+++ b/app/models/support/gds/user_facing_component.rb
@@ -4,13 +4,9 @@ module Support
   module GDS
     class UserFacingComponent
       include ActiveModel::Model
-      attr_accessor :name, :id, :inside_government_related
+      attr_accessor :name, :id
 
       validates :name, :id, presence: true
-
-      def inside_government_related?
-        inside_government_related
-      end
     end
   end
 end

--- a/app/models/support/gds/user_facing_components.rb
+++ b/app/models/support/gds/user_facing_components.rb
@@ -33,7 +33,7 @@ module Support
             { name: "Signon", id: "signon" },
             { name: "Specialist Publisher", id: "specialist_publisher" },
             { name: "Travel Advice Publisher", id: "travel_advice_publisher" },
-            { name: "Whitehall Publisher", id: "inside_government_publisher", inside_government_related: true },
+            { name: "Whitehall", id: "whitehall" },
           ]
         end
       end

--- a/app/models/support/gds/with_request_context.rb
+++ b/app/models/support/gds/with_request_context.rb
@@ -7,25 +7,9 @@ module Support
         base.validates_presence_of :request_context
         base.validates :request_context,
                        inclusion: {
-                         in: %w[mainstream inside_government detailed_guidance],
+                         in: %w[mainstream detailed_guidance],
                          message: "%{value} is not a valid option",
                        }
-      end
-
-      def formatted_request_context
-        Hash[request_context_options].key(request_context)
-      end
-
-      def inside_government_related?
-        %w[inside_government detailed_guidance].include?(request_context)
-      end
-
-      def request_context_options
-        [
-          ["Detailed Guidance", "detailed_guidance"],
-          ["Departments and policy", "inside_government"],
-          ["Services and information", "mainstream"],
-        ]
       end
     end
   end

--- a/app/models/support/requests/change_existing_user_request.rb
+++ b/app/models/support/requests/change_existing_user_request.rb
@@ -20,10 +20,6 @@ module Support
         "Change an existing user's account"
       end
 
-      def inside_government_related?
-        false
-      end
-
       def self.label
         "Change an existing user's account"
       end

--- a/app/models/support/requests/create_new_user_request.rb
+++ b/app/models/support/requests/create_new_user_request.rb
@@ -20,10 +20,6 @@ module Support
         "Create a new user account"
       end
 
-      def inside_government_related?
-        false
-      end
-
       def self.label
         "Create a new user"
       end

--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -27,10 +27,6 @@ module Support
         Support::GDS::UserFacingComponents.all + [Support::GDS::UserFacingComponent.new(name: "Do not know", id: "do_not_know")]
       end
 
-      def inside_government_related?
-        fault_context && fault_context.inside_government_related?
-      end
-
       def self.label
         "Report a technical fault to GDS"
       end

--- a/app/models/zendesk/ticket/change_existing_user_request_ticket.rb
+++ b/app/models/zendesk/ticket/change_existing_user_request_ticket.rb
@@ -6,7 +6,7 @@ module Zendesk
       end
 
       def tags
-        super + [@request.action] + inside_government_tag_if_needed
+        super + [@request.action]
       end
 
     protected

--- a/app/models/zendesk/ticket/create_new_user_request_ticket.rb
+++ b/app/models/zendesk/ticket/create_new_user_request_ticket.rb
@@ -6,7 +6,7 @@ module Zendesk
       end
 
       def tags
-        super + [@request.action] + inside_government_tag_if_needed
+        super + [@request.action]
       end
 
     protected

--- a/app/models/zendesk/ticket/technical_fault_report_ticket.rb
+++ b/app/models/zendesk/ticket/technical_fault_report_ticket.rb
@@ -6,7 +6,7 @@ module Zendesk
       end
 
       def tags
-        super + ["technical_fault", fault_context_tag] + inside_government_tag_if_needed
+        super + ["technical_fault", fault_context_tag]
       end
 
     protected

--- a/app/models/zendesk/ticket/unpublish_content_request_ticket.rb
+++ b/app/models/zendesk/ticket/unpublish_content_request_ticket.rb
@@ -6,7 +6,7 @@ module Zendesk
       end
 
       def tags
-        super + ["unpublish_content", "inside_government", @request.reason_for_unpublishing]
+        super + ["unpublish_content", @request.reason_for_unpublishing]
       end
 
     protected

--- a/app/models/zendesk/zendesk_ticket.rb
+++ b/app/models/zendesk/zendesk_ticket.rb
@@ -51,10 +51,6 @@ module Zendesk
       %w[govt_form]
     end
 
-    def inside_government_tag_if_needed
-      @request.inside_government_related? ? %w[inside_government] : []
-    end
-
     def to_s
       Zendesk::SnippetCollection.new(base_attribute_snippets + comment_snippets).to_s
     end

--- a/spec/features/technical_fault_reports_spec.rb
+++ b/spec/features/technical_fault_reports_spec.rb
@@ -45,7 +45,7 @@ Should have linked through",
     )
 
     expect(page).to have_selector(:id, "support_requests_technical_fault_report_fault_context_attributes_name_gov_uk_content")
-    expect(page).to have_selector(:id, "support_requests_technical_fault_report_fault_context_attributes_name_inside_government_publisher")
+    expect(page).to have_selector(:id, "support_requests_technical_fault_report_fault_context_attributes_name_whitehall")
     expect(page).to have_selector(:id, "support_requests_technical_fault_report_fault_context_attributes_name_mainstream_publisher")
     expect(page).to have_selector(:id, "support_requests_technical_fault_report_fault_context_attributes_name_travel_advice_publisher")
     expect(page).to have_selector(:id, "support_requests_technical_fault_report_fault_context_attributes_name_specialist_publisher")

--- a/spec/features/unpublish_content_requests_spec.rb
+++ b/spec/features/unpublish_content_requests_spec.rb
@@ -16,7 +16,7 @@ feature "Unpublish content requests" do
     request = expect_zendesk_to_receive_ticket(
       "subject" => "Published in error - Unpublish content request",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
-      "tags" => %w[govt_form unpublish_content inside_government published_in_error],
+      "tags" => %w[govt_form unpublish_content published_in_error],
       "comment" => {
         "body" =>
 "[URL of content to be unpublished]
@@ -43,7 +43,7 @@ Typo in slug name",
     request = expect_zendesk_to_receive_ticket(
       "subject" => "Duplicate of another page - Unpublish content request",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
-      "tags" => %w[govt_form unpublish_content inside_government duplicate_publication],
+      "tags" => %w[govt_form unpublish_content duplicate_publication],
       "comment" => {
         "body" =>
 "[URL of content to be unpublished]

--- a/spec/models/support/gds/user_facing_component_spec.rb
+++ b/spec/models/support/gds/user_facing_component_spec.rb
@@ -9,11 +9,6 @@ module Support
 
       it { should validate_presence_of(:name) }
       it { should allow_value(name: "gov_uk").for(:name) }
-
-      it "knows whether components are Inside Government-related or not" do
-        expect(component(name: "inside_government_publisher", inside_government_related: true)).to be_inside_government_related
-        expect(component(name: "gov_uk")).to_not be_inside_government_related
-      end
     end
   end
 end

--- a/spec/models/support/gds/with_request_context_spec.rb
+++ b/spec/models/support/gds/with_request_context_spec.rb
@@ -12,19 +12,8 @@ module Support
     describe TestModelWithRequestContext do
       it { should validate_presence_of(:request_context) }
       it { should allow_value("mainstream").for(:request_context) }
-      it { should allow_value("inside_government").for(:request_context) }
       it { should allow_value("detailed_guidance").for(:request_context) }
       it { should_not allow_value("xxx").for(:request_context) }
-
-      it "knows if it's related to inside government or not" do
-        expect(TestModelWithRequestContext.new(request_context: "inside_government")).to be_inside_government_related
-        expect(TestModelWithRequestContext.new(request_context: "detailed_guidance")).to be_inside_government_related
-        expect(TestModelWithRequestContext.new(request_context: "mainstream")).to_not be_inside_government_related
-      end
-
-      it "defines the formatted version" do
-        expect(TestModelWithRequestContext.new(request_context: "inside_government").formatted_request_context).to eq("Departments and policy")
-      end
     end
   end
 end

--- a/spec/models/support/requests/technical_fault_report_spec.rb
+++ b/spec/models/support/requests/technical_fault_report_spec.rb
@@ -10,11 +10,9 @@ module Support
       it { should validate_presence_of(:what_happened) }
       it { should validate_presence_of(:what_should_have_happened) }
 
-      it "is Inside Government-related if the fault is caused by an Inside Government technical component" do
-        expect(TechnicalFaultReport.new(fault_context: double(inside_government_related?: true))
-          .inside_government_related?).to be_truthy
-        expect(TechnicalFaultReport.new(fault_context: double(inside_government_related?: false))
-          .inside_government_related?).to be_falsey
+      it "sets the fault context based on fault context attributes" do
+        report = described_class.new(fault_context_attributes: { "name" => "content_data" })
+        expect(report.fault_context.name).to eq "Content Data"
       end
 
       it "assigns fault_context to a 'do_not_know' UserFacingComponent when 'do_not_know' is passed into the 'fault_context_attributes' 'name' attribute" do

--- a/spec/models/zendesk/ticket/technical_fault_report_ticket_spec.rb
+++ b/spec/models/zendesk/ticket/technical_fault_report_ticket_spec.rb
@@ -9,13 +9,8 @@ module Zendesk
         )
       end
 
-      subject { ticket_with_fault_context(id: "abc", inside_government_related?: false) }
+      subject { ticket_with_fault_context(id: "abc") }
       its(:tags) { should include("fault_with_abc", "technical_fault") }
-
-      context "a inside government-related report" do
-        subject { ticket_with_fault_context(inside_government_related?: true, id: "some_component") }
-        its(:tags) { should include("inside_government") }
-      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes several problems:

1. Whitehall being referred to as "Inside Government Publisher" (nobody calls it that anymore). Now fixed to Whitehall.
2. Removes unused `formatted_request_context` method in `WithRequestContext` module.
3. Lots of special cases around adding an "inside_government" tag, which is no longer used in any routing in Zendesk: See [screenshot of Zendesk 'Triggers' search](https://github.com/alphagov/support/assets/5111927/27309a74-998a-4b87-81b6-0b4f0e019850)

What _is_ used is the `fault_with_inside_government_publisher` tag on the [Initial Routing: Gov't Form publisher tech fault requests to 2nd Line--GOV.UK Alerts and Issues](https://govuk.zendesk.com/admin/objects-rules/rules/triggers/35985647) (to route to Technical 2nd Line). This will now be changed to `fault_with_whitehall`.

However, I've [raised a request](https://govuk.zendesk.com/agent/tickets/5623570) with User Support to change the routing rule to simply route everything with `technical_fault` ([included with every technical fault report](https://github.com/alphagov/support/blob/7ce521c4df65826af6fb42d1b9eece3910111209/app/models/zendesk/ticket/technical_fault_report_ticket.rb#L9)) to 2nd Line, so this should not be an issue.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
