### PR TITLE
Update title and descriptions of content advice and request forms

### DIFF
--- a/app/models/support/requests/content_advice_request.rb
+++ b/app/models/support/requests/content_advice_request.rb
@@ -21,7 +21,7 @@ module Support
       end
 
       def self.description
-        "Ask for help or advice on any content problems. Request short URLs, topical event pages, groups or manuals."
+        "Ask for help or advice on any content problems. Request short URLs, topical event pages, groups or manuals and changes to content in history mode."
       end
     end
   end

--- a/app/models/support/requests/content_change_request.rb
+++ b/app/models/support/requests/content_change_request.rb
@@ -16,11 +16,11 @@ module Support
       end
 
       def self.label
-        "Request a content change or new content on GOV.UK"
+        "Request a content change or new content on mainstream GOV.UK content"
       end
 
       def self.description
-        "Request changes to GOV.UK content managed by GDS content designers"
+        "Request changes to 'mainstream' GOV.UK content managed by GDS content designers"
       end
 
       def self.reason_for_change_options

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -80,7 +80,7 @@ private
   def user_makes_a_content_change_request(details)
     visit "/"
 
-    click_on "Request a content change or new content on GOV.UK"
+    click_on "Request a content change or new content on mainstream GOV.UK content"
 
     expect(page).to have_content("You'll get an automated response to confirm we've received your request. We'll then review your request within 2 working days.")
 


### PR DESCRIPTION
This pull request:

- changes the description of the content advice support form to add 'changes to content in history mode' to the content
- changes the title of the 'Request a content change or new content on GOV.UK' form to make it clearer it for mainstream content
- updates description of the 'Request a content change or new content on GOV.UK' form

https://trello.com/c/PV0dNaXe

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
