### PR TITLE
Create new user form improvements

### DIFF
--- a/app/controllers/create_new_user_requests_controller.rb
+++ b/app/controllers/create_new_user_requests_controller.rb
@@ -26,6 +26,7 @@ protected
       :email,
       :organisation,
       :access_to_whitehall_publisher,
+      :access_to_other_publishing_apps,
       :additional_comments,
       requester_attributes: %i[email name collaborator_emails],
     ).to_h

--- a/app/controllers/create_new_user_requests_controller.rb
+++ b/app/controllers/create_new_user_requests_controller.rb
@@ -25,6 +25,7 @@ protected
       :name,
       :email,
       :organisation,
+      :access_to_whitehall_publisher,
       :additional_comments,
       requester_attributes: %i[email name collaborator_emails],
     ).to_h

--- a/app/models/support/requests/create_new_user_request.rb
+++ b/app/models/support/requests/create_new_user_request.rb
@@ -12,7 +12,6 @@ module Support
 
       validates :name, :email, presence: true
       validates :email, format: { with: /@/ }
-      validates :additional_comments, presence: true
       validates :access_to_whitehall_publisher,
                 inclusion: { in: :access_to_whitehall_publisher_option_keys,
                              allow_blank: false,
@@ -21,6 +20,9 @@ module Support
                 inclusion: { in: :access_to_other_publishing_apps_option_keys,
                              allow_blank: false,
                              message: "Select if the user needs access to other publishing apps" }
+      validates :additional_comments,
+                presence: { message: "List which publishing applications and permissions the user needs" },
+                if: -> { access_to_other_publishing_apps == "required" }
 
       def action
         "create_new_user"

--- a/app/models/support/requests/create_new_user_request.rb
+++ b/app/models/support/requests/create_new_user_request.rb
@@ -13,16 +13,11 @@ module Support
       validates :name, :email, presence: true
       validates :email, format: { with: /@/ }
       validates :access_to_whitehall_publisher,
-                inclusion: { in: :access_to_whitehall_publisher_option_keys,
-                             allow_blank: false,
-                             message: "Select if the user needs access to Whitehall Publisher" }
+                inclusion: { in: :access_to_whitehall_publisher_option_keys, allow_blank: false }
       validates :access_to_other_publishing_apps,
-                inclusion: { in: :access_to_other_publishing_apps_option_keys,
-                             allow_blank: false,
-                             message: "Select if the user needs access to other publishing apps" }
+                inclusion: { in: :access_to_other_publishing_apps_option_keys, allow_blank: false }
       validates :additional_comments,
-                presence: { message: "List which publishing applications and permissions the user needs" },
-                if: -> { access_to_other_publishing_apps == "required" }
+                presence: true, if: -> { access_to_other_publishing_apps == "required" }
 
       def action
         "create_new_user"

--- a/app/models/support/requests/create_new_user_request.rb
+++ b/app/models/support/requests/create_new_user_request.rb
@@ -5,12 +5,17 @@ module Support
         :name,
         :email,
         :organisation,
+        :access_to_whitehall_publisher,
         :additional_comments,
       )
 
       validates :name, :email, presence: true
       validates :email, format: { with: /@/ }
       validates :additional_comments, presence: true
+      validates :access_to_whitehall_publisher,
+                inclusion: { in: :access_to_whitehall_publisher_option_keys,
+                             allow_blank: false,
+                             message: "Select if the user needs access to Whitehall Publisher" }
 
       def action
         "create_new_user"
@@ -26,6 +31,22 @@ module Support
 
       def self.description
         "Request a new user account."
+      end
+
+      def access_to_whitehall_publisher_options
+        {
+          "not_required" => "No, the user does not need to draft or publish content on Whitehall publisher",
+          "requires_writer_permission" => "Yes, as a writer who can draft content",
+          "requires_editor_permissions" => "Yes, as an editor who can publish content",
+        }
+      end
+
+      def access_to_whitehall_publisher_option_keys
+        access_to_whitehall_publisher_options.keys
+      end
+
+      def formatted_access_to_whitehall_publisher_option
+        access_to_whitehall_publisher_options[access_to_whitehall_publisher]
       end
     end
   end

