### PR TITLE
Change content emergency contact

### DIFF
--- a/app/views/content_change_requests/_request_details.html.erb
+++ b/app/views/content_change_requests/_request_details.html.erb
@@ -116,7 +116,7 @@
 
 <div class="alert alert-info alert-block">
   <p><strong>If your request is urgent</strong></p>
-  <p>Submit this form and <a target="_blank" href="https://support.publishing.service.gov.uk/emergency-contact-details">use one of our emergency contact methods</a>.</p>
+  <p>Submit this form and <a target="_blank" rel="noreferrer noopener" href="https://support.publishing.service.gov.uk/emergency-contact-details">use one of our emergency contact methods (opens in new tab)</a>.</p>
 
   <p>It's urgent only if the public or the government faces immediate and significant financial, legal or physical risk.</p>
 </div>

--- a/app/views/content_change_requests/_request_details.html.erb
+++ b/app/views/content_change_requests/_request_details.html.erb
@@ -116,7 +116,7 @@
 
 <div class="alert alert-info alert-block">
   <p><strong>If your request is urgent</strong></p>
-  <p>Submit this form and <a target="_blank" rel="noreferrer noopener" href="https://support.publishing.service.gov.uk/emergency-contact-details">use one of our emergency contact methods (opens in new tab)</a>.</p>
+  <p>Submit this form and <%= link_to "use one of our emergency contact methods (opens in new tab)", emergency_contact_details_path, target: "_blank" %>.</p>
 
   <p>It's urgent only if the public or the government faces immediate and significant financial, legal or physical risk.</p>
 </div>

--- a/app/views/content_change_requests/_request_details.html.erb
+++ b/app/views/content_change_requests/_request_details.html.erb
@@ -116,11 +116,8 @@
 
 <div class="alert alert-info alert-block">
   <p><strong>If your request is urgent</strong></p>
-  <p>Submit this form and call:</p>
-  <ul>
-    <li><%= @primary_contact_details[:urgent_department_content_change][:phone] %> between 9am and 6pm</li>
-    <li><%= @primary_contact_details[:urgent_mainstream_content_change][:phone] %> at other times</li>
-  </ul>
+  <p>Submit this form and <a target="_blank" href="https://support.publishing.service.gov.uk/emergency-contact-details">use one of our emergency contact methods</a>.</p>
+
   <p>It's urgent only if the public or the government faces immediate and significant financial, legal or physical risk.</p>
 </div>
 

--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -50,7 +50,7 @@
     </div>
     <div class="row add-bottom-padding add-top-padding">
       <div class="col-md-12">
-        <p class="remove-bottom-margin"><%= @primary_contact_details[:urgent_department_content_change][:phone] %></p>
+        <p class="remove-bottom-margin"><%= mail_to @primary_contact_details[:content_emergency][:email] %></p>
         <p>Monday to Friday, 9am to 6pm<br>(excluding bank holidays)</p>
       </div>
     </div>

--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -28,14 +28,13 @@
     <h2 id="request-change">Request a change to GOV.UK content</h2>
     <div class="row">
       <div class="col-md-6">
-        <p>Before you call, you must first:</p>
+        <p>Before you contact us, you must first:</p>
         <ul>
-          <li><%= link_to "submit a support request", new_content_change_request_path %> before you phone</li>
+          <li><%= link_to "submit a support request", new_content_change_request_path %></li>
           <li><%= link_to "read the full guidelines", "https://www.gov.uk/guidance/contact-the-government-digital-service/how-to-contact-gds" %></li>
-          <li>leave a message and a contact number if the phone is not answered - please do not text</li>
         </ul>
-        <p>The phone number you need and what counts as an emergency depends on whether you are calling within office hours.</p>
-        <p>Both phone numbers will put you in contact with a member of the GOV.UK content team.</p>
+        <p>The way you contact us and what counts as an emergency depends on whether you are calling within office hours.</p>
+        <p>Both contact methods will put you in contact with a member of the GOV.UK content team.</p>
       </div>
     </div>
 
@@ -60,6 +59,7 @@
     <div class="row">
       <div class="col-md-6">
         <p>Use only if the public or government is facing immediate and significant financial, legal or physical risk.</p>
+        <p>Leave a message and a contact number if the phone is not answered – please do not text.</p>
       </div>
     </div>
     <div class="row add-bottom-padding add-top-padding">

--- a/config/emergency_contact_details.json
+++ b/config/emergency_contact_details.json
@@ -10,9 +10,6 @@
     "urgent_mainstream_content_change": {
       "phone": "05555 555 555"
     },
-    "urgent_department_content_change": {
-      "phone": "05555 555 555"
-    },
     "content_emergency": {
       "email": "idasupport@email.uk"
     }

--- a/config/emergency_contact_details.json
+++ b/config/emergency_contact_details.json
@@ -12,6 +12,9 @@
     },
     "urgent_department_content_change": {
       "phone": "05555 555 555"
+    },
+    "content_emergency": {
+      "email": "idasupport@email.uk"
     }
   },
   "secondary_contacts": [


### PR DESCRIPTION
🛑  DO NOT MERGE until we are given the go-ahead from Keith or John-Paul.

### Prerequisites:
- [x]  Add new value in AWS Secrets Manager in all 3 environments 

## What
The office hours content emergency phone is being replaced by a group email address. 
Closes https://github.com/alphagov/support/issues/1614

#### "Request a content change or new content on GOV.UK" page
Integration URL: https://support.integration.publishing.service.gov.uk/content_change_request/new
| Before    | After |
| -------- | ------- |
|  n/a due to sensitive content | <img width="561" alt="Screenshot 2025-02-12 at 14 55 29" src="https://github.com/user-attachments/assets/8c15e204-a053-4fbc-8b7f-094b0c646a14" /> |

#### "Emergency contacts" page
Screenshots not available due to sensitive content. 
Visit integration URL for review: https://support.integration.publishing.service.gov.uk/emergency-contact-details

### How to review this
- check if secrets include the new value
- visit https://support.integration.publishing.service.gov.uk/content_change_request/new
- visit https://support.integration.publishing.service.gov.uk/emergency-contact-details

### Post deployment tasks:
- [ ]  Remove old value from AWS Secrets Manager in all 3 environments 

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
