### PR TITLE
Update date input components

### DIFF
--- a/app/views/campaign_requests/_request_details.html.erb
+++ b/app/views/campaign_requests/_request_details.html.erb
@@ -80,6 +80,9 @@
       </span>
 
       <br>
+        <div id="start-date-hint" class="govuk-hint">
+          For example, 27 3 2007
+        </div>
 
       <span class="govuk-date-input__item">
        <%= r.label :start_day, "Day", class: "govuk-label govuk-date-input__label" %>
@@ -108,6 +111,9 @@
       </span>
 
       <br>
+        <div id="start-date-hint" class="govuk-hint">
+          For example, 27 3 2007
+        </div>
 
       <span class="govuk-date-input__item">
        <%= r.label :end_day, "Day", class: "govuk-label govuk-date-input__label" %>
@@ -134,6 +140,9 @@
       </span>
 
       <br>
+        <div id="start-date-hint" class="govuk-hint">
+          For example, 27 3 2007
+        </div>
 
       <span class="govuk-date-input__item">
        <%= r.label :development_start_day, "Day", class: "govuk-label govuk-date-input__label" %>

--- a/app/views/campaign_requests/_request_details.html.erb
+++ b/app/views/campaign_requests/_request_details.html.erb
@@ -88,19 +88,19 @@
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :start_day, "Day", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :start_day, required: false, value: r.object.start_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "start-day" %>
+              <%= r.text_field :start_day, required: false, value: r.object.start_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "start-day", inputmode: "numeric" %>
             </div>
           </div>
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
                 <%= r.label :start_month, "Month", class: "govuk-label govuk-date-input__label" %>
-                <%= r.text_field :start_month, required: false, value: r.object.start_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "start-month" %>
+                <%= r.text_field :start_month, required: false, value: r.object.start_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "start-month", inputmode: "numeric" %>
             </div>
           </div>
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :start_year, "Year", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :start_year, required: false, value: r.object.start_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "start-year" %>
+              <%= r.text_field :start_year, required: false, value: r.object.start_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "start-year", inputmode: "numeric" %>
             </div>
           </div>
         </div>
@@ -126,19 +126,19 @@
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
                 <%= r.label :end_day, "Day", class: "govuk-label govuk-date-input__label" %>
-                <%= r.text_field :end_day, required: false, value: r.object.end_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "end-day" %>
+                <%= r.text_field :end_day, required: false, value: r.object.end_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "end-day", inputmode: "numeric" %>
             </div>
           </div>
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :end_month, "Month", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :end_month, required: false, value: r.object.end_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "end-month" %>
+              <%= r.text_field :end_month, required: false, value: r.object.end_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "end-month", inputmode: "numeric" %>
             </div>
           </div>
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :end_year, "Year", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :end_year, required: false, value: r.object.end_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "end-year" %>
+              <%= r.text_field :end_year, required: false, value: r.object.end_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "end-year", inputmode: "numeric" %>
             </div>
           </div>
         </div>
@@ -161,19 +161,19 @@
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :development_start_day, "Day", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :development_start_day, required: false, value: r.object.development_start_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "development-start-day" %>
+              <%= r.text_field :development_start_day, required: false, value: r.object.development_start_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "development-start-day", inputmode: "numeric" %>
             </div>
           </div>
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :development_start_month, "Month", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :development_start_month, required: false, value: r.object.development_start_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "development-start-month" %>
+              <%= r.text_field :development_start_month, required: false, value: r.object.development_start_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "development-start-month", inputmode: "numeric" %>
             </div>
            </div>
            <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :development_start_year, "Year", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :development_start_year, required: false, value: r.object.development_start_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "development-start-year" %>
+              <%= r.text_field :development_start_year, required: false, value: r.object.development_start_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "development-start-year", inputmode: "numeric" %>
             </div>
           </div>
         </div>

--- a/app/views/campaign_requests/_request_details.html.erb
+++ b/app/views/campaign_requests/_request_details.html.erb
@@ -73,96 +73,115 @@
     </div>
 
     <div class="form-group">