--- a/app/models/support/requests/create_new_user_request.rb
+++ b/app/models/support/requests/create_new_user_request.rb
@@ -6,6 +6,7 @@ module Support
         :email,
         :organisation,
         :access_to_whitehall_publisher,
+        :access_to_other_publishing_apps,
         :additional_comments,
       )
 
@@ -16,6 +17,10 @@ module Support
                 inclusion: { in: :access_to_whitehall_publisher_option_keys,
                              allow_blank: false,
                              message: "Select if the user needs access to Whitehall Publisher" }
+      validates :access_to_other_publishing_apps,
+                inclusion: { in: :access_to_other_publishing_apps_option_keys,
+                             allow_blank: false,
+                             message: "Select if the user needs access to other publishing apps" }
 
       def action
         "create_new_user"
@@ -47,6 +52,21 @@ module Support
 
       def formatted_access_to_whitehall_publisher_option
         access_to_whitehall_publisher_options[access_to_whitehall_publisher]
+      end
+
+      def access_to_other_publishing_apps_options
+        {
+          "not_required" => "No, the user does not need access to any other publishing application",
+          "required" => "Yes, the user needs access to the applications and permissions listed below",
+        }
+      end
+
+      def access_to_other_publishing_apps_option_keys
+        access_to_other_publishing_apps_options.keys
+      end
+
+      def formatted_access_to_other_publishing_apps_option
+        access_to_other_publishing_apps_options[access_to_other_publishing_apps]
       end
     end
   end

--- a/app/models/zendesk/ticket/create_new_user_request_ticket.rb
+++ b/app/models/zendesk/ticket/create_new_user_request_ticket.rb
@@ -38,6 +38,11 @@ module Zendesk
             field: :formatted_access_to_whitehall_publisher_option,
             label: "Access to Whitehall Publisher",
           ),
+          Zendesk::LabelledSnippet.new(
+            on: @request,
+            field: :formatted_access_to_other_publishing_apps_option,
+            label: "Access to other publishing apps",
+          ),
           Zendesk::LabelledSnippet.new(on: @request, field: :additional_comments),
         ]
       end

--- a/app/models/zendesk/ticket/create_new_user_request_ticket.rb
+++ b/app/models/zendesk/ticket/create_new_user_request_ticket.rb
@@ -33,6 +33,11 @@ module Zendesk
             field: :organisation,
             label: "Organisation",
           ),
+          Zendesk::LabelledSnippet.new(
+            on: @request,
+            field: :formatted_access_to_whitehall_publisher_option,
+            label: "Access to Whitehall Publisher",
+          ),
           Zendesk::LabelledSnippet.new(on: @request, field: :additional_comments),
         ]
       end

--- a/app/views/create_new_user_requests/_request_details.html.erb
+++ b/app/views/create_new_user_requests/_request_details.html.erb
@@ -74,14 +74,14 @@
     <div class="form-group">
       <span class="form-label">
         <%= f.label :additional_comments do %>
-          List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.<abbr title="required">*</abbr>
+          List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.
         <% end %>
       </span>
       <p class="help-block hint-block--md-6" id="additional-comments-hint">
         All users have basic access to Content Data, Feedback Explorer, GovSearch and Support forms.
       </p>
       <span class="form-wrapper">
-        <%= f.text_area :additional_comments, required: true, aria: { required: true }, class: "input-md-6 form-control", rows: 6, cols: 50 %>
+        <%= f.text_area :additional_comments, class: "input-md-6 form-control", rows: 6, cols: 50 %>
       </span>
     </div>
 

--- a/app/views/create_new_user_requests/_request_details.html.erb
+++ b/app/views/create_new_user_requests/_request_details.html.erb
@@ -37,6 +37,24 @@
 
     <div class="form-group">
       <span class="form-label">
