### PR TITLE
Improve URL regex match

### DIFF
--- a/app/models/support/requests/anonymous/explore.rb
+++ b/app/models/support/requests/anonymous/explore.rb
@@ -33,7 +33,7 @@ module Support
         def paths_from_urls
           urls = []
           parsed_urls.each do |url|
-            path = URI(url).path.sub(/^(http(s)?(:)?(\/)+?(:)?)?((\/)?www.)?gov.uk/, "")
+            path = URI(url).path.sub(/\A(http(s)?(:)?(\/)+?(:)?)?((\/)?www\.)?gov\.uk/, "")
             urls << (path.start_with?("/") ? path : "/#{path}")
           end
           urls.uniq


### PR DESCRIPTION
Escaped . regular expression is more specific and restrictive in its matching of the domain name "gov.uk" by ensuring that the dot character is exactly matched, whereas the old regular expression allows for any character to be present in place of the dot.

This means it will only match "gov.uk" and won't match variations like "govXuk" or "gov1uk".

Trello: https://trello.com/c/tiWPB7lJ/3474-review-code-scanning-alerts-for-our-repos

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
