### PR TITLE
Update create new user request

### DIFF
--- a/app/controllers/create_new_user_requests_controller.rb
+++ b/app/controllers/create_new_user_requests_controller.rb
@@ -25,6 +25,7 @@ protected
       :new_or_existing_user,
       :whitehall_training,
       :access_to_other_publishing_apps,
+      :writing_for_govuk_training,
       :additional_comments,
       requester_attributes: %i[email name collaborator_emails],
     ).to_h

--- a/app/controllers/create_new_user_requests_controller.rb
+++ b/app/controllers/create_new_user_requests_controller.rb
@@ -22,6 +22,7 @@ protected
       :name,
       :email,
       :organisation,
+      :new_or_existing_user,
       :whitehall_training,
       :access_to_other_publishing_apps,
       :additional_comments,

--- a/app/models/support/requests/create_new_user_request.rb
+++ b/app/models/support/requests/create_new_user_request.rb
@@ -8,6 +8,7 @@ module Support
         :new_or_existing_user,
         :whitehall_training,
         :access_to_other_publishing_apps,
+        :writing_for_govuk_training,
         :additional_comments,
       )
 
@@ -19,6 +20,8 @@ module Support
                 inclusion: { in: :whitehall_training_option_keys, allow_blank: false }
       validates :access_to_other_publishing_apps,
                 inclusion: { in: :access_to_other_publishing_apps_option_keys, allow_blank: false }
+      validates :writing_for_govuk_training,
+                inclusion: { in: :writing_for_govuk_training_option_keys, allow_blank: true }
       validates :additional_comments,
                 presence: true, if: -> { access_to_other_publishing_apps == "whitehall_training_additional_apps_access_yes" }
 
@@ -72,6 +75,18 @@ module Support
 
       def formatted_access_to_other_publishing_apps_option
         access_to_other_publishing_apps_options[access_to_other_publishing_apps]
+      end
+
+      def writing_for_govuk_training_options
+        Zendesk::CustomField.options_hash("[Whitehall training] Writing for GOV.UK training required?")
+      end
+
+      def writing_for_govuk_training_option_keys
+        writing_for_govuk_training_options.keys
+      end
+
+      def formatted_writing_for_govuk_training_option
+        writing_for_govuk_training_options[writing_for_govuk_training]
       end
     end
   end

--- a/app/models/support/requests/create_new_user_request.rb
+++ b/app/models/support/requests/create_new_user_request.rb
@@ -40,7 +40,7 @@ module Support
       def_delegator self, :label, :formatted_action
 
       def self.description
-        "Request a new user account."
+        "Use this form to request a new user account or training for new and existing users."
       end
 
       def new_or_existing_user_options

--- a/app/models/support/requests/create_new_user_request.rb
+++ b/app/models/support/requests/create_new_user_request.rb
@@ -5,6 +5,7 @@ module Support
         :name,
         :email,
         :organisation,
+        :new_or_existing_user,
         :whitehall_training,
         :access_to_other_publishing_apps,
         :additional_comments,
@@ -12,6 +13,8 @@ module Support
 
       validates :name, :email, presence: true
       validates :email, format: { with: /@/ }
+      validates :new_or_existing_user,
+                inclusion: { in: :new_or_existing_user_option_keys, allow_blank: false }
       validates :whitehall_training,
                 inclusion: { in: :whitehall_training_option_keys, allow_blank: false }
       validates :access_to_other_publishing_apps,
@@ -33,6 +36,18 @@ module Support
 
       def self.description
         "Request a new user account."
+      end
+
+      def new_or_existing_user_options
+        Zendesk::CustomField.options_hash("[Whitehall training] New or existing user?")
+      end
+
+      def new_or_existing_user_option_keys
+        new_or_existing_user_options.keys
+      end
+
+      def formatted_new_or_existing_user_option
+        new_or_existing_user_options[new_or_existing_user]
       end
 
       def whitehall_training_options

--- a/app/models/support/requests/create_new_user_request.rb
+++ b/app/models/support/requests/create_new_user_request.rb
@@ -1,6 +1,10 @@
+require "forwardable"
+
 module Support
   module Requests
     class CreateNewUserRequest < Request
+      extend Forwardable
+
       attr_accessor(
         :name,
         :email,
@@ -29,13 +33,11 @@ module Support
         "create_new_user"
       end
 
-      def formatted_action
-        "Create a new user account"
+      def self.label
+        "Create a new user or request training"
       end
 
-      def self.label
-        "Create a new user"
-      end
+      def_delegator self, :label, :formatted_action
 
       def self.description
         "Request a new user account."

--- a/app/models/zendesk/ticket/create_new_user_request_ticket.rb
+++ b/app/models/zendesk/ticket/create_new_user_request_ticket.rb
@@ -24,6 +24,7 @@ module Zendesk
           CustomField.set(id: 16_186_526_602_396, input: @request.formatted_access_to_other_publishing_apps_option),
         ]
         fields << CustomField.set(id: 16_186_432_238_236, input: @request.organisation) if @request.organisation