-      <span class="form-label">
-        <%= r.label :start_date do %>
-          Start date of campaign site<abbr title="required">*</abbr>
-        <% end %>
-      </span>
-
-      <br>
+      <fieldset class="govuk-fieldset" role="group" aria-describedby="start-date-hint">
+        <span class="form-label">
+          <%= r.label :start_date do %>
+            Start date of campaign site<abbr title="required">*</abbr>
+          <% end %>
+        </span>
+        
         <div id="start-date-hint" class="govuk-hint">
           For example, 27 3 2007
         </div>
 
-      <span class="govuk-date-input__item">
-       <%= r.label :start_day, "Day", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :start_day, required: false, value: r.object.start_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "start-day" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :start_month, "Month", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :start_month, required: false, value: r.object.start_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "start-month" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :start_year, "Year", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :start_year, required: false, value: r.object.start_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "start-year" %>
-      </span>
-      <p class="help-block">
-        Once your site is live, you should allow time for testing before driving traffic to it. We advise leaving 1-2 days for no-cost campaigns, and at least a week for paid advertising campaigns.
-      </p>
+        <div class="govuk-date-input" id="start-date">
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= r.label :start_day, "Day", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :start_day, required: false, value: r.object.start_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "start-day" %>
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+                <%= r.label :start_month, "Month", class: "govuk-label govuk-date-input__label" %>
+                <%= r.text_field :start_month, required: false, value: r.object.start_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "start-month" %>
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= r.label :start_year, "Year", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :start_year, required: false, value: r.object.start_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "start-year" %>
+            </div>
+          </div>
+        </div>
+        <p class="help-block">
+          Once your site is live, you should allow time for testing before driving traffic to it. We advise leaving 1-2 days for no-cost campaigns, and at least a week for paid advertising campaigns.
+        </p>
+      </fieldset>
     </div>
 
     <div class="form-group">
-      <span class="form-label">
-        <%= r.label :end_date do %>
-          Proposed end date of campaign site<abbr title="required">*</abbr>
-        <% end %>
-      </span>
+      <fieldset class="govuk-fieldset" role="group" aria-describedby="end-date-hint">
+        <span class="form-label">
+          <%= r.label :end_date do %>
+            Proposed end date of campaign site<abbr title="required">*</abbr>
+          <% end %>
+        </span>
 
-      <br>
         <div id="start-date-hint" class="govuk-hint">
           For example, 27 3 2007
         </div>
 
-      <span class="govuk-date-input__item">
-       <%= r.label :end_day, "Day", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :end_day, required: false, value: r.object.end_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "end-day" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :end_month, "Month", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :end_month, required: false, value: r.object.end_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "end-month" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :end_year, "Year", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :end_year, required: false, value: r.object.end_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "end-year" %>
-      </span>
-
+        <div class="govuk-date-input" id="end-date">
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+                <%= r.label :end_day, "Day", class: "govuk-label govuk-date-input__label" %>
+                <%= r.text_field :end_day, required: false, value: r.object.end_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "end-day" %>
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= r.label :end_month, "Month", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :end_month, required: false, value: r.object.end_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "end-month" %>
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= r.label :end_year, "Year", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :end_year, required: false, value: r.object.end_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "end-year" %>
+            </div>
+          </div>
+        </div>
+      </fieldset>
     </div>
 
     <div class="form-group">
-      <span class="form-label">
-        <%= r.label :development_start_date do %>
-          Site build to commence on<abbr title="required">*</abbr>
-        <% end %>
-      </span>
+      <fieldset class="govuk-fieldset" role="group" aria-describedby="development-start-date-hint">
+        <span class="form-label">
+          <%= r.label :development_start_date do %>
+            Site build to commence on<abbr title="required">*</abbr>
+          <% end %>
+        </span>
 
