### PR TITLE
Adding alert to Change Existing User Account form

### DIFF
--- a/app/views/change_existing_user_requests/_request_details.html.erb
+++ b/app/views/change_existing_user_requests/_request_details.html.erb
@@ -1,5 +1,19 @@
 <p><%= f.object.class.description %></p>
 
+<div class="alert alert-info alert-block">
+  <p>
+    You do not need to submit a request if you're a super organisation admin or organisation admin and you're requesting to:
+    <ul>
+    <li>change an account's permissions for a 'devolved' application, including upgrading an account to 'editor' in Whitehall Publisher</li>
+    <li>reset 2-step verification for an account</li>
+    <li>unsuspend an account</li>
+    <li>resend a signup ('account invitation') email for an account</li>
+    </ul>
+    <br>
+    Find out <%= link_to 'how to manage your organisation’s accounts in the "Introduction and access to Whitehall publisher" guidance', 'https://www.gov.uk/guidance/how-to-publish-on-gov-uk/introduction-and-access-to-whitehall-publisher#manage-your-organisations-accounts' %>.
+  </p>
+</div>
+
 <div class="row">
   <div class="col-md-6">
     <div class="form-group">


### PR DESCRIPTION
Adding an alert to the form, advising users trying to use this form
of circumstances when they do not need to raise a request.

As per Zendesk ticket: [https://govuk.zendesk.com/agent/tickets/5908958](url)

<img width="988" alt="ExistingUserAccountForm" src="https://github.com/user-attachments/assets/bd0733bc-6106-4fb2-b072-9e05767cd30b">

Closes https://github.com/alphagov/support/issues/1463


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
