### PR TITLE
Remove "Content Publisher" as an option on Technical Fault Report

### DIFF
--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -23,7 +23,6 @@ module Support
         "collections_publisher" => "Collections Publisher",
         "contacts_admin" => "Contacts Admin",
         "content_data" => "Content Data",
-        "content_publisher" => "Content Publisher",
         "content_tagger" => "Content Tagger",
         "datagovuk" => "data.gov.uk",
         "email_alerts" => "Email alerts",


### PR DESCRIPTION
Content Publisher is a deprecated app, and had just 9-17 monthly users in the last quarter.
https://docs.google.com/document/d/1qcnGDzw5PKKg97c3ivDpBtmbbutsUcIfk5GZxqLqFjg/edit?tab=t.0#heading=h.sll6kqtr8gmz

Of the 9 technical fault reports associated with "Content Publisher" raised since August, just 1 has actually been to do with Content Publisher. The other 8 were all Whitehall requests.

Removing this option from the form should make it clearer to users that "Whitehall" or "GOV.UK: content" is the option they need, and should reduce the number of misleadingly labelled Zendesk tickets for our support queue.

If users have a genuine issue with Content Publisher itself, they can choose the "Other / do not know" option.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
