### PR TITLE
Sanitising input

### DIFF
--- a/app/helpers/referrer_helper.rb
+++ b/app/helpers/referrer_helper.rb
@@ -4,7 +4,7 @@ module ReferrerHelper
   def friendly_referrer(referrer)
     uri = URI.parse(referrer)
     if uri.host
-      if /www\.gov.uk/.match?(uri.host)
+      if /\Awww\.gov.uk/.match?(uri.host)
         uri.path
       else
         uri.host.sub(/www\./, "")


### PR DESCRIPTION
Caught in CodeQL alert

Sanitising untrusted input with regular expressions is a common technique. However, it is error-prone to match untrusted input against regular expressions without anchors such as \A or \z. Malicious input can bypass such security checks by embedding one of the allowed patterns in an unexpected location.

Trello: https://trello.com/c/tiWPB7lJ/3474-review-code-scanning-alerts-for-our-repos



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
