### PR TITLE
Use release branch of `jquery-ui-rails`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "govuk_app_config"
 gem "govuk_publishing_components"
 gem "govuk_sidekiq"
 gem "gretel"
-gem "jquery-ui-rails", github: "jquery-ui-rails/jquery-ui-rails", tag: "v8.0.0" # https://github.com/jquery-ui-rails/jquery-ui-rails/pull/139#issuecomment-1768150544
+gem "jquery-ui-rails", github: "jquery-ui-rails/jquery-ui-rails", tag: "v8.0.0-release" # https://github.com/jquery-ui-rails/jquery-ui-rails/pull/139#issuecomment-1768150544
 gem "kaminari"
 gem "plek"
 gem "redis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/jquery-ui-rails/jquery-ui-rails.git
-  revision: f811a328324b4d937e26ae539cc6bbdfbf7830fd
-  tag: v8.0.0
+  revision: decd03951fecf845076df58728c2ae3fc1ab6d38
+  tag: v8.0.0-release
   specs:
-    jquery-ui-rails (7.0.0)
+    jquery-ui-rails (8.0.0)
       railties (>= 3.2.16)
 
 GEM


### PR DESCRIPTION
We are currently using release tag `v8.0.0` of `jquery-ui-rails`, which has the gem version specified as 7.0.0.

This means our `Gemfile.lock` contains 7.0.0 and therefore dependabot keeps raising PRs to attempt to upgrade it.

Switching instead to the `v8.0.0-release` branch, which actually bumps the gem version to 8.0.0.