### PR TITLE
Refactor how we call Support API

### DIFF
--- a/app/controllers/anonymous_feedback/document_types_controller.rb
+++ b/app/controllers/anonymous_feedback/document_types_controller.rb
@@ -1,5 +1,3 @@
-require "gds_api/support_api"
-
 class AnonymousFeedback::DocumentTypesController < AuthorisationController
   def show
     authorize! :read, :anonymous_feedback
@@ -19,13 +17,6 @@ class AnonymousFeedback::DocumentTypesController < AuthorisationController
 private
 
   def fetch_document_type_summary_from_support_api(ordering)
-    support_api.document_type_summary(params[:document_type], ordering:)
-  end
-
-  def support_api
-    GdsApi::SupportApi.new(
-      Plek.find("support-api"),
-      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
-    )
+    Services.support_api.document_type_summary(params[:document_type], ordering:)
   end
 end

--- a/app/controllers/anonymous_feedback/explore_controller.rb
+++ b/app/controllers/anonymous_feedback/explore_controller.rb
@@ -1,5 +1,3 @@
-require "gds_api/support_api"
-
 class AnonymousFeedback::ExploreController < AuthorisationController
   include ExploreHelper
 
@@ -8,9 +6,9 @@ class AnonymousFeedback::ExploreController < AuthorisationController
   def new
     @explore_by_multiple_paths = Support::Requests::Anonymous::ExploreByMultiplePaths.new
     @explore_by_organisation = Support::Requests::Anonymous::ExploreByOrganisation.new(organisation: current_user.organisation_slug)
-    @organisations_list = parse_organisations(support_api.organisations_list)
+    @organisations_list = parse_organisations(Services.support_api.organisations_list)
     @explore_by_document_type = Support::Requests::Anonymous::ExploreByDocumentType.new
-    @document_type_list = parse_doctypes(support_api.document_type_list)
+    @document_type_list = parse_doctypes(Services.support_api.document_type_list)
   end
 
   def create
@@ -37,13 +35,6 @@ class AnonymousFeedback::ExploreController < AuthorisationController
   end
 
 private
-
-  def support_api
-    GdsApi::SupportApi.new(
-      Plek.find("support-api"),
-      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
-    )
-  end
 
   def explore_by_multiple_path_params
     params.require(:support_requests_anonymous_explore_by_multiple_paths).permit(:list_of_urls, :uploaded_list)

--- a/app/controllers/anonymous_feedback/export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/export_requests_controller.rb
@@ -1,4 +1,3 @@
-require "gds_api/support_api"
 require "csv"
 
 class AnonymousFeedback::ExportRequestsController < AuthorisationController
@@ -7,7 +6,7 @@ class AnonymousFeedback::ExportRequestsController < AuthorisationController
 
     set_path_set_id_param
 
-    support_api.create_feedback_export_request(export_request_params)
+    Services.support_api.create_feedback_export_request(export_request_params)
 
     redirect_to anonymous_feedback_index_path(anonymous_feedback_params),
                 notice: "We are sending your CSV file to #{current_user.email}. If you don't see it in a few minutes, check your spam folder."
@@ -16,7 +15,7 @@ class AnonymousFeedback::ExportRequestsController < AuthorisationController
   def show
     authorize! :read, :anonymous_feedback
 
-    response = support_api.feedback_export_request(params[:id])
+    response = Services.support_api.feedback_export_request(params[:id])
     if response["ready"]
       filename = response["filename"]
       file = get_csv_file_from_s3(filename)
@@ -68,13 +67,6 @@ private
       paths:,
       path_set_id: saved_paths.try(:id),
       organisation_slug: anonymous_feedback_params[:organisation],
-    )
-  end
-
-  def support_api
-    GdsApi::SupportApi.new(
-      Plek.find("support-api"),
-      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
     )
   end
 

--- a/app/controllers/anonymous_feedback/global_export_requests_controller.rb
+++ b/app/controllers/anonymous_feedback/global_export_requests_controller.rb
@@ -1,10 +1,8 @@
-require "gds_api/support_api"
-
 class AnonymousFeedback::GlobalExportRequestsController < AuthorisationController
   def create
     authorize! :request, :global_export_request
 
-    support_api.create_global_export_request(export_request_params)
+    Services.support_api.create_global_export_request(export_request_params)
     redirect_to anonymous_feedback_explore_path,
                 notice: "We are sending your CSV file to #{current_user.email}. If you don't see it in a few minutes, check your spam folder."
   end
@@ -19,13 +17,6 @@ private
         notification_email: current_user.email,
         exclude_spam: exclude_spam?,
       )
-  end
-
-  def support_api
-    GdsApi::SupportApi.new(
-      Plek.find("support-api"),
-      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
-    )
   end
 
   def exclude_spam?

--- a/app/controllers/anonymous_feedback/organisations_controller.rb
+++ b/app/controllers/anonymous_feedback/organisations_controller.rb
@@ -1,5 +1,3 @@
-require "gds_api/support_api"
-
 class AnonymousFeedback::OrganisationsController < AuthorisationController
   def show
     authorize! :read, :anonymous_feedback
@@ -19,13 +17,6 @@ class AnonymousFeedback::OrganisationsController < AuthorisationController
 private
 
   def fetch_organisation_summary_from_support_api(ordering)