+        <%= f.label :access_to_whitehall_publisher, class: "control-label" do %>
+          Does the user need access to Whitehall Publisher?<abbr title="required">*</abbr>
+        <% end %>
+      </span>
+      <span class="form-wrapper">
+        <%= f.collection_radio_buttons :access_to_whitehall_publisher, f.object.access_to_whitehall_publisher_options, :first, :first, required: true, aria: { required: true } do |builder| %>
+          <div class="radio">
+            <%= builder.label class: "custom-control-label" do %>
+              <%= builder.radio_button(class: "custom-control-input") %>
+              <%= builder.object.last %>
+            <% end %>
+          </div>
+        <% end %>
+      </span>
+    </div>
+
+    <div class="form-group">
+      <span class="form-label">
         <%= f.label :additional_comments do %>
           List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.<abbr title="required">*</abbr>
         <% end %>

--- a/app/views/create_new_user_requests/_request_details.html.erb
+++ b/app/views/create_new_user_requests/_request_details.html.erb
@@ -55,6 +55,24 @@
 
     <div class="form-group">
       <span class="form-label">
+        <%= f.label :access_to_other_publishing_apps, class: "control-label" do %>
+          Does this user need access to any other publishing applications?<abbr title="required">*</abbr>
+        <% end %>
+      </span>
+      <span class="form-wrapper">
+        <%= f.collection_radio_buttons :access_to_other_publishing_apps, f.object.access_to_other_publishing_apps_options, :first, :first, required: true, aria: { required: true } do |builder| %>
+          <div class="radio">
+            <%= builder.label class: "custom-control-label" do %>
+              <%= builder.radio_button(class: "custom-control-input") %>
+              <%= builder.object.last %>
+            <% end %>
+          </div>
+        <% end %>
+      </span>
+    </div>
+
+    <div class="form-group">
+      <span class="form-label">
         <%= f.label :additional_comments do %>
           List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.<abbr title="required">*</abbr>
         <% end %>

--- a/app/views/create_new_user_requests/_request_details.html.erb
+++ b/app/views/create_new_user_requests/_request_details.html.erb
@@ -38,7 +38,7 @@
     <div class="form-group">
       <span class="form-label">
         <%= f.label :additional_comments do %>
-          What additional publishing permissions does the user need?<abbr title="required">*</abbr>
+          List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.<abbr title="required">*</abbr>
         <% end %>
       </span>
       <p class="help-block hint-block--md-6" id="additional-comments-hint">

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,7 @@ module Support
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.assets.prefix = "/assets/support"
+
+    config.active_model.i18n_customize_full_message = true
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,21 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activemodel:
+    errors:
+      models:
+        support/requests/create_new_user_request:
+          format: '%{message}'
+          attributes:
+            name:
+              blank: Enter a name
+            email:
+              blank: Enter an email address
+              invalid: Enter an email address in the correct format, like name@example.com
+            access_to_whitehall_publisher:
+              inclusion: Select if the user needs access to Whitehall Publisher
+            access_to_other_publishing_apps:
+              inclusion: Select if the user needs access to other publishing apps
+            additional_comments:
+              blank: List which publishing applications and permissions the user needs
+

--- a/spec/controllers/create_new_user_requests_controller_spec.rb
+++ b/spec/controllers/create_new_user_requests_controller_spec.rb
@@ -53,7 +53,7 @@ describe CreateNewUserRequestsController, type: :controller do
 
     expect(controller).to have_rendered(:new)
     expect(response.body).to have_css(".alert", text: /Name can't be blank/)
-    expect(response.body).to have_css(".alert", text: /Additional comments can't be blank/)
+    expect(response.body).to have_css(".alert", text: /Select if the user needs access to Whitehall Publisher/)
   end
 
   it "retains the previously selected organisation if validation fails" do

--- a/spec/controllers/create_new_user_requests_controller_spec.rb
+++ b/spec/controllers/create_new_user_requests_controller_spec.rb
@@ -17,6 +17,7 @@ describe CreateNewUserRequestsController, type: :controller do
         "requester_attributes" => valid_requester_params,
         **valid_requested_user_params,
         "action" => "create_new_user",
+        "access_to_whitehall_publisher" => "not_required",
         "additional_comments" => "not-blank",
       },
     }

