### PR TITLE
Add missing full stops to technical fault report description.

### DIFF
--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -69,7 +69,7 @@ module Support
       end
 
       def self.description
-        "Report something that is not working with any publishing application, eg Whitehall, finders or specialist publisher. Also use for any urgent technical changes"
+        "Report something that is not working with any publishing application, e.g. Whitehall, finders or specialist publisher. Also use for any urgent technical changes."
       end
     end
   end

--- a/spec/features/technical_fault_reports_spec.rb
+++ b/spec/features/technical_fault_reports_spec.rb
@@ -56,7 +56,7 @@ private
 
     click_on "Report a technical fault to GDS"
 
-    expect(page).to have_content("Report something that is not working with any publishing application, eg Whitehall, finders or specialist publisher. Also use for any urgent technical changes")
+    expect(page).to have_content("Report something that is not working with any publishing application, e.g. Whitehall, finders or specialist publisher. Also use for any urgent technical changes.")
 
     within "#technical-fault-context" do
       choose details[:location_of_fault]


### PR DESCRIPTION
There was a missing full-stop from the end of the line and in `e.g.`.