-    support_api.organisation_summary(params[:slug], ordering:)
-  end
-
-  def support_api
-    GdsApi::SupportApi.new(
-      Plek.find("support-api"),
-      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
-    )
+    Services.support_api.organisation_summary(params[:slug], ordering:)
   end
 end

--- a/app/controllers/anonymous_feedback/problem_reports_controller.rb
+++ b/app/controllers/anonymous_feedback/problem_reports_controller.rb
@@ -1,5 +1,3 @@
-require "gds_api/support_api"
-
 class AnonymousFeedback::ProblemReportsController < AuthorisationController
   def index
     authorize! :request, :review_feedback
@@ -29,7 +27,7 @@ private
 
   def fetch_problem_reports
     AnonymousFeedbackApiResponse.new(
-      support_api.problem_reports(api_params).to_hash,
+      Services.support_api.problem_reports(api_params).to_hash,
     )
   end
 
@@ -40,13 +38,6 @@ private
       from_date: index_params[:from_date],
       to_date: index_params[:to_date],
     }.select { |_, value| value.present? }
-  end
-
-  def support_api
-    GdsApi::SupportApi.new(
-      Plek.find("support-api"),
-      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
-    )
   end
 
   def index_params
@@ -67,6 +58,6 @@ private
   end
 
   def reviewed_items_successfully?
-    support_api.mark_reviewed_for_spam(review_params).code == 200
+    Services.support_api.mark_reviewed_for_spam(review_params).code == 200
   end
 end

--- a/app/controllers/anonymous_feedback_controller.rb
+++ b/app/controllers/anonymous_feedback_controller.rb
@@ -1,5 +1,3 @@
-require "gds_api/support_api"
-
 class AnonymousFeedbackController < RequestsController
   include ExploreHelper
 
@@ -23,8 +21,8 @@ class AnonymousFeedbackController < RequestsController
         # api_response rather than user-supplied params (note it's not
         # currently available on the api_response)
         @filtered_by = scope_filters
-        @organisations_list = parse_organisations(support_api.organisations_list)
-        @document_type_list = parse_doctypes(support_api.document_type_list)
+        @organisations_list = parse_organisations(Services.support_api.organisations_list)
+        @document_type_list = parse_doctypes(Services.support_api.document_type_list)
       end
       format.json { render json: api_response.results }
     end
@@ -136,14 +134,7 @@ private
 
   def fetch_anonymous_feedback_from_support_api
     AnonymousFeedbackApiResponse.new(
-      support_api.anonymous_feedback(api_params).to_hash,
-    )
-  end
-
-  def support_api
-    GdsApi::SupportApi.new(
-      Plek.find("support-api"),
-      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
+      Services.support_api.anonymous_feedback(api_params).to_hash,
     )
   end
 end

--- a/app/controllers/create_new_user_requests_controller.rb
+++ b/app/controllers/create_new_user_requests_controller.rb
@@ -47,15 +47,6 @@ protected
   end
 
   def organisation_options
-    @organisation_options ||= support_api.organisations_list.to_a.map { |o| organisation_title(o) }
-  end
-
-private
-
-  def support_api
-    GdsApi::SupportApi.new(
-      Plek.find("support-api"),
-      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
-    )
+    @organisation_options ||= Services.support_api.organisations_list.to_a.map { |o| organisation_title(o) }
   end
 end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,0 +1,10 @@
+require "gds_api/support_api"
+
+module Services
+  def self.support_api
+    @support_api ||= GdsApi::SupportApi.new(
+      Plek.find("support-api"),
+      bearer_token: ENV["SUPORT_API_BEARER_TOKEN"] || "example",
+    )
+  end
+end

--- a/app/presenters/scope_filters_presenter.rb
+++ b/app/presenters/scope_filters_presenter.rb
@@ -1,5 +1,3 @@
-require "gds_api/support_api"
-
 class ScopeFiltersPresenter
   attr_reader :organisation_slug, :document_type, :path_set_id
 
@@ -51,7 +49,7 @@ class ScopeFiltersPresenter
   end
 
   def organisation
-    @organisation ||= support_api.organisation(organisation_slug) if organisation_slug.present?
+    @organisation ||= Services.support_api.organisation(organisation_slug) if organisation_slug.present?
   end
 
   def to_s
@@ -98,12 +96,5 @@ private
 
     result = paths_or_urls.compact.map(&:strip).map { |path_or_url| normalize_path(path_or_url) }.uniq
     result.empty? ? ["/"] : result
-  end
-
-  def support_api
-    GdsApi::SupportApi.new(
-      Plek.find("support-api"),
-      bearer_token: ENV["SUPPORT_API_BEARER_TOKEN"],
-    )
   end
 end


### PR DESCRIPTION
This follows pattern of other GOV.UK apps. It removes duplication and the service won't need to be instantiated in each controller.

SUPORT_API_BEARER_TOKEN is defined in all environments:
- https://github.com/alphagov/govuk-helm-charts/blob/e060791/charts/app-config/values-integration.yaml#L2899-L2903
- https://github.com/alphagov/govuk-helm-charts/blob/e060791/charts/app-config/values-staging.yaml#L2801-L2805
- https://github.com/alphagov/govuk-helm-charts/blob/e060791/charts/app-config/values-production.yaml#L2913-L2917


[Trello](https://trello.com/c/lkOEEOBG/3551-use-support-api-to-raise-tickets-from-support-5)

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
