### PR TITLE
Update list of applications for the Technical Fault Report form

### DIFF
--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -5,6 +5,20 @@ module Support
     class TechnicalFaultReport < Request
       attr_accessor :fault_context, :fault_specifics, :actions_leading_to_problem, :what_happened, :what_should_have_happened
 
+      # Zendesk tickets are created with a generic `technical_fault`
+      # tag as well as a tag of the form `fault_with_*`, where * is a
+      # key from this hash, e.g. `fault_with_collections_publisher`.
+      #
+      # By default, all `technical_fault` tagged tickets are triaged
+      # to `GOV.UK 2nd Line--Alerts and Issues` via this trigger:
+      # https://govuk.zendesk.com/admin/objects-rules/rules/triggers/35985647
+      #
+      # Tickets may be triaged elsewhere if there is another trigger
+      # looking for the `fault_with_*` tag. Therefore, when editing
+      # the following hash, you should always check whether there is
+      # a corresponding trigger to add/remove/edit. Search all triggers:
+      # https://govuk.zendesk.com/admin/objects-rules/rules/triggers/
+      # ("Conditions" -> "Tags" -> "Contains at least one of the following")
       OPTIONS = {
         "collections_publisher" => "Collections Publisher",
         "contacts_admin" => "Contacts Admin",

--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -36,6 +36,7 @@ module Support
         "short_url_manager" => "Short URL Manager",
         "signon" => "Signon",
         "specialist_publisher" => "Specialist Publisher",
+        "support" => "Support app",
         "transition" => "Transition",
         "travel_advice_publisher" => "Travel Advice Publisher",
         "whitehall" => "Whitehall",

--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -36,6 +36,7 @@ module Support
         "short_url_manager" => "Short URL Manager",
         "signon" => "Signon",
         "specialist_publisher" => "Specialist Publisher",
+        "transition" => "Transition",
         "travel_advice_publisher" => "Travel Advice Publisher",
         "whitehall" => "Whitehall",
         "do_not_know" => "Do not know",

--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -23,7 +23,7 @@ module Support
         "collections_publisher" => "Collections Publisher",
         "contacts_admin" => "Contacts Admin",
         "content_data" => "Content Data",
-        "content_publisher" => "Content Publisher (beta)",
+        "content_publisher" => "Content Publisher",
         "content_tagger" => "Content Tagger",
         "datagovuk" => "data.gov.uk",
         "gov_uk_content" => "GOV.UK: content",

--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -26,6 +26,7 @@ module Support
         "content_publisher" => "Content Publisher",
         "content_tagger" => "Content Tagger",
         "datagovuk" => "data.gov.uk",
+        "email_alerts" => "Email alerts",
         "gov_uk_content" => "GOV.UK: content",
         "imminence" => "Imminence",
         "local_links_manager" => "Local Links Manager",

--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -35,6 +35,7 @@ module Support
         "service_manual_publisher" => "Service Manual Publisher",
         "short_url_manager" => "Short URL Manager",
         "signon" => "Signon",
+        "smart_answers" => "Smart Answers",
         "specialist_publisher" => "Specialist Publisher",
         "support" => "Support app",
         "transition" => "Transition",


### PR DESCRIPTION
Also adds an inline comment giving a strong hint to the developer to check Zendesk when making changes to this config.
See commits for details.

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