-      <br>
-        <div id="start-date-hint" class="govuk-hint">
+        <div id="development-start-date-hint" class="govuk-hint">
           For example, 27 3 2007
         </div>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :development_start_day, "Day", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :development_start_day, required: false, value: r.object.development_start_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "development-start-day" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :development_start_month, "Month", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :development_start_month, required: false, value: r.object.development_start_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "development-start-month" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :development_start_year, "Year", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :development_start_year, required: false, value: r.object.development_start_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "development-start-year" %>
-      </span>
-
+        
+        <div class="govuk-date-input" id="development-start-date">
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= r.label :development_start_day, "Day", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :development_start_day, required: false, value: r.object.development_start_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "development-start-day" %>
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= r.label :development_start_month, "Month", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :development_start_month, required: false, value: r.object.development_start_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "development-start-month" %>
+            </div>
+           </div>
+           <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= r.label :development_start_year, "Year", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :development_start_year, required: false, value: r.object.development_start_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "development-start-year" %>
+            </div>
+          </div>
+        </div>
+        <p class="help-block">
+          We expect the website to go live within 1 month of approval
+        </p>
+      </fieldset>
     </div>
-    <p class="help-block">
-      We expect the website to go live within 1 month of approval
-    </p>
 
     <div class="form-group">
       <span class="form-label">

--- a/app/views/content_advice_requests/_request_details.html.erb
+++ b/app/views/content_advice_requests/_request_details.html.erb
@@ -51,33 +51,42 @@
 </fieldset>
 
 <%= f.fields_for :time_constraint do |r| %>
-  <fieldset>
-    <legend>
-      <span>Time constraints</span>
-    </legend>
-
+  <fieldset class="govuk-fieldset" role="group">
     <div class="form-group">
-      <h4>
-        <%= "Is there a date you need to have a response by?" %>
-      </h4>
+      <fieldset class="govuk-fieldset" role="group" aria-describedby="needed-by-date-hint">
+        <legend>
+          <span>Time constraints</span>
+        </legend>
+        <span class="form-label">
+          <%= r.label :needed_by_date do %>
+            Is there a date you need to have a response by?
+          <% end %>
+        </span>
+
         <div id="start-date-hint" class="govuk-hint">
           For example, 27 3 2007
         </div>
 
-      <span class="govuk-date-input__item">
-        <%= r.label :needed_by_day, "Day", class: "govuk-label govuk-date-input__label" %>
-        <%= r.text_field :needed_by_day, required: false, value: r.object.needed_by_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-day" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :needed_by_month, "Month", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :needed_by_month, required: false, value: r.object.needed_by_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-month" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :needed_by_year, "Year", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :needed_by_year, required: false, value: r.object.needed_by_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "needed-by-year" %>
-      </span>
+        <div class="govuk-date-input" id="needed-by-date">
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= r.label :needed_by_day, "Day", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :needed_by_day, required: false, value: r.object.needed_by_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-day" %>
+            </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <%= r.label :needed_by_month, "Month", class: "govuk-label govuk-date-input__label" %>
+            <%= r.text_field :needed_by_month, required: false, value: r.object.needed_by_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-month" %>
+          </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <%= r.label :needed_by_year, "Year", class: "govuk-label govuk-date-input__label" %>
+            <%= r.text_field :needed_by_year, required: false, value: r.object.needed_by_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "needed-by-year" %>
+          </div>
+        </div>
+      </fieldset>
     </div>
 
     <div class="form-group">

--- a/app/views/content_advice_requests/_request_details.html.erb
+++ b/app/views/content_advice_requests/_request_details.html.erb
@@ -60,6 +60,9 @@
       <h4>
         <%= "Is there a date you need to have a response by?" %>
       </h4>
+        <div id="start-date-hint" class="govuk-hint">
+          For example, 27 3 2007
+        </div>
 
       <span class="govuk-date-input__item">
         <%= r.label :needed_by_day, "Day", class: "govuk-label govuk-date-input__label" %>

