### PR TITLE
Use Support API to raise Zendesk tickets

### DIFF
--- a/app/models/zendesk/zendesk_tickets.rb
+++ b/app/models/zendesk/zendesk_tickets.rb
@@ -7,7 +7,7 @@ module Zendesk
         requester: { "locale_id" => 1, "email" => ticket_to_raise.email, "name" => ticket_to_raise.name },
         collaborators: ticket_to_raise.collaborator_emails,
         tags: ticket_to_raise.tags,
-        comment: { "body" => ticket_to_raise.comment },
+        description: ticket_to_raise.comment,
       }
       ticket_options.merge!(custom_fields: ticket_to_raise.custom_fields) if ticket_to_raise.respond_to?(:custom_fields)
       ticket_options.merge!(ticket_form_id: ticket_to_raise.class::TICKET_FORM_ID) if ticket_to_raise.class.const_defined?(:TICKET_FORM_ID)

--- a/spec/controllers/change_existing_user_requests_controller_spec.rb
+++ b/spec/controllers/change_existing_user_requests_controller_spec.rb
@@ -25,7 +25,7 @@ describe ChangeExistingUserRequestsController, type: :controller do
   end
 
   it "submits the request to Zendesk" do
-    stub_ticket_creation = stub_zendesk_ticket_creation(
+    stub_ticket_creation = stub_support_api_valid_raise_support_ticket(
       hash_including("tags" => %w[govt_form change_user]),
     )
 

--- a/spec/controllers/create_new_user_requests_controller_spec.rb
+++ b/spec/controllers/create_new_user_requests_controller_spec.rb
@@ -32,7 +32,7 @@ describe CreateNewUserRequestsController, type: :controller do
 
   it "submits the request to Zendesk and creates a Zendesk user with the requested user details" do
     zendesk_has_no_user_with_email(valid_requested_user_params["email"])
-    stub_ticket_creation = stub_zendesk_ticket_creation(
+    stub_ticket_creation = stub_support_api_valid_raise_support_ticket(
       hash_including("tags" => %w[govt_form create_new_user]),
     )
     stub_user_creation = stub_zendesk_user_creation(

--- a/spec/controllers/general_requests_controller_spec.rb
+++ b/spec/controllers/general_requests_controller_spec.rb
@@ -13,7 +13,6 @@ describe GeneralRequestsController, type: :controller do
 
   before do
     login_as create(:user)
-    zendesk_has_no_user_with_email(@user.email)
   end
 
   context "a submitted general request" do

--- a/spec/controllers/general_requests_controller_spec.rb
+++ b/spec/controllers/general_requests_controller_spec.rb
@@ -19,7 +19,7 @@ describe GeneralRequestsController, type: :controller do
   context "a submitted general request" do
     it "adds the user agent to the ticket in the comments" do
       request.user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2)"
-      ticket_request = stub_zendesk_ticket_creation_with_body(/Mozilla\/5.0/)
+      ticket_request = stub_support_api_valid_raise_support_ticket(/Mozilla\/5.0/)
 
       post :create, params: valid_general_request_params
 

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -33,7 +33,6 @@ describe RequestsController, type: :controller do
     stub_const("TestRequest", test_request_class)
     stub_const("TestZendeskTicket", test_zendesk_ticket_class)
     login_as user
-    zendesk_has_no_user_with_email(user.email)
 
     prevent_implicit_rendering
   end

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -84,7 +84,7 @@ describe RequestsController, type: :controller do
     end
 
     it "submits it to Zendesk" do
-      ticket_request = stub_zendesk_ticket_creation(hash_including("tags" => %w[tag_a tag_b]))
+      ticket_request = stub_support_api_valid_raise_support_ticket(hash_including("tags" => %w[tag_a tag_b]))
 
       post :create, params: valid_params_for_test_request
 
@@ -94,7 +94,7 @@ describe RequestsController, type: :controller do
 
     it "reads the signed-in user's details as the requester" do
       requester_details = { "email" => @user[:email], "name" => @user[:name] }
-      ticket_request = stub_zendesk_ticket_creation(
+      ticket_request = stub_support_api_valid_raise_support_ticket(
         hash_including("requester" => hash_including(requester_details)),
       )
 
@@ -107,7 +107,7 @@ describe RequestsController, type: :controller do
       params = valid_params_for_test_request.tap do |p|
         p["test_request"]["requester_attributes"].merge!("collaborator_emails" => "ab@c.com, def@g.com")
       end
-      ticket_request = stub_zendesk_ticket_creation(hash_including("collaborators" => ["ab@c.com", "def@g.com"]))
+      ticket_request = stub_support_api_valid_raise_support_ticket(hash_including("collaborators" => ["ab@c.com", "def@g.com"]))
 
       post(:create, params:)
 

--- a/spec/features/analytics_requests_spec.rb
+++ b/spec/features/analytics_requests_spec.rb
@@ -5,7 +5,6 @@ feature "Analytics requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do

--- a/spec/features/analytics_requests_spec.rb
+++ b/spec/features/analytics_requests_spec.rb
@@ -13,8 +13,7 @@ feature "Analytics requests" do
       "subject" => "Request for analytics",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form analytics],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Google Analytics Access]
 Sarah Jones sarah@example.com some area
 
@@ -26,7 +25,6 @@ Government Digital Service
 
 [Help]
 Need help with cats",
-      },
     )
 
     visit "/"