+        fields << CustomField.set(id: 18_626_967_621_276, input: @request.formatted_writing_for_govuk_training_option) if @request.writing_for_govuk_training.present?
         fields
       end
 
@@ -65,6 +66,11 @@ module Zendesk
             on: @request,
             field: :formatted_access_to_other_publishing_apps_option,
             label: "Access to other publishing apps",
+          ),
+          Zendesk::LabelledSnippet.new(
+            on: @request,
+            field: :formatted_writing_for_govuk_training_option,
+            label: "Writing for GOV.UK training",
           ),
           Zendesk::LabelledSnippet.new(on: @request, field: :additional_comments),
         ]

--- a/app/models/zendesk/ticket/create_new_user_request_ticket.rb
+++ b/app/models/zendesk/ticket/create_new_user_request_ticket.rb
@@ -19,6 +19,7 @@ module Zendesk
         fields = [
           CustomField.set(id: 16_186_374_142_108, input: @request.name),
           CustomField.set(id: 16_186_377_836_316, input: @request.email),
+          CustomField.set(id: 18_626_821_668_764, input: @request.formatted_new_or_existing_user_option),
           CustomField.set(id: 16_186_461_678_108, input: @request.formatted_whitehall_training_option),
           CustomField.set(id: 16_186_526_602_396, input: @request.formatted_access_to_other_publishing_apps_option),
         ]
@@ -49,6 +50,11 @@ module Zendesk
             on: @request,
             field: :organisation,
             label: "Organisation",
