### PR TITLE
Don't create Zendesk account for new user requests

### DIFF
--- a/app/controllers/create_new_user_requests_controller.rb
+++ b/app/controllers/create_new_user_requests_controller.rb
@@ -34,16 +34,9 @@ protected
 
   def save_to_zendesk(submitted_request)
     super
-    requested_user = Support::GDS::RequestedUser.new(
+    Support::GDS::RequestedUser.new(
       create_or_change_user_request_params.slice(:name, :email, :organisation),
     )
-    create_or_update_user_in_zendesk(requested_user)
-  end
-
-  def create_or_update_user_in_zendesk(requested_user)
-    GDS_ZENDESK_CLIENT.users.create_or_update_user(requested_user)
-  rescue ZendeskAPI::Error::ClientError => e
-    exception_notification_for(e)
   end
 
   def organisation_options

--- a/spec/controllers/change_existing_user_requests_controller_spec.rb
+++ b/spec/controllers/change_existing_user_requests_controller_spec.rb
@@ -21,7 +21,6 @@ describe ChangeExistingUserRequestsController, type: :controller do
 
   before do
     login_as create(:user_manager)
-    zendesk_has_no_user_with_email(@user.email)
   end
 
   it "submits the request to Zendesk" do

--- a/spec/controllers/create_new_user_requests_controller_spec.rb
+++ b/spec/controllers/create_new_user_requests_controller_spec.rb
@@ -26,26 +26,18 @@ describe CreateNewUserRequestsController, type: :controller do
 
   before do
     login_as create(:user_manager)
-    zendesk_has_no_user_with_email(@user.email)
     stub_support_api_organisations_list
   end
 
-  it "submits the request to Zendesk and creates a Zendesk user with the requested user details" do
-    zendesk_has_no_user_with_email(valid_requested_user_params["email"])
+  it "submits the request to Zendesk" do
     stub_ticket_creation = stub_support_api_valid_raise_support_ticket(
       hash_including("tags" => %w[govt_form create_new_user]),
-    )
-    stub_user_creation = stub_zendesk_user_creation(
-      email: "subject@digital.cabinet-office.gov.uk",
-      name: "subject",
-      verified: true,
     )
 
     post :create, params: valid_create_user_request_params
 
     expect(request).to redirect_to("/acknowledge")
     expect(stub_ticket_creation).to have_been_made
-    expect(stub_user_creation).to have_been_made
   end
 
   it "re-displays the form with error messages if validation fails" do
@@ -60,18 +52,5 @@ describe CreateNewUserRequestsController, type: :controller do
     post :create, params: { "support_requests_create_new_user_request" => { "organisation" => "Cabinet Office (CO)" } }
 
     expect(response.body).to have_css("select option[selected='selected'][value='Cabinet Office (CO)']")
-  end
-
-  it "doesn't expose an error to the user when automatic user creation goes wrong" do
-    zendesk_is_unavailable
-
-    allow_any_instance_of(Zendesk::ZendeskTickets).to receive(:raise_ticket)
-
-    expect(GovukError).to receive(:notify)
-      .with(kind_of(ZendeskAPI::Error::ClientError))
-
-    post :create, params: valid_create_user_request_params
-
-    expect(response).to redirect_to("/acknowledge")
   end
 end

--- a/spec/features/change_existing_user_requests_spec.rb
+++ b/spec/features/change_existing_user_requests_spec.rb
@@ -12,8 +12,6 @@ feature "Change existing user requests" do
   end
 
   scenario "changing user permissions" do
-    zendesk_has_user(email: "bob@gov.uk", name: "Bob Fields")
-
     ticket_request = expect_zendesk_to_receive_ticket(
       "subject" => "Change an existing user's account",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),

--- a/spec/features/create_new_user_requests_spec.rb
+++ b/spec/features/create_new_user_requests_spec.rb
@@ -22,8 +22,6 @@ feature "Create new user requests" do
       },
     ])
 
-    zendesk_has_no_user_with_email("bob@gov.uk")
-
     ticket_request = expect_zendesk_to_receive_ticket(
       "subject" => "Create a new user account",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
@@ -50,13 +48,6 @@ Yes, the user needs access to the applications and permissions listed below
 [Additional comments]
 XXXX",
     )
-
-    user_creation_request = stub_zendesk_user_creation(
-      email: "bob@gov.uk",
-      name: "Bob Fields",
-      verified: true,
-    )
-
     visit "/"
 
     click_on "Create a new user"
@@ -73,6 +64,5 @@ XXXX",
     user_submits_the_request_successfully
 
     expect(ticket_request).to have_been_made
-    expect(user_creation_request).to have_been_made
   end
 end


### PR DESCRIPTION
This functionality was originally introduced 12 years ago, with no explanation as to why it was needed: https://github.com/alphagov/support/pull/22

It removes the complexity from Support app and allows us to retrie `gds_zendesk` gem, without the need to create another API endpoint.

It seems unnecessary to create Zendesk account for users who may not need to ever raise Zendesk tickets.  When a Zendesk ticket is received, a Zendesk account is automatically created for a user.

At present only name, email and organisation are set or updated. Having this information in Zendesk add little value, as organisation can be derived from email address. 
The 'Change existing user request' doesn't update Zendesk accounts.
All those properties can be updated by the users themselves if necessary (e.g. machinery of government changes).

Users can view Zendesk ticket they raised in Zendesk, which they access via a link in Support app. The link takes them to the GDS Support Services Signing page with instructions on how to get a password. Once the user sets the password their account is verified.

<kbd><img width="1190" alt="Screenshot 2024-08-12 at 11 58 42" src="https://github.com/user-attachments/assets/d6490288-91f4-49b7-959a-66de1991cea8"></kbd>

<kbd><img width="323" alt="Screenshot 2024-08-12 at 12 41 39" src="https://github.com/user-attachments/assets/eff57fc9-d1fb-4a8a-8af2-147b3841464a"></kbd>

<kbd><img width="842" alt="Screenshot 2024-08-08 at 16 50 13" src="https://github.com/user-attachments/assets/95aba875-cc66-4129-ade3-e74187a321e7"></kbd>

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