--- a/spec/features/campaign_requests_spec.rb
+++ b/spec/features/campaign_requests_spec.rb
@@ -18,8 +18,7 @@ feature "Campaign requests" do
       "subject" => "Campaign",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form campaign],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Name of the Head of Digital Communications who signed off the campaign website application]
 John Smith
 
@@ -85,7 +84,6 @@ Yes
 
 [I/We agree to take responsibility to maintain and up-date the Cookie Notice and Privacy Notice as necessary, with our Data Protection Officer]
 Yes",
-      },
     )
 
     user_makes_a_campaign_request(

--- a/spec/features/campaign_requests_spec.rb
+++ b/spec/features/campaign_requests_spec.rb
@@ -10,7 +10,6 @@ feature "Campaign requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do

--- a/spec/features/change_existing_user_requests_spec.rb
+++ b/spec/features/change_existing_user_requests_spec.rb
@@ -9,7 +9,6 @@ feature "Change existing user requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "changing user permissions" do

--- a/spec/features/change_existing_user_requests_spec.rb
+++ b/spec/features/change_existing_user_requests_spec.rb
@@ -19,8 +19,7 @@ feature "Change existing user requests" do
       "subject" => "Change an existing user's account",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form change_user],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Action]
 Change an existing user's account
 
@@ -32,7 +31,6 @@ bob@gov.uk
 
 [Additional comments]
 XXXX",
-      },
     )
 
     visit "/"

--- a/spec/features/changes_to_publishing_apps_requests_spec.rb
+++ b/spec/features/changes_to_publishing_apps_requests_spec.rb
@@ -9,7 +9,6 @@ feature "New feature requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do

--- a/spec/features/changes_to_publishing_apps_requests_spec.rb
+++ b/spec/features/changes_to_publishing_apps_requests_spec.rb
@@ -17,14 +17,12 @@ feature "New feature requests" do
       "subject" => "Abc",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form new_feature_request],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[User need]
 Information on XYZ
 
 [Feature evidence]
 See here: google.com",
-      },
     )
 
     user_makes_a_new_feature_request(

--- a/spec/features/content_advice_requests_spec.rb
+++ b/spec/features/content_advice_requests_spec.rb
@@ -10,7 +10,6 @@ feature "Request for content advice" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do

--- a/spec/features/content_advice_requests_spec.rb
+++ b/spec/features/content_advice_requests_spec.rb
@@ -17,8 +17,7 @@ feature "Request for content advice" do
     request = expect_zendesk_to_receive_ticket(
       "subject" => "Needed by 12 Jan: Which format - Advice on content",
       "tags" => %w[govt_form dept_content_advice],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Needed by date]
 12-01-#{next_year}
 
@@ -33,7 +32,6 @@ https://www.gov.uk/x, https://www.gov.uk/y
 
 [Contact number]
 0121 111111",
-      },
     )
 
     user_requests_content_advice(
@@ -52,8 +50,7 @@ https://www.gov.uk/x, https://www.gov.uk/y
     request = expect_zendesk_to_receive_ticket(
       "subject" => "Tricky query - Advice on content",
       "tags" => %w[govt_form dept_content_advice],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Details]
 I have a tricky query, here's my content...
 
@@ -62,7 +59,6 @@ https://www.gov.uk/x, https://www.gov.uk/y
 
 [Contact number]
 0121 111111",
-      },
     )
 
     user_requests_content_advice(

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -18,8 +18,7 @@ feature "Content change requests" do
       "subject" => "Update X",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form content_amend],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Reason for request]
 Factual inaccuracy
 
@@ -46,7 +45,6 @@ Out of date XX YY
 
 [Reason for time constraint]
 New law",
-      },
       "custom_fields" =>
            [{ "id" => 7_948_652_819_356, "value" => "cr_inaccuracy" },
             { "id" => 7_949_106_580_380, "value" => "cr_benefits" },

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -10,7 +10,6 @@ feature "Content change requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful mainstream content change request " do

--- a/spec/features/content_data_feedback_spec.rb
+++ b/spec/features/content_data_feedback_spec.rb
@@ -7,7 +7,6 @@ feature "New Content Data feedback" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do

--- a/spec/features/content_data_feedback_spec.rb
+++ b/spec/features/content_data_feedback_spec.rb
@@ -15,8 +15,7 @@ feature "New Content Data feedback" do
       "subject" => "Content Data feedback",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form content_data_feedback],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Your feedback is about]
 accessibility or usability
 
