### PR TITLE
Make technical fault report Zendesk ticket subjects more useful

### DIFF
--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -38,6 +38,10 @@ module Support
         OPTIONS[fault_context]
       end
 
+      def fault_subject
+        "Technical fault with #{formatted_fault_context}"
+      end
+
       def self.label
         "Report a technical fault to GDS"
       end

--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -39,6 +39,8 @@ module Support
       end
 
       def fault_subject
+        return "Technical fault report" if fault_context == "do_not_know"
+
         "Technical fault with #{formatted_fault_context}"
       end
 

--- a/app/models/zendesk/ticket/technical_fault_report_ticket.rb
+++ b/app/models/zendesk/ticket/technical_fault_report_ticket.rb
@@ -2,7 +2,7 @@ module Zendesk
   module Ticket
     class TechnicalFaultReportTicket < Zendesk::ZendeskTicket
       def subject
-        "Technical fault report"
+        "Technical fault with #{@request.formatted_fault_context}"
       end
 
       def tags

--- a/app/models/zendesk/ticket/technical_fault_report_ticket.rb
+++ b/app/models/zendesk/ticket/technical_fault_report_ticket.rb
@@ -2,7 +2,7 @@ module Zendesk
   module Ticket
     class TechnicalFaultReportTicket < Zendesk::ZendeskTicket
       def subject
-        "Technical fault with #{@request.formatted_fault_context}"
+        @request.fault_subject
       end
 
       def tags

--- a/spec/features/technical_fault_reports_spec.rb
+++ b/spec/features/technical_fault_reports_spec.rb
@@ -14,7 +14,7 @@ feature "Technical fault reports" do
 
   scenario "successful report" do
     request = expect_zendesk_to_receive_ticket(
-      "subject" => "Technical fault report",
+      "subject" => "Technical fault with GOV.UK: content",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form technical_fault fault_with_gov_uk_content],
       "comment" => {

--- a/spec/models/support/requests/technical_fault_report_spec.rb
+++ b/spec/models/support/requests/technical_fault_report_spec.rb
@@ -18,6 +18,13 @@ module Support
           expect(report.formatted_fault_context).to eq "Do not know"
         end
       end
+
+      describe "#fault_subject" do
+        it "returns a subject to be used for the Zendesk ticket" do
+          report = described_class.new(fault_context: "content_data")
+          expect(report.fault_subject).to eq "Technical fault with Content Data"
+        end
+      end
     end
   end
 end

--- a/spec/models/support/requests/technical_fault_report_spec.rb
+++ b/spec/models/support/requests/technical_fault_report_spec.rb
@@ -24,6 +24,11 @@ module Support
           report = described_class.new(fault_context: "content_data")
           expect(report.fault_subject).to eq "Technical fault with Content Data"
         end
+
+        it "returns a special subject if 'Do not know' was selected" do
+          report = described_class.new(fault_context: "do_not_know")
+          expect(report.fault_subject).to eq "Technical fault report"
+        end
       end
     end
   end


### PR DESCRIPTION
Before: "Technical fault report"
After:" Technical fault with {APP_NAME}"

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
