### PR TITLE
Setup Google Tag Manager

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,12 @@
 <% content_for :page_title, ' | GOV.UK Support' %>
 <% content_for :head do %>
+  <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
+    } %>
+  <% end %>
   <%= csrf_meta_tag %>
   <%= csp_meta_tag %>
   <%= stylesheet_link_tag "legacy/application", :media => "all" %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -1,3 +1,13 @@
+<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+  <% content_for :head do %>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
+    } %>
+  <% end %>
+<% end %>
+
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   product_name: "Support",
   environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,


### PR DESCRIPTION
This allows us to implement basic GA4 tracking on all pages of the app. It is configured using the following environment variables:
- GOOGLE_TAG_MANAGER_ID
- GOOGLE_TAG_MANAGER_AUTH (integration only)
- GOOGLE_TAG_MANAGER_PREVIEW (integration only)

If only the `GOOGLE_TAG_MANAGER_ID` is set then the default environment of the GTM container will be used.

If `GOOGLE_TAG_MANAGER_AUTH` and `GOOGLE_TAG_MANAGER_PREVIEW` are set then the specified GTM container environment will be used - specifically for testing the configuration in Integration before rolling out to Production.

This has been successfully tested in Integration using [the test environment](https://tagmanager.google.com/?pli=1#/container/accounts/6005964263/containers/168629509/workspaces/6/variables) in Google Tag Manager.

Related PR  - https://github.com/alphagov/govuk-helm-charts/pull/1936

Trello card: https://trello.com/c/owLrfsOP/3473-implement-tracking-in-ga4-for-support-3
