### PR TITLE
[PP-7008] Add custom field for content requests form

### DIFF
--- a/app/models/zendesk/ticket/content_change_request_ticket.rb
+++ b/app/models/zendesk/ticket/content_change_request_ticket.rb
@@ -15,6 +15,7 @@ module Zendesk
         fields = [
           CustomField.set(id: 7_948_652_819_356, input: @request.reason_for_change),
           CustomField.set(id: 7_949_106_580_380, input: @request.subject_area),
+          CustomField.set(id: 19_824_287_274_012, input: @request.url),
         ]
         fields << CustomField.set(id: 7_949_136_091_548, input: needed_by_date) if needed_by_date
         fields << CustomField.set(id: 7_949_152_975_772, input: not_before_date) if not_before_date

--- a/config/zendesk/custom_fields_data.yml
+++ b/config/zendesk/custom_fields_data.yml
@@ -46,6 +46,9 @@
   name: "[CR] Do not publish before (time)"
   id: 8250075489052
 - !ruby/object:Zendesk::CustomFieldType::Text
+  name: "[CR] Which URLs are affected?"
+  id: 19824287274012
+- !ruby/object:Zendesk::CustomFieldType::Text
   name: "[Whitehall training] User's name"
   id: 16186374142108
 - !ruby/object:Zendesk::CustomFieldType::Text

--- a/spec/features/content_change_requests_spec.rb
+++ b/spec/features/content_change_requests_spec.rb
@@ -47,6 +47,7 @@ New law",
       "custom_fields" =>
            [{ "id" => 7_948_652_819_356, "value" => "cr_inaccuracy" },
             { "id" => 7_949_106_580_380, "value" => "cr_benefits" },
+            { "id" => 19_824_287_274_012, "value" => "http://gov.uk/X" },
             { "id" => 7_949_136_091_548, "value" => "#{next_year}-12-31" },
             { "id" => 7_949_152_975_772, "value" => "#{next_year}-12-01" },
             { "id" => 8_250_061_570_844, "value" => "13:00" },

--- a/spec/models/zendesk/ticket/content_change_request_ticket_spec.rb
+++ b/spec/models/zendesk/ticket/content_change_request_ticket_spec.rb
@@ -28,10 +28,12 @@ module Zendesk
         request_ticket = ticket(
           reason_for_change: "Factual inaccuracy",
           subject_area: "Benefits",
+          url: "https://www.gov.uk",
         )
         expect(request_ticket.custom_fields).to eq([
           { "id" => 7_948_652_819_356, "value" => "cr_inaccuracy" },
           { "id" => 7_949_106_580_380, "value" => "cr_benefits" },
+          { "id" => 19_824_287_274_012, "value" => "https://www.gov.uk" },
         ])
       end
 
@@ -39,6 +41,7 @@ module Zendesk
         request_ticket = ticket(
           reason_for_change: "Factual inaccuracy",
           subject_area: "Benefits",
+          url: "https://www.gov.uk",
           time_constraint: OpenStruct.new(
             needed_by_date: "15-09-2023",
             not_before_date: "10-09-2023",
@@ -49,6 +52,7 @@ module Zendesk
         expect(request_ticket.custom_fields).to eq([
           { "id" => 7_948_652_819_356, "value" => "cr_inaccuracy" },
           { "id" => 7_949_106_580_380, "value" => "cr_benefits" },
+          { "id" => 19_824_287_274_012, "value" => "https://www.gov.uk" },
           { "id" => 7_949_136_091_548, "value" => "2023-09-15" },
           { "id" => 7_949_152_975_772, "value" => "2023-09-10" },
           { "id" => 8_250_061_570_844, "value" => "09:00" },


### PR DESCRIPTION
Content Support have requested that the 'Which URLs are affected?' field on the content requests form should map to a custom Zendesk field.

This field has been set up in Zendesk by User Support with the ID 19824287274012.

Therefore adding this mapping into the request form.