@@ -25,7 +24,6 @@ I am having trouble reading the screen
 
 [What's the impact on your work if we don't do anything about it?]
 Cannot work",
-      },
     )
 
     user_provides_feedback(

--- a/spec/features/create_new_user_requests_spec.rb
+++ b/spec/features/create_new_user_requests_spec.rb
@@ -9,7 +9,6 @@ feature "Create new user requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "user creation request" do

--- a/spec/features/create_new_user_requests_spec.rb
+++ b/spec/features/create_new_user_requests_spec.rb
@@ -29,8 +29,7 @@ feature "Create new user requests" do
       "subject" => "Create a new user account",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form create_new_user],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Action]
 Create a new user account
 
@@ -51,7 +50,6 @@ Yes, the user needs access to the applications and permissions listed below
 
 [Additional comments]
 XXXX",
-      },
     )
 
     user_creation_request = stub_zendesk_user_creation(

--- a/spec/features/general_requests_spec.rb
+++ b/spec/features/general_requests_spec.rb
@@ -17,14 +17,12 @@ feature "General requests" do
       "subject" => "Downtime - Govt Agency General Issue",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form govt_agency_general],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Url]
 https://www.gov.uk
 
 [Details]
 The site is down",
-      },
     )
 
     user_makes_a_general_request(

--- a/spec/features/general_requests_spec.rb
+++ b/spec/features/general_requests_spec.rb
@@ -9,7 +9,6 @@ feature "General requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do

--- a/spec/features/live_campaign_requests_spec.rb
+++ b/spec/features/live_campaign_requests_spec.rb
@@ -9,7 +9,6 @@ feature "Live Campaign requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do

--- a/spec/features/live_campaign_requests_spec.rb
+++ b/spec/features/live_campaign_requests_spec.rb
@@ -17,8 +17,7 @@ feature "Live Campaign requests" do
       "subject" => "Live Campaign",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form live_campaign],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Campaign Title]
 Workplace pensions
 
@@ -33,7 +32,6 @@ This is a time constraint
 
 [Reason for the above dates?]
 This is a reason for choosing specific dates",
-      },
     )
 
     user_makes_a_live_campaign_request(

--- a/spec/features/remove_user_requests_spec.rb
+++ b/spec/features/remove_user_requests_spec.rb
@@ -18,8 +18,7 @@ feature "Remove user requests" do
       "subject" => "Remove user",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form remove_user],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Not before date]
 31-12-#{next_year}
 
@@ -31,7 +30,6 @@ bob@someagency.gov.uk
 
 [Reason for removal]
 User has left the organisation",
-      },
     )
 
     user_requests_removal_of_another_user(

--- a/spec/features/remove_user_requests_spec.rb
+++ b/spec/features/remove_user_requests_spec.rb
@@ -10,7 +10,6 @@ feature "Remove user requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do

--- a/spec/features/report_an_issue_with_govuk_search_results_spec.rb
+++ b/spec/features/report_an_issue_with_govuk_search_results_spec.rb
@@ -5,7 +5,7 @@ feature "Report an issue with GOV.UK search results" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
+    # zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do
@@ -13,8 +13,7 @@ feature "Report an issue with GOV.UK search results" do
       "subject" => "Report an issue with GOV.UK search results",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@email.co.uk"),
       "tags" => %w[govt_form site_search],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[What search query did you use?]
 search-query
 
@@ -26,7 +25,6 @@ improve-search-results
 
 [Why is this change necessary?]
 improvement-justification",
-      },
     )
 
     user_reports_issue_with_search_results(

--- a/spec/features/report_an_issue_with_govuk_search_results_spec.rb
+++ b/spec/features/report_an_issue_with_govuk_search_results_spec.rb
@@ -5,7 +5,6 @@ feature "Report an issue with GOV.UK search results" do
 
   background do
     login_as user
-    # zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do

--- a/spec/features/taxonomy_change_topic_requests_spec.rb
+++ b/spec/features/taxonomy_change_topic_requests_spec.rb
@@ -17,8 +17,7 @@ feature "Taxonomy topic change requests" do
       "subject" => "Taxonomy change topic request - \"Abc\"",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form taxonomy_change_topic_request],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Type of change]
 Name of topic
 
@@ -30,7 +29,6 @@ Change the name to \"XYZ\".
 
 [Reasons for changes]
 People expect to find it here.",