--- a/app/views/content_advice_requests/_request_details.html.erb
+++ b/app/views/content_advice_requests/_request_details.html.erb
@@ -71,19 +71,19 @@
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :needed_by_day, "Day", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :needed_by_day, required: false, value: r.object.needed_by_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-day" %>
+              <%= r.text_field :needed_by_day, required: false, value: r.object.needed_by_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-day", inputmode: "numeric" %>
             </div>
         </div>
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <%= r.label :needed_by_month, "Month", class: "govuk-label govuk-date-input__label" %>
-            <%= r.text_field :needed_by_month, required: false, value: r.object.needed_by_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-month" %>
+            <%= r.text_field :needed_by_month, required: false, value: r.object.needed_by_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-month", inputmode: "numeric" %>
           </div>
         </div>
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <%= r.label :needed_by_year, "Year", class: "govuk-label govuk-date-input__label" %>
-            <%= r.text_field :needed_by_year, required: false, value: r.object.needed_by_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "needed-by-year" %>
+            <%= r.text_field :needed_by_year, required: false, value: r.object.needed_by_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "needed-by-year", inputmode: "numeric" %>
           </div>
         </div>
       </fieldset>

--- a/app/views/remove_user_requests/_request_details.html.erb
+++ b/app/views/remove_user_requests/_request_details.html.erb
@@ -31,44 +31,39 @@
     </div>
 
     <%= f.fields_for :time_constraint do |r| %>
-
-      <h4>
-        <%= "MUST NOT be removed BEFORE" %>
-      </h4>
-
-      <div id="date-hint" class="govuk-hint">
-       For example, 27 3 2007
-      </div>
-      
       <div class="form-group">
+        <fieldset class="govuk-fieldset" role="group" aria-describedby="not-before-date-hint">
+          <span class="form-label">
+            <%= r.label :not_before_date do %>
+              MUST NOT be removed BEFORE
+            <% end %>
+          </span>
 
-        <div class="govuk-date-input" id="not-before-date-input">
-          
-          <div class="govuk-date-input__item">
-            <div class="govuk-form-group">
-              <%= r.label :not_before_day, "Day", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :not_before_day, required: false, value: r.object.not_before_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-day" %>
-            </div>
+          <div id="not-before-date-hint" class="govuk-hint">
+            For example, 27 3 2007
           </div>
 
+          <div class="govuk-date-input" id="not-before-date">
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <%= r.label :not_before_day, "Day", class: "govuk-label govuk-date-input__label" %>
+                <%= r.text_field :not_before_day, required: false, value: r.object.not_before_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-day" %>
+              </div>
+          </div>
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
-            <%= r.label :not_before_month, "Month", class: "govuk-label govuk-date-input__label" %>
-            <%= r.text_field :not_before_month, required: false, value: r.object.not_before_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-month" %>
+              <%= r.label :not_before_month, "Month", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :not_before_month, required: false, value: r.object.not_before_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-month" %>
             </div>
           </div>
-
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
-            <%= r.label :not_before_year, "Year", class: "govuk-label govuk-date-input__label" %>
-            <%= r.text_field :not_before_year, required: false, value: r.object.not_before_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "not-before-year" %>
+              <%= r.label :not_before_year, "Year", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :not_before_year, required: false, value: r.object.not_before_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "not-before-year" %>
             </div>
           </div>
-
-        </div>
-
+        </fieldset>
       </div>
-
     <% end %>
 
     <div class="form-group">

--- a/app/views/remove_user_requests/_request_details.html.erb
+++ b/app/views/remove_user_requests/_request_details.html.erb
@@ -47,19 +47,19 @@
             <div class="govuk-date-input__item">
               <div class="govuk-form-group">
                 <%= r.label :not_before_day, "Day", class: "govuk-label govuk-date-input__label" %>
-                <%= r.text_field :not_before_day, required: false, value: r.object.not_before_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-day" %>
+                <%= r.text_field :not_before_day, required: false, value: r.object.not_before_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-day", inputmode: "numeric" %>
               </div>
           </div>
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :not_before_month, "Month", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :not_before_month, required: false, value: r.object.not_before_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-month" %>
+              <%= r.text_field :not_before_month, required: false, value: r.object.not_before_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-month", inputmode: "numeric" %>
             </div>
           </div>
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :not_before_year, "Year", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :not_before_year, required: false, value: r.object.not_before_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "not-before-year" %>
+              <%= r.text_field :not_before_year, required: false, value: r.object.not_before_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "not-before-year", inputmode: "numeric" %>
             </div>
           </div>
         </fieldset>