--- a/spec/controllers/create_new_user_requests_controller_spec.rb
+++ b/spec/controllers/create_new_user_requests_controller_spec.rb
@@ -18,6 +18,7 @@ describe CreateNewUserRequestsController, type: :controller do
         **valid_requested_user_params,
         "action" => "create_new_user",
         "access_to_whitehall_publisher" => "not_required",
+        "access_to_other_publishing_apps" => "required",
         "additional_comments" => "not-blank",
       },
     }

--- a/spec/controllers/create_new_user_requests_controller_spec.rb
+++ b/spec/controllers/create_new_user_requests_controller_spec.rb
@@ -52,7 +52,7 @@ describe CreateNewUserRequestsController, type: :controller do
     post :create, params: { "support_requests_create_new_user_request" => { "action" => "create_new_user" } }
 
     expect(controller).to have_rendered(:new)
-    expect(response.body).to have_css(".alert", text: /Name can't be blank/)
+    expect(response.body).to have_css(".alert", text: /Enter a name/)
     expect(response.body).to have_css(".alert", text: /Select if the user needs access to Whitehall Publisher/)
   end
 

--- a/spec/features/create_new_user_requests_spec.rb
+++ b/spec/features/create_new_user_requests_spec.rb
@@ -46,6 +46,9 @@ Cabinet Office (CO)
 [Access to Whitehall Publisher]
 No, the user does not need to draft or publish content on Whitehall publisher
 
+[Access to other publishing apps]
+Yes, the user needs access to the applications and permissions listed below
+
 [Additional comments]
 XXXX",
       },
@@ -67,6 +70,7 @@ XXXX",
     fill_in "User's email", with: "bob@gov.uk"
     select "Cabinet Office (CO)", from: "User's organisation"
     choose "No, the user does not need to draft or publish content on Whitehall publisher"
+    choose "Yes, the user needs access to the applications and permissions listed below"
     fill_in "List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.", with: "XXXX"
 
     user_submits_the_request_successfully

--- a/spec/features/create_new_user_requests_spec.rb
+++ b/spec/features/create_new_user_requests_spec.rb
@@ -63,7 +63,7 @@ XXXX",
     fill_in "User's name", with: "Bob Fields"
     fill_in "User's email", with: "bob@gov.uk"
     select "Cabinet Office (CO)", from: "User's organisation"
-    fill_in "What additional publishing permissions does the user need?", with: "XXXX"
+    fill_in "List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.", with: "XXXX"
 
     user_submits_the_request_successfully
 

--- a/spec/features/create_new_user_requests_spec.rb
+++ b/spec/features/create_new_user_requests_spec.rb
@@ -43,6 +43,9 @@ bob@gov.uk
 [Organisation]
 Cabinet Office (CO)
 
+[Access to Whitehall Publisher]
+No, the user does not need to draft or publish content on Whitehall publisher
+
 [Additional comments]
 XXXX",
       },
@@ -63,6 +66,7 @@ XXXX",
     fill_in "User's name", with: "Bob Fields"
     fill_in "User's email", with: "bob@gov.uk"
     select "Cabinet Office (CO)", from: "User's organisation"
+    choose "No, the user does not need to draft or publish content on Whitehall publisher"
     fill_in "List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.", with: "XXXX"
 
     user_submits_the_request_successfully

--- a/spec/models/support/requests/create_new_user_request_spec.rb
+++ b/spec/models/support/requests/create_new_user_request_spec.rb
@@ -15,6 +15,9 @@ module Support
       it { should allow_value("ab@c.com").for(:email) }
       it { should_not allow_value("ab").for(:email) }
 
+      it { should_not allow_values(nil, "").for(:access_to_whitehall_publisher) }
+      it { should validate_inclusion_of(:access_to_whitehall_publisher).in_array(%w[not_required requires_writer_permission requires_editor_permissions]).with_message("Select if the user needs access to Whitehall Publisher") }
+
       it { should allow_value("a comment").for(:additional_comments) }
 
       it "provides formatted action" do
@@ -24,6 +27,13 @@ module Support
       it "validates that additional_comments is not blank" do
         request = request(additional_comments: "")
         expect(request).to have_at_least(1).error_on(:additional_comments)