-      },
     )
 
     user_makes_a_taxomomy_change_topic_request(

--- a/spec/features/taxonomy_change_topic_requests_spec.rb
+++ b/spec/features/taxonomy_change_topic_requests_spec.rb
@@ -9,7 +9,6 @@ feature "Taxonomy topic change requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do

--- a/spec/features/taxonomy_new_topic_requests_spec.rb
+++ b/spec/features/taxonomy_new_topic_requests_spec.rb
@@ -9,7 +9,6 @@ feature "New taxonomy topic requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful request" do

--- a/spec/features/taxonomy_new_topic_requests_spec.rb
+++ b/spec/features/taxonomy_new_topic_requests_spec.rb
@@ -17,8 +17,7 @@ feature "New taxonomy topic requests" do
       "subject" => "Taxonomy new topic request - \"Abc\"",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form taxonomy_new_topic_request],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Requested topic]
 Abc
 
@@ -30,7 +29,6 @@ People expect to find it here.
 
 [Parent topic]
 Education, training and skills",
-      },
     )
 
     user_makes_a_taxomomy_new_topic_request(

--- a/spec/features/technical_fault_reports_spec.rb
+++ b/spec/features/technical_fault_reports_spec.rb
@@ -17,8 +17,7 @@ feature "Technical fault reports" do
       "subject" => "Technical fault with GOV.UK: content",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form technical_fault fault_with_gov_uk_content],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[Location of fault]
 GOV.UK: content
 
@@ -33,7 +32,6 @@ Broken link
 
 [What should have happened]
 Should have linked through",
-      },
     )
 
     user_fills_in_a_technical_fault_report(

--- a/spec/features/technical_fault_reports_spec.rb
+++ b/spec/features/technical_fault_reports_spec.rb
@@ -9,7 +9,6 @@ feature "Technical fault reports" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "successful report" do

--- a/spec/features/unpublish_content_requests_spec.rb
+++ b/spec/features/unpublish_content_requests_spec.rb
@@ -9,7 +9,6 @@ feature "Unpublish content requests" do
 
   background do
     login_as user
-    zendesk_has_no_user_with_email(user.email)
   end
 
   scenario "request to unpublish in case of publishing error" do

--- a/spec/features/unpublish_content_requests_spec.rb
+++ b/spec/features/unpublish_content_requests_spec.rb
@@ -17,8 +17,7 @@ feature "Unpublish content requests" do
       "subject" => "Published in error - Unpublish content request",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form unpublish_content published_in_error],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[URL of content to be unpublished]
 https://www.gov.uk/X
 
@@ -27,7 +26,6 @@ Published in error
 
 [Further explanation]
 Typo in slug name",
-      },
     )
 
     user_makes_a_request_to_unpublish_content(
@@ -44,8 +42,7 @@ Typo in slug name",
       "subject" => "Duplicate of another page - Unpublish content request",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "tags" => %w[govt_form unpublish_content duplicate_publication],
-      "comment" => {
-        "body" =>
+      "description" =>
 "[URL of content to be unpublished]
 https://www.gov.uk/X
 
@@ -60,7 +57,6 @@ https://www.gov.uk/Y
 
 [Automatic redirect?]
 true",
-      },
     )
 
     user_makes_a_request_to_unpublish_content(

--- a/spec/models/zendesk/zendesk_tickets_spec.rb
+++ b/spec/models/zendesk/zendesk_tickets_spec.rb
@@ -26,7 +26,7 @@ describe Zendesk::ZendeskTickets do
         "requester" => { "locale_id" => 1, "email" => "ab@c.com", "name" => "Harry Potter" },
         "collaborators" => [],
         "tags" => %w[govt_form campaign],
-        "comment" => { "body" => "Biscuits for everyone" },
+        "description" => "Biscuits for everyone",
       )
     end
 

--- a/spec/support/gds_zendesk_helpers.rb
+++ b/spec/support/gds_zendesk_helpers.rb
@@ -2,7 +2,7 @@ require "gds_zendesk/test_helpers"
 
 module ZendeskRequestMockingExtensions
   def expect_zendesk_to_receive_ticket(opts)
-    stub_zendesk_ticket_creation_with_body("ticket" => hash_including(opts))
+    stub_support_api_valid_raise_support_ticket(hash_including(opts))
   end
 
   def stub_custom_fields_data(opts = [])


### PR DESCRIPTION
Switches to using the [/support-tickets Support API endpoint via GDS API Adapters](https://github.com/alphagov/gds-api-adapters/blob/9b03c6d5e8ec03ce86d79fdc1ed0efdd0b474095/lib/gds_api/support_api.rb#L25).

It also removes GovukStatsd, which is deprecated. Raising appropriate errors that will appear in Sentry will still allow us to track the issues without the need for dashboards.

It uses Sidekiq configuration to handle exceptions appropriately.

### Why
gds_zendesk is deprecated and will be archived.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