+          ),
+          Zendesk::LabelledSnippet.new(
+            on: @request,
+            field: :formatted_new_or_existing_user_option,
+            label: "New or existing user",
           ),
           Zendesk::LabelledSnippet.new(
             on: @request,

--- a/app/views/create_new_user_requests/_request_details.html.erb
+++ b/app/views/create_new_user_requests/_request_details.html.erb
@@ -116,6 +116,27 @@
       </span>
     </div>
 
+    <div class="form-group">
+      <span class="form-label">
+        <%= f.label :writing_for_govuk_training, class: "control-label" do %>
+          Does the user require Writing for GOV.UK training?
+        <% end %>
+      </span>
+      <p class="help-block hint-block--md-6" id="writing-training-hint">
+        New publishers who only have access to Manuals Publisher, Specialist Publisher or Travel Advice Publisher can request Writing for GOV.UK training.
+      </p>
+      <span class="form-wrapper">
+        <%= f.collection_radio_buttons :writing_for_govuk_training, f.object.writing_for_govuk_training_options, :first, :first do |builder| %>
+           <div class="radio">
+            <%= builder.label class: "custom-control-label" do %>
+              <%= builder.radio_button(class: "custom-control-input") %>
+              <%= builder.object.last %>
+            <% end %>
+          </div>
+        <% end %>
+      </span>
+    </div>
+
     <%= f.fields_for :requester do |r| %>
       <div class="form-group">
         <span class="form-label">

--- a/app/views/create_new_user_requests/_request_details.html.erb
+++ b/app/views/create_new_user_requests/_request_details.html.erb
@@ -59,7 +59,7 @@
     <div class="form-group">
       <span class="form-label">
         <%= f.label :whitehall_training, class: "control-label" do %>
-          Does the user need training to access Whitehall Publisher?<abbr title="required">*</abbr>
+          Does the user require any training?<abbr title="required">*</abbr>
         <% end %>
       </span>
       <div class="help-block hint-block--md-6" id="publisher-training-hint">
@@ -68,6 +68,7 @@
           <li>Writing and Publishing on GOV.UK for press officers - if they only need to publish news stories and press releases</li>
           <li>Writing and Publishing on GOV.UK - for all other publishers</li>
         </ul>
+        <p>Existing publishers can request refresher training.</p>
       </div>
       <span class="form-wrapper">
         <%= f.collection_radio_buttons :whitehall_training, f.object.whitehall_training_options, :first, :first, required: true, aria: { required: true } do |builder| %>

--- a/app/views/create_new_user_requests/_request_details.html.erb
+++ b/app/views/create_new_user_requests/_request_details.html.erb
@@ -2,66 +2,71 @@
 
 <div class="row">
   <div class="col-md-6">
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :name do %>
-          User's name<abbr title="required">*</abbr>
-        <% end %>
-      </span>
-      <span class="form-wrapper">
-        <%= f.text_field :name, required: true, aria: { required: true }, class: "form-control" %>
-      </span>
-    </div>
+    <fieldset>
+      <legend>
+        <span>User details</span>
+      </legend>
 
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :email do %>
-          User's email<abbr title="required">*</abbr>
-        <% end %>
-      </span>
-      <p class="help-block hint-block--md-6" id="user-email-hint">
-        The user will be copied into this request.
-      </p>
-      <span class="form-wrapper">
-        <%= f.email_field :email, required: true, aria: { required: true }, class: "form-control" %>
-      </span>
-    </div>
+      <div class="form-group">
+        <span class="form-label">
+          <%= f.label :name do %>
+            User's name<abbr title="required">*</abbr>
+          <% end %>
+        </span>
+        <span class="form-wrapper">
+          <%= f.text_field :name, required: true, aria: { required: true }, class: "form-control" %>
+        </span>
+      </div>
 
-    <div class="form-group select">
-      <span class="form-label">
-        <%= f.label :organisation do %>
-          User's organisation
-        <% end %>
-      </span>
-      <span class="form-wrapper">
-        <%= f.select :organisation, options_for_select(organisation_options, f.object.organisation), { include_blank: true }, multiple: false, class: "select2 form-control", type: "organisation" %>
-      </span>
-    </div>
+      <div class="form-group">
+        <span class="form-label">
+          <%= f.label :email do %>
+            User's email<abbr title="required">*</abbr>
+          <% end %>
+        </span>
+        <p class="help-block hint-block--md-6" id="user-email-hint">
+          The user will be copied into this request.
+        </p>
+        <span class="form-wrapper">
+          <%= f.email_field :email, required: true, aria: { required: true }, class: "form-control" %>
+        </span>
+      </div>
 
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :new_or_existing_user, class: "control-label" do %>
-          Are they a new or existing user?<abbr title="required">*</abbr>
-        <% end %>
-      </span>
-      <span class="form-wrapper">
-        <%= f.collection_radio_buttons :new_or_existing_user, f.object.new_or_existing_user_options, :first, :first, required: true, aria: { required: true } do |builder| %>
-           <div class="radio">
-            <%= builder.label class: "custom-control-label" do %>
-              <%= builder.radio_button(class: "custom-control-input") %>
-              <%= builder.object.last %>
-            <% end %>
-          </div>
-        <% end %>
-      </span>
-    </div>
+      <div class="form-group select">
+        <span class="form-label">
+          <%= f.label :organisation do %>
+            User's organisation
+          <% end %>
+        </span>
+        <span class="form-wrapper">
+          <%= f.select :organisation, options_for_select(organisation_options, f.object.organisation), { include_blank: true }, multiple: false, class: "select2 form-control", type: "organisation" %>
+        </span>
+      </div>
 
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :whitehall_training, class: "control-label" do %>
-          Does the user require any training?<abbr title="required">*</abbr>
-        <% end %>
-      </span>
+      <div class="form-group">
+        <span class="form-label">
+          <%= f.label :new_or_existing_user, class: "control-label" do %>
+            Are they a new or existing user?<abbr title="required">*</abbr>
+          <% end %>
+        </span>
+        <span class="form-wrapper">
+          <%= f.collection_radio_buttons :new_or_existing_user, f.object.new_or_existing_user_options, :first, :first, required: true, aria: { required: true } do |builder| %>
+            <div class="radio">
+              <%= builder.label class: "custom-control-label" do %>
+                <%= builder.radio_button(class: "custom-control-input") %>
+                <%= builder.object.last %>
+              <% end %>
+            </div>
+          <% end %>
+        </span>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>
+        <span>Training and access to Whitehall Publisher</span>
+      </legend>
+
       <div class="help-block hint-block--md-6" id="publisher-training-hint">
         <p>All new publishers using Whitehall Publisher must complete training. New publishers can complete either:</p>
         <ul>
@@ -70,88 +75,108 @@
         </ul>
         <p>Existing publishers can request refresher training.</p>
       </div>
-      <span class="form-wrapper">
-        <%= f.collection_radio_buttons :whitehall_training, f.object.whitehall_training_options, :first, :first, required: true, aria: { required: true } do |builder| %>
-           <% if builder.value == f.object.whitehall_training_options.keys.last %>
-            <p>or</p>
-           <% end %>
-           <div class="radio">
-            <%= builder.label class: "custom-control-label" do %>
-              <%= builder.radio_button(class: "custom-control-input") %>
-              <%= builder.object.last %>
-            <% end %>
-          </div>
-        <% end %>
-      </span>
-    </div>
 
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :access_to_other_publishing_apps, class: "control-label" do %>
-          Does this user need access to any other publishing applications?<abbr title="required">*</abbr>
-        <% end %>
-      </span>
-      <span class="form-wrapper">
-        <%= f.collection_radio_buttons :access_to_other_publishing_apps, f.object.access_to_other_publishing_apps_options, :first, :first, required: true, aria: { required: true } do |builder| %>
-          <div class="radio">
-            <%= builder.label class: "custom-control-label" do %>
-              <%= builder.radio_button(class: "custom-control-input") %>
-              <%= builder.object.last %>
-            <% end %>
-          </div>
-        <% end %>
-      </span>
-    </div>
-
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :additional_comments do %>
-          List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.
-        <% end %>
-      </span>
-      <p class="help-block hint-block--md-6" id="additional-comments-hint">
-        All users have basic access to Content Data, Feedback Explorer, GovSearch and Support forms.
-      </p>
-      <span class="form-wrapper">
-        <%= f.text_area :additional_comments, class: "input-md-6 form-control", rows: 6, cols: 50 %>
-      </span>
-    </div>
-
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :writing_for_govuk_training, class: "control-label" do %>
-          Does the user require Writing for GOV.UK training?
-        <% end %>
-      </span>
-      <p class="help-block hint-block--md-6" id="writing-training-hint">
-        New publishers who only have access to Manuals Publisher, Specialist Publisher or Travel Advice Publisher can request Writing for GOV.UK training.
-      </p>
-      <span class="form-wrapper">
-        <%= f.collection_radio_buttons :writing_for_govuk_training, f.object.writing_for_govuk_training_options, :first, :first do |builder| %>
-           <div class="radio">
-            <%= builder.label class: "custom-control-label" do %>
-              <%= builder.radio_button(class: "custom-control-input") %>
-              <%= builder.object.last %>
-            <% end %>
-          </div>
-        <% end %>
-      </span>
-    </div>
-
-    <%= f.fields_for :requester do |r| %>
       <div class="form-group">
         <span class="form-label">
-          <%= r.label :collaborator_emails, "Who needs a copy of this request?" %>
+          <%= f.label :whitehall_training, class: "control-label" do %>
+            Does the user require any training?<abbr title="required">*</abbr>
+          <% end %>
         </span>
-        <p class="help-block hint-block--md-6" id="collaborators-hint">
-          The user will be copied into the request. Separate email addresses with commas.
-        </p>
         <span class="form-wrapper">
-          <%= r.text_field :collaborator_emails, required: false, class: "input-md-6 form-control", value: r.object.collaborator_emails.join(", "), aria: {
-          describedby: "collaborators-hint"
-          } %>
+          <%= f.collection_radio_buttons :whitehall_training, f.object.whitehall_training_options, :first, :first, required: true, aria: { required: true } do |builder| %>
+            <% if builder.value == f.object.whitehall_training_options.keys.last %>
+              <p>or</p>
+            <% end %>
+            <div class="radio">
+              <%= builder.label class: "custom-control-label" do %>
+                <%= builder.radio_button(class: "custom-control-input") %>
+                <%= builder.object.last %>
+              <% end %>
+            </div>
+          <% end %>
         </span>
       </div>
-    <% end %>
+    </fieldset>
+
+    <fieldset>
+      <legend>
+        <span>Training and access to other publishing applications</span>
+      </legend>
+
+      <div class="form-group">
+        <span class="form-label">
+          <%= f.label :access_to_other_publishing_apps, class: "control-label" do %>
+            Does this user need access to any other publishing applications?<abbr title="required">*</abbr>
+          <% end %>
+        </span>
+        <span class="form-wrapper">
+          <%= f.collection_radio_buttons :access_to_other_publishing_apps, f.object.access_to_other_publishing_apps_options, :first, :first, required: true, aria: { required: true } do |builder| %>
+            <div class="radio">
+              <%= builder.label class: "custom-control-label" do %>
+                <%= builder.radio_button(class: "custom-control-input") %>
+                <%= builder.object.last %>
+              <% end %>
+            </div>
+          <% end %>
+        </span>
+      </div>
+
+      <div class="form-group">
+        <span class="form-label">
+          <%= f.label :additional_comments do %>
+            List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.
+          <% end %>
+        </span>
+        <p class="help-block hint-block--md-6" id="additional-comments-hint">
+          All users have basic access to Content Data, Feedback Explorer, GovSearch and Support forms.
+        </p>
+        <span class="form-wrapper">
+          <%= f.text_area :additional_comments, class: "input-md-6 form-control", rows: 6, cols: 50 %>
+        </span>
+      </div>
+
+      <div class="form-group">
+        <span class="form-label">
+          <%= f.label :writing_for_govuk_training, class: "control-label" do %>
+            Does the user require Writing for GOV.UK training?
+          <% end %>
+        </span>
+        <p class="help-block hint-block--md-6" id="writing-training-hint">
+          New publishers who only have access to Manuals Publisher, Specialist Publisher or Travel Advice Publisher can request Writing for GOV.UK training.
+        </p>
+        <span class="form-wrapper">
+          <%= f.collection_radio_buttons :writing_for_govuk_training, f.object.writing_for_govuk_training_options, :first, :first do |builder| %>
+            <div class="radio">
+              <%= builder.label class: "custom-control-label" do %>
+                <%= builder.radio_button(class: "custom-control-input") %>
+                <%= builder.object.last %>
+              <% end %>
+            </div>
+          <% end %>
+        </span>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>
+        <span>Copy of the request</span>
+      </legend>
+
+      <%= f.fields_for :requester do |r| %>
+        <div class="form-group">
+          <span class="form-label">
+            <%= r.label :collaborator_emails, "Who needs a copy of this request?" %>
+          </span>
+          <p class="help-block hint-block--md-6" id="collaborators-hint">
+            The user will be copied into the request. Separate email addresses with commas.
+          </p>
+          <span class="form-wrapper">
+            <%= r.text_field :collaborator_emails, required: false, class: "input-md-6 form-control", value: r.object.collaborator_emails.join(", "), aria: {
+            describedby: "collaborators-hint"
+            } %>
+          </span>
+        </div>
+      <% end %>
+    </fieldset>
   </div>
 </div>

--- a/app/views/create_new_user_requests/_request_details.html.erb
+++ b/app/views/create_new_user_requests/_request_details.html.erb
@@ -20,7 +20,7 @@
         <% end %>
       </span>
       <p class="help-block hint-block--md-6" id="user-email-hint">
-        The new user will be copied into this request.
+        The user will be copied into this request.
       </p>
       <span class="form-wrapper">
         <%= f.email_field :email, required: true, aria: { required: true }, class: "form-control" %>
@@ -35,6 +35,24 @@
       </span>
       <span class="form-wrapper">
         <%= f.select :organisation, options_for_select(organisation_options, f.object.organisation), { include_blank: true }, multiple: false, class: "select2 form-control", type: "organisation" %>
+      </span>
+    </div>
+
+    <div class="form-group">
+      <span class="form-label">
+        <%= f.label :new_or_existing_user, class: "control-label" do %>
+          Are they a new or existing user?<abbr title="required">*</abbr>
+        <% end %>
+      </span>
+      <span class="form-wrapper">
+        <%= f.collection_radio_buttons :new_or_existing_user, f.object.new_or_existing_user_options, :first, :first, required: true, aria: { required: true } do |builder| %>
+           <div class="radio">
+            <%= builder.label class: "custom-control-label" do %>
+              <%= builder.radio_button(class: "custom-control-input") %>
+              <%= builder.object.last %>
+            <% end %>
+          </div>
+        <% end %>
       </span>
     </div>
 
@@ -104,7 +122,7 @@
           <%= r.label :collaborator_emails, "Who needs a copy of this request?" %>
         </span>
         <p class="help-block hint-block--md-6" id="collaborators-hint">
-          The new user will be copied into the request. Separate email addresses with commas.
+          The user will be copied into the request. Separate email addresses with commas.
         </p>
         <span class="form-wrapper">
           <%= r.text_field :collaborator_emails, required: false, class: "input-md-6 form-control", value: r.object.collaborator_emails.join(", "), aria: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,10 +41,11 @@ en:
             email:
               blank: Enter an email address
               invalid: Enter an email address in the correct format, like name@example.com
+            new_or_existing_user:
+              inclusion: Select if the user is new or existing
             whitehall_training:
               inclusion: Select if the user needs training or access to Whitehall Publisher
             access_to_other_publishing_apps:
               inclusion: Select if the user needs access to other publishing apps
             additional_comments:
               blank: List which publishing applications and permissions the user needs
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,5 +47,7 @@ en:
               inclusion: Select if the user needs training or access to Whitehall Publisher
             access_to_other_publishing_apps:
               inclusion: Select if the user needs access to other publishing apps
+            writing_for_govuk_training:
+              inclusion: Select if the user needs Writing for GOV.UK training
             additional_comments:
               blank: List which publishing applications and permissions the user needs

--- a/config/zendesk/custom_fields_data.yml
+++ b/config/zendesk/custom_fields_data.yml
@@ -67,7 +67,7 @@
     whitehall_training_required_none: No, the user does not need to draft or publish content on Whitehall Publisher
     whitehall_training_required_press_officer: Yes, they need Writing and Publishing on GOV.UK for press officers training
     whitehall_training_required_standard: Yes, they need Writing and Publishing on GOV.UK training
-    whitehall_training_completed: They’ve completed training and need a Production account to access Whitehall Publisher
+    whitehall_training_completed: They’ve completed training and need a Production account (new users only)
 - !ruby/object:Zendesk::CustomFieldType::DropDown
   name: "[Whitehall training] Access to other publishing Apps required?"
   id: 16186526602396

--- a/config/zendesk/custom_fields_data.yml
+++ b/config/zendesk/custom_fields_data.yml
@@ -55,6 +55,12 @@
   name: "[Whitehall training] User's organisation"
   id: 16186432238236
 - !ruby/object:Zendesk::CustomFieldType::DropDown
+  name: "[Whitehall training] New or existing user?"
+  id: 18626821668764
+  options:
+    whitehall_training_new_user: They’re a new user and do not have a Production account
+    whitehall_training_existing_user: They’re an existing user and already have a Production account
+- !ruby/object:Zendesk::CustomFieldType::DropDown
   name: "[Whitehall training] Training required?"
   id: 16186461678108
   options:
@@ -68,3 +74,9 @@
   options:
     whitehall_training_additional_apps_access_no: No, the user does not need access to any other publishing application
     whitehall_training_additional_apps_access_yes: Yes, the user needs access to the applications and permissions listed below
+- !ruby/object:Zendesk::CustomFieldType::DropDown
+  name: "[Whitehall training] Writing for GOV.UK training required?"
+  id: 18626967621276
+  options:
+    whitehall_training_writing_for_govuk_required_yes: Yes, they need Writing for GOV.UK training
+    whitehall_training_writing_for_govuk_required_no: No, the user does not need Writing for GOV.UK training

--- a/spec/controllers/create_new_user_requests_controller_spec.rb
+++ b/spec/controllers/create_new_user_requests_controller_spec.rb
@@ -17,6 +17,7 @@ describe CreateNewUserRequestsController, type: :controller do
         "requester_attributes" => valid_requester_params,
         **valid_requested_user_params,
         "action" => "create_new_user",
+        "new_or_existing_user" => "whitehall_training_new_user",
         "whitehall_training" => "whitehall_training_required_none",
         "access_to_other_publishing_apps" => "whitehall_training_additional_apps_access_yes",
         "additional_comments" => "not-blank",
@@ -46,6 +47,7 @@ describe CreateNewUserRequestsController, type: :controller do
     expect(controller).to have_rendered(:new)
     expect(response.body).to have_css(".alert", text: /Enter a name/)
     expect(response.body).to have_css(".alert", text: /Enter an email address/)
+    expect(response.body).to have_css(".alert", text: /Select if the user is new or existing/)
     expect(response.body).to have_css(".alert", text: /Select if the user needs training or access to Whitehall Publisher/)
     expect(response.body).to have_css(".alert", text: /Select if the user needs access to other publishing apps/)
   end

--- a/spec/features/create_new_user_requests_spec.rb
+++ b/spec/features/create_new_user_requests_spec.rb
@@ -40,6 +40,9 @@ bob@gov.uk
 [Organisation]
 Cabinet Office (CO)
 
+[New or existing user]
+They’re a new user and do not have a Production account
+
 [Training or access to Whitehall Publisher]
 No, the user does not need to draft or publish content on Whitehall Publisher
 
@@ -51,6 +54,7 @@ XXXX",
       "custom_fields" => [
         { "id" => 16_186_374_142_108, "value" => "Bob Fields" },
         { "id" => 16_186_377_836_316, "value" => "bob@gov.uk" },
+        { "id" => 18_626_821_668_764, "value" => "whitehall_training_new_user" },
         { "id" => 16_186_461_678_108, "value" => "whitehall_training_required_none" },
         { "id" => 16_186_526_602_396, "value" => "whitehall_training_additional_apps_access_yes" },
         { "id" => 16_186_432_238_236, "value" => "Cabinet Office (CO)" },
@@ -66,6 +70,7 @@ XXXX",
     fill_in "User's name", with: "Bob Fields"
     fill_in "User's email", with: "bob@gov.uk"
     select "Cabinet Office (CO)", from: "User's organisation"
+    choose "They’re a new user and do not have a Production account"
     choose "No, the user does not need to draft or publish content on Whitehall Publisher"
     choose "Yes, the user needs access to the applications and permissions listed below"
     fill_in "List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.", with: "XXXX"

--- a/spec/features/create_new_user_requests_spec.rb
+++ b/spec/features/create_new_user_requests_spec.rb
@@ -49,6 +49,9 @@ No, the user does not need to draft or publish content on Whitehall Publisher
 [Access to other publishing apps]
 Yes, the user needs access to the applications and permissions listed below
 
+[Writing for GOV.UK training]
+No, the user does not need Writing for GOV.UK training
+
 [Additional comments]
 XXXX",
       "custom_fields" => [
@@ -58,6 +61,7 @@ XXXX",
         { "id" => 16_186_461_678_108, "value" => "whitehall_training_required_none" },
         { "id" => 16_186_526_602_396, "value" => "whitehall_training_additional_apps_access_yes" },
         { "id" => 16_186_432_238_236, "value" => "Cabinet Office (CO)" },
+        { "id" => 18_626_967_621_276, "value" => "whitehall_training_writing_for_govuk_required_no" },
       ],
       "ticket_form_id" => 16_186_592_181_660,
     )
@@ -74,6 +78,7 @@ XXXX",
     choose "No, the user does not need to draft or publish content on Whitehall Publisher"
     choose "Yes, the user needs access to the applications and permissions listed below"
     fill_in "List any other publishing applications and permissions the user needs. If you’re not sure what these are, explain what tasks they need to be able to do.", with: "XXXX"
+    choose "No, the user does not need Writing for GOV.UK training"
 
     user_submits_the_request_successfully
 

--- a/spec/features/create_new_user_requests_spec.rb
+++ b/spec/features/create_new_user_requests_spec.rb
@@ -23,13 +23,13 @@ feature "Create new user requests" do
     ])
 
     ticket_request = expect_support_api_to_receive_raise_ticket(
-      "subject" => "Create a new user account",
+      "subject" => "Create a new user or request training",
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@agency.gov.uk"),
       "collaborators" => %w[bob@gov.uk],
       "tags" => %w[govt_form create_new_user],
       "description" =>
 "[Action]
-Create a new user account
+Create a new user or request training
 
 [Requested user's name]
 Bob Fields

--- a/spec/models/support/requests/create_new_user_request_spec.rb
+++ b/spec/models/support/requests/create_new_user_request_spec.rb
@@ -36,6 +36,13 @@ module Support
           .with_message("Select if the user needs access to other publishing apps")
       }
 
+      it {
+        should validate_inclusion_of(:writing_for_govuk_training)
+          .in_array(%w[whitehall_training_writing_for_govuk_required_yes whitehall_training_writing_for_govuk_required_no])
+          .allow_blank
+          .with_message("Select if the user needs Writing for GOV.UK training")
+      }
+
       context "when access to other publishing apps is required" do
         before { subject.access_to_other_publishing_apps = "whitehall_training_additional_apps_access_yes" }
 
@@ -95,6 +102,18 @@ module Support
         it "returns the human readable name for the no access option" do
           request = described_class.new(access_to_other_publishing_apps: "whitehall_training_additional_apps_access_no")
           expect(request.formatted_access_to_other_publishing_apps_option).to eq "No, the user does not need access to any other publishing application"
+        end
+      end
+
+      describe "#formatted_writing_for_govuk_training_option" do
+        it "returns the human readable name for the training required option" do
+          request = described_class.new(writing_for_govuk_training: "whitehall_training_writing_for_govuk_required_yes")
+          expect(request.formatted_writing_for_govuk_training_option).to eq "Yes, they need Writing for GOV.UK training"
+        end
+
+        it "returns the human readable name for the training not required option" do
+          request = described_class.new(writing_for_govuk_training: "whitehall_training_writing_for_govuk_required_no")
+          expect(request.formatted_writing_for_govuk_training_option).to eq "No, the user does not need Writing for GOV.UK training"
         end
       end
     end

--- a/spec/models/support/requests/create_new_user_request_spec.rb
+++ b/spec/models/support/requests/create_new_user_request_spec.rb
@@ -89,7 +89,7 @@ module Support
 
         it "returns the human readable name for the completed training option" do
           request = described_class.new(whitehall_training: "whitehall_training_completed")
-          expect(request.formatted_whitehall_training_option).to eq "They’ve completed training and need a Production account to access Whitehall Publisher"
+          expect(request.formatted_whitehall_training_option).to eq "They’ve completed training and need a Production account (new users only)"
         end
       end
 

--- a/spec/models/support/requests/create_new_user_request_spec.rb
+++ b/spec/models/support/requests/create_new_user_request_spec.rb
@@ -56,7 +56,7 @@ module Support
       end
 
       it "provides formatted action" do
-        expect(request.formatted_action).to eq("Create a new user account")
+        expect(request.formatted_action).to eq("Create a new user or request training")
       end
 
       describe "#formatted_new_or_existing_user_option" do

--- a/spec/models/support/requests/create_new_user_request_spec.rb
+++ b/spec/models/support/requests/create_new_user_request_spec.rb
@@ -15,6 +15,13 @@ module Support
       it { should allow_value("ab@c.com").for(:email) }
       it { should_not allow_value("ab").for(:email) }
 
+      it { should_not allow_values(nil, "").for(:new_or_existing_user) }
+      it {
+        should validate_inclusion_of(:new_or_existing_user)
+          .in_array(%w[whitehall_training_new_user whitehall_training_existing_user])
+          .with_message("Select if the user is new or existing")
+      }
+
       it { should_not allow_values(nil, "").for(:whitehall_training) }
       it {
         should validate_inclusion_of(:whitehall_training)
@@ -43,6 +50,18 @@ module Support
 
       it "provides formatted action" do
         expect(request.formatted_action).to eq("Create a new user account")
+      end
+
+      describe "#formatted_new_or_existing_user_option" do
+        it "returns the human readable name for the new user option" do
+          request = described_class.new(new_or_existing_user: "whitehall_training_new_user")
+          expect(request.formatted_new_or_existing_user_option).to eq "They’re a new user and do not have a Production account"
+        end
+
+        it "returns the human readable name for the existing user option" do
+          request = described_class.new(new_or_existing_user: "whitehall_training_existing_user")
+          expect(request.formatted_new_or_existing_user_option).to eq "They’re an existing user and already have a Production account"
+        end
       end
 
       describe "#formatted_whitehall_training_option" do

--- a/spec/models/zendesk/ticket/create_new_user_request_ticket_spec.rb
+++ b/spec/models/zendesk/ticket/create_new_user_request_ticket_spec.rb
@@ -13,12 +13,14 @@ module Zendesk
           request_ticket = ticket(
             name: "Bob Fields",
             email: "bob@gov.uk",
+            formatted_new_or_existing_user_option: "They’re a new user and do not have a Production account",
             formatted_whitehall_training_option: "No, the user does not need to draft or publish content on Whitehall Publisher",
             formatted_access_to_other_publishing_apps_option: "No, the user does not need access to any other publishing application",
           )
           expect(request_ticket.custom_fields).to eq([
             { "id" => 16_186_374_142_108, "value" => "Bob Fields" },
             { "id" => 16_186_377_836_316, "value" => "bob@gov.uk" },
+            { "id" => 18_626_821_668_764, "value" => "whitehall_training_new_user" },
             { "id" => 16_186_461_678_108, "value" => "whitehall_training_required_none" },
             { "id" => 16_186_526_602_396, "value" => "whitehall_training_additional_apps_access_no" },
           ])
@@ -29,12 +31,14 @@ module Zendesk
             name: "Bob Fields",
             email: "bob@gov.uk",
             organisation: "Cabinet Office (CO)",
+            formatted_new_or_existing_user_option: "They’re a new user and do not have a Production account",
             formatted_whitehall_training_option: "No, the user does not need to draft or publish content on Whitehall Publisher",
             formatted_access_to_other_publishing_apps_option: "No, the user does not need access to any other publishing application",
           )
           expect(request_ticket.custom_fields).to eq([
             { "id" => 16_186_374_142_108, "value" => "Bob Fields" },
             { "id" => 16_186_377_836_316, "value" => "bob@gov.uk" },
+            { "id" => 18_626_821_668_764, "value" => "whitehall_training_new_user" },
             { "id" => 16_186_461_678_108, "value" => "whitehall_training_required_none" },
             { "id" => 16_186_526_602_396, "value" => "whitehall_training_additional_apps_access_no" },
             { "id" => 16_186_432_238_236, "value" => "Cabinet Office (CO)" },

--- a/spec/models/zendesk/ticket/create_new_user_request_ticket_spec.rb
+++ b/spec/models/zendesk/ticket/create_new_user_request_ticket_spec.rb
@@ -4,7 +4,7 @@ module Zendesk
   module Ticket
     describe CreateNewUserRequestTicket do
       def ticket(opts = {})
-        defaults = { requester: nil, title: nil, organisation: nil }
+        defaults = { requester: nil, title: nil, organisation: nil, writing_for_govuk_training: nil }
         CreateNewUserRequestTicket.new(double(defaults.merge(opts)))
       end
 
@@ -34,6 +34,8 @@ module Zendesk
             formatted_new_or_existing_user_option: "They’re a new user and do not have a Production account",
             formatted_whitehall_training_option: "No, the user does not need to draft or publish content on Whitehall Publisher",
             formatted_access_to_other_publishing_apps_option: "No, the user does not need access to any other publishing application",
+            writing_for_govuk_training: "whitehall_training_writing_for_govuk_required_no",
+            formatted_writing_for_govuk_training_option: "No, the user does not need Writing for GOV.UK training",
           )
           expect(request_ticket.custom_fields).to eq([
             { "id" => 16_186_374_142_108, "value" => "Bob Fields" },
@@ -42,6 +44,7 @@ module Zendesk
             { "id" => 16_186_461_678_108, "value" => "whitehall_training_required_none" },
             { "id" => 16_186_526_602_396, "value" => "whitehall_training_additional_apps_access_no" },
             { "id" => 16_186_432_238_236, "value" => "Cabinet Office (CO)" },
+            { "id" => 18_626_967_621_276, "value" => "whitehall_training_writing_for_govuk_required_no" },
           ])
         end
       end


### PR DESCRIPTION
[Trello](https://trello.com/c/IN20Asaz/1634-updates-to-the-create-new-user-support-form)

This updates the create new user request form per a content team request. The main changes are two new questions, minor tweaks to existing copy, and fieldsets for grouping questions

I haven't updated the name of the files or classes here in order to keep things focused on the user-facing changes with minimal diff, but I have opened #1666 to do that as an optional extra

## Screenshots

### Before

![2025-04-01 17 57 38 support dev gov uk 323fb116c394](https://github.com/user-attachments/assets/75b4f31e-3c28-4e1e-9390-8e50b12483d0)

### After

![2025-04-02 08 56 30 support dev gov uk d6e084036fcc](https://github.com/user-attachments/assets/201c18f8-66c7-419c-a001-6e0e151e0dfe)