### PR TITLE
Update technical fault options as per March 2024 review

### DIFF
--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -27,12 +27,14 @@ module Support
         "content_tagger" => "Content Tagger",
         "datagovuk" => "data.gov.uk",
         "email_alerts" => "Email alerts",
+        "feedback_explorer" => "Feedback explorer",
         "gov_uk_content" => "GOV.UK: content",
         "imminence" => "Imminence",
         "local_links_manager" => "Local Links Manager",
         "mainstream_publisher" => "Mainstream Publisher",
         "manuals_publisher" => "Manuals Publisher",
         "maslow" => "Maslow",
+        "search" => "Search",
         "service_manual_publisher" => "Service Manual Publisher",
         "short_url_manager" => "Short URL Manager",
         "signon" => "Signon",
@@ -42,7 +44,7 @@ module Support
         "transition" => "Transition",
         "travel_advice_publisher" => "Travel Advice Publisher",
         "whitehall" => "Whitehall",
-        "do_not_know" => "Do not know",
+        "do_not_know" => "Other / do not know",
       }.freeze
 
       validates :fault_context, :fault_specifics, :actions_leading_to_problem, :what_happened, :what_should_have_happened, presence: true

--- a/spec/models/support/requests/technical_fault_report_spec.rb
+++ b/spec/models/support/requests/technical_fault_report_spec.rb
@@ -15,7 +15,7 @@ module Support
       describe "#formatted_fault_context" do
         it "returns the human readable name for the chosen context" do
           report = described_class.new(fault_context: "do_not_know")
-          expect(report.formatted_fault_context).to eq "Do not know"
+          expect(report.formatted_fault_context).to eq "Other / do not know"
         end
       end
 


### PR DESCRIPTION
On @nicholsj' suggestion:

- We should have a "Search" option for general tech support issues (as opposed to the existing https://support.publishing.service.gov.uk/report_an_issue_with_govuk_search_results_request/new form, which is for reporting search results themselves)
- We should have an option for "Feedback explorer" (it's part of the Support app, but users don't necessarily know that, and it may well move into Content Data in future)
- We can make it clearer that "Do not know" is also for times where the user _does_ know the area, but it doesn't fit into any of the existing options.

NB, I'll get User Support to make sure the `fault_with_feedback_explorer` tag routes to [GOV.UK Platform Support](https://govuk.zendesk.com/agent/filters/12863141605916).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
