### PR TITLE
Remove Contacts Admin

### DIFF
--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -21,7 +21,6 @@ module Support
       # ("Conditions" -> "Tags" -> "Contains at least one of the following")
       OPTIONS = {
         "collections_publisher" => "Collections Publisher",
-        "contacts_admin" => "Contacts Admin",
         "content_data" => "Content Data",
         "content_tagger" => "Content Tagger",
         "datagovuk" => "data.gov.uk",


### PR DESCRIPTION
It's being retired

Trello: https://trello.com/c/MiBvG4Xs/3767-retire-contacts-admin

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