--- a/app/views/support/_time_constraint.html.erb
+++ b/app/views/support/_time_constraint.html.erb
@@ -5,29 +5,35 @@
     </legend>
 
     <div class="form-group">
-      <span class="form-label">
-        <%= r.label :needed_by_date, "Deadline" %>
-      </span>
-      <br>
+      <fieldset class="govuk-fieldset" role="group" aria-describedby="needed-by-date-hint">
+        <span class="form-label">
+          <%= r.label :needed_by_date, "Deadline" %>
+        </span>
 
-      <span class="govuk-date-input__item">
         <div id="needed-by-date-hint" class="govuk-hint">
           For example, 27 3 2007
         </div>
 
-       <%= r.label :needed_by_day, "Day", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :needed_by_day, required: false, value: r.object.needed_by_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-day" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :needed_by_month, "Month", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :needed_by_month, required: false, value: r.object.needed_by_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-month" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :needed_by_year, "Year", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :needed_by_year, required: false, value: r.object.needed_by_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "needed-by-year" %>
-      </span> 
+        <div class="govuk-date-input" id="needed-by-date">
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= r.label :needed_by_day, "Day", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :needed_by_day, required: false, value: r.object.needed_by_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-day" %>
+            </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <%= r.label :needed_by_month, "Month", class: "govuk-label govuk-date-input__label" %>
+            <%= r.text_field :needed_by_month, required: false, value: r.object.needed_by_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-month" %>
+          </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <%= r.label :needed_by_year, "Year", class: "govuk-label govuk-date-input__label" %>
+            <%= r.text_field :needed_by_year, required: false, value: r.object.needed_by_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "needed-by-year" %>
+          </div>
+        </div>
+      </fieldset>
     </div>
 
     <div class="form-group">
@@ -40,29 +46,35 @@
     </div>
 
     <div class="form-group">
-      <span class="form-label">
-        <%= r.label :not_before_date, "Must not be published before" %>
-      </span>
-      <br>
+      <fieldset class="govuk-fieldset" role="group" aria-describedby="not-before-date-hint">
+        <span class="form-label">
+          <%= r.label :not_before_date, "Must not be published before" %>
+        </span>
 
-      <span class="govuk-date-input__item">
         <div id="not-before-date-hint" class="govuk-hint">
           For example, 27 3 2007
         </div>
 
-        <%= r.label :not_before_day, "Day", class: "govuk-label govuk-date-input__label" %>
-        <%= r.text_field :not_before_day, required: false, value: r.object.not_before_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-day" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :not_before_month, "Month", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :not_before_month, required: false, value: r.object.not_before_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-month" %>
-      </span>
-
-      <span class="govuk-date-input__item">
-       <%= r.label :not_before_year, "Year", class: "govuk-label govuk-date-input__label" %>
-       <%= r.text_field :not_before_year, required: false, value: r.object.not_before_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "not-before-year" %>
-      </span>
+        <div class="govuk-date-input" id="not-before-date">
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= r.label :not_before_day, "Day", class: "govuk-label govuk-date-input__label" %>
+              <%= r.text_field :not_before_day, required: false, value: r.object.not_before_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-day" %>
+            </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <%= r.label :not_before_month, "Month", class: "govuk-label govuk-date-input__label" %>
+            <%= r.text_field :not_before_month, required: false, value: r.object.not_before_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-month" %>
+          </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <%= r.label :not_before_year, "Year", class: "govuk-label govuk-date-input__label" %>
+            <%= r.text_field :not_before_year, required: false, value: r.object.not_before_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "not-before-year" %>
+          </div>
+        </div>
+      </fieldset>
     </div>
 
     <div class="form-group">

