### PR TITLE
Update CSRF protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_support_user!
 
-  protect_from_forgery
+  protect_from_forgery with: :exception
 
   rescue_from Timeout::Error, with: :service_unavailable
 


### PR DESCRIPTION
If the security token doesn't match what was expected, an exception will be thrown.

Ref: https://guides.rubyonrails.org/security.html#required-security-token

The Ruby guide above gives a solution to implement better CSRF protection.

Trello: https://trello.com/c/tiWPB7lJ/3474-review-code-scanning-alerts-for-our-repos

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
