### PR TITLE
Switch to RubyGems version of `jquery-ui-rails`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "govuk_app_config"
 gem "govuk_publishing_components"
 gem "govuk_sidekiq"
 gem "gretel"
-gem "jquery-ui-rails", github: "jquery-ui-rails/jquery-ui-rails", tag: "v8.0.0-release" # https://github.com/jquery-ui-rails/jquery-ui-rails/pull/139#issuecomment-1768150544
+gem "jquery-ui-rails"
 gem "kaminari"
 gem "plek"
 gem "redis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/jquery-ui-rails/jquery-ui-rails.git
-  revision: decd03951fecf845076df58728c2ae3fc1ab6d38
-  tag: v8.0.0-release
-  specs:
-    jquery-ui-rails (8.0.0)
-      railties (>= 3.2.16)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -250,6 +242,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (8.0.0)
+      railties (>= 3.2.16)
     json (2.12.0)
     jwt (2.10.1)
       base64
@@ -821,7 +815,7 @@ DEPENDENCIES
   govuk_sidekiq
   govuk_test
   gretel
-  jquery-ui-rails!
+  jquery-ui-rails
   kaminari
   listen
   plek


### PR DESCRIPTION
Version 8.0.0 of the `jquery-ui-rails` gem was not previously released to RubyGems, so we specified a tag for the GitHub repo.

This version is now available, so we can switch to using RubyGems instead.

[Trello card](https://trello.com/c/CB1AbcRK)