--- a/app/views/support/_time_constraint.html.erb
+++ b/app/views/support/_time_constraint.html.erb
@@ -11,6 +11,10 @@
       <br>
 
       <span class="govuk-date-input__item">
+        <div id="needed-by-date-hint" class="govuk-hint">
+          For example, 27 3 2007
+        </div>
+
        <%= r.label :needed_by_day, "Day", class: "govuk-label govuk-date-input__label" %>
        <%= r.text_field :needed_by_day, required: false, value: r.object.needed_by_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-day" %>
       </span>
@@ -42,6 +46,10 @@
       <br>
 
       <span class="govuk-date-input__item">
+        <div id="not-before-date-hint" class="govuk-hint">
+          For example, 27 3 2007
+        </div>
+
         <%= r.label :not_before_day, "Day", class: "govuk-label govuk-date-input__label" %>
         <%= r.text_field :not_before_day, required: false, value: r.object.not_before_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-day" %>
       </span>

--- a/app/views/support/_time_constraint.html.erb
+++ b/app/views/support/_time_constraint.html.erb
@@ -18,19 +18,19 @@
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :needed_by_day, "Day", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :needed_by_day, required: false, value: r.object.needed_by_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-day" %>
+              <%= r.text_field :needed_by_day, required: false, value: r.object.needed_by_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-day", inputmode: "numeric" %>
             </div>
         </div>
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <%= r.label :needed_by_month, "Month", class: "govuk-label govuk-date-input__label" %>
-            <%= r.text_field :needed_by_month, required: false, value: r.object.needed_by_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-month" %>
+            <%= r.text_field :needed_by_month, required: false, value: r.object.needed_by_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "needed-by-month", inputmode: "numeric" %>
           </div>
         </div>
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <%= r.label :needed_by_year, "Year", class: "govuk-label govuk-date-input__label" %>
-            <%= r.text_field :needed_by_year, required: false, value: r.object.needed_by_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "needed-by-year" %>
+            <%= r.text_field :needed_by_year, required: false, value: r.object.needed_by_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "needed-by-year", inputmode: "numeric" %>
           </div>
         </div>
       </fieldset>
@@ -59,19 +59,19 @@
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= r.label :not_before_day, "Day", class: "govuk-label govuk-date-input__label" %>
-              <%= r.text_field :not_before_day, required: false, value: r.object.not_before_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-day" %>
+              <%= r.text_field :not_before_day, required: false, value: r.object.not_before_day, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-day", inputmode: "numeric" %>
             </div>
         </div>
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <%= r.label :not_before_month, "Month", class: "govuk-label govuk-date-input__label" %>
-            <%= r.text_field :not_before_month, required: false, value: r.object.not_before_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-month" %>
+            <%= r.text_field :not_before_month, required: false, value: r.object.not_before_month, class: "govuk-input govuk-date-input__input govuk-input--width-2", id: "not-before-month", inputmode: "numeric" %>
           </div>
         </div>
         <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <%= r.label :not_before_year, "Year", class: "govuk-label govuk-date-input__label" %>
-            <%= r.text_field :not_before_year, required: false, value: r.object.not_before_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "not-before-year" %>
+            <%= r.text_field :not_before_year, required: false, value: r.object.not_before_year, class: "govuk-input govuk-date-input__input govuk-input--width-4", id: "not-before-year", inputmode: "numeric" %>
           </div>
         </div>
       </fieldset>


### PR DESCRIPTION
Adds:
- missing hint text for date input fields
- fieldset and label HTML tags
- missing `<div class="govuk-form-group">` and `<div class="govuk-date-input”>`
- switches spans to divs which ensures correct margins without need for line breaks
- inputmode="numeric" 

Also corrects indentation.

As per https://design-system.service.gov.uk/patterns/dates/

### Visual change
<kbd><img width="411" alt="Screenshot 2024-09-20 at 13 51 40" src="https://github.com/user-attachments/assets/9b585ffe-fdd4-4ae5-b571-e8a434843014"></kbd>


---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