+      end
+
+      describe "#formatted_access_to_whitehall_publisher_option" do
+        it "returns the human readable name for the chosen options" do
+          report = described_class.new(access_to_whitehall_publisher: "not_required")
+          expect(report.formatted_access_to_whitehall_publisher_option).to eq "No, the user does not need to draft or publish content on Whitehall publisher"
+        end
       end
     end
   end

--- a/spec/models/support/requests/create_new_user_request_spec.rb
+++ b/spec/models/support/requests/create_new_user_request_spec.rb
@@ -21,15 +21,20 @@ module Support
       it { should_not allow_values(nil, "").for(:access_to_other_publishing_apps) }
       it { should validate_inclusion_of(:access_to_other_publishing_apps).in_array(%w[not_required required]).with_message("Select if the user needs access to other publishing apps") }
 
-      it { should allow_value("a comment").for(:additional_comments) }
+      context "when access to other publishing apps is required" do
+        before { subject.access_to_other_publishing_apps = "required" }
+
+        it { should validate_presence_of(:additional_comments).with_message("List which publishing applications and permissions the user needs") }
+      end
+
+      context "when access to other publishing apps is not required" do
+        before { subject.access_to_other_publishing_apps = "not_required" }
+
+        it { should_not validate_presence_of(:additional_comments) }
+      end
 
       it "provides formatted action" do
         expect(request.formatted_action).to eq("Create a new user account")
-      end
-
-      it "validates that additional_comments is not blank" do
-        request = request(additional_comments: "")
-        expect(request).to have_at_least(1).error_on(:additional_comments)
       end
 
       describe "#formatted_access_to_whitehall_publisher_option" do

--- a/spec/models/support/requests/create_new_user_request_spec.rb
+++ b/spec/models/support/requests/create_new_user_request_spec.rb
@@ -18,6 +18,9 @@ module Support
       it { should_not allow_values(nil, "").for(:access_to_whitehall_publisher) }
       it { should validate_inclusion_of(:access_to_whitehall_publisher).in_array(%w[not_required requires_writer_permission requires_editor_permissions]).with_message("Select if the user needs access to Whitehall Publisher") }
 
+      it { should_not allow_values(nil, "").for(:access_to_other_publishing_apps) }
+      it { should validate_inclusion_of(:access_to_other_publishing_apps).in_array(%w[not_required required]).with_message("Select if the user needs access to other publishing apps") }
+
       it { should allow_value("a comment").for(:additional_comments) }
 
       it "provides formatted action" do
@@ -33,6 +36,13 @@ module Support
         it "returns the human readable name for the chosen options" do
           report = described_class.new(access_to_whitehall_publisher: "not_required")
           expect(report.formatted_access_to_whitehall_publisher_option).to eq "No, the user does not need to draft or publish content on Whitehall publisher"
+        end
+      end
+
+      describe "#formatted_access_to_other_publishing_apps_option" do
+        it "returns the human readable name for the chosen options" do
+          report = described_class.new(access_to_other_publishing_apps: "not_required")
+          expect(report.formatted_access_to_other_publishing_apps_option).to eq "No, the user does not need access to any other publishing application"
         end
       end
     end


### PR DESCRIPTION
https://trello.com/c/2B5qTHlZ

![image](https://github.com/alphagov/support/assets/47089130/815f93d6-9b9b-46ce-92d7-5652c7a8ec34)

### Update label for additional comments
We are going to add additional questions so that the user can specify whether
they want to list any additional publishing applications.

Therefore, this label is updated to be less generic.

### Add access to Whitehall question
As the "additional comments" question is quite generic, 2nd line content is
having to reply to users to specify whether the new user need access to
Whitehall publisher.

Add a new question that specifically asks whether the user needs access to
Whitehall publisher.

### Add access to other apps question
As the "additional comments" question is quite generic, 2nd line content is
having to reply to users to specify whether the new user need access to
applications other than Whitehall publisher.

Add a new question that specifically asks whether the user needs access to apps
other than Whitehall publisher.

### Additional comments can be blank
Additional comments is used to list the applications that the user needs access
to.

Now that we have a new question asking whether the user needs access to other
applications, this can be blank.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
