### PR TITLE
Improve URL regex match

### DIFF
--- a/app/presenters/scope_filters_presenter.rb
+++ b/app/presenters/scope_filters_presenter.rb
@@ -81,7 +81,7 @@ private
       normalized_path = URI.parse(path_or_url).path
 
       if normalized_path.present?
-        normalized_path.sub!(/^(http(s)?(:)?(\/)+?(:)?)?((\/)?www.)?gov.uk/, "")
+        normalized_path.sub!(/\A(http(s)?(:)?(\/)+?(:)?)?((\/)?www\.)?gov\.uk/, "")
         normalized_path.start_with?("/") ? normalized_path : "/#{normalized_path}"
       else
         "/"


### PR DESCRIPTION
Escaped `.` regular expression is more specific and restrictive in its matching of the domain name "gov.uk" by ensuring that the dot character is exactly matched, whereas the old regular expression allows for any character to be present in place of the dot. 

This means it will only match "gov.uk" and won't match variations like "govXuk" or "gov1uk".

Trello: https://trello.com/c/tiWPB7lJ/3474-review-code-scanning-alerts-for-our-repos

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
