### PR TITLE
Add note about checking status page first

### DIFF
--- a/app/views/support/emergency_contact_details.html.erb
+++ b/app/views/support/emergency_contact_details.html.erb
@@ -72,7 +72,8 @@
     <h2 id="report-problem">Report a major technical problem with GOV.UK</h2>
     <div class="row">
       <div class="col-md-6">
-        <p>Use only for critical, high-profile technical issues with the GOV.UK site - such as pages not loading or search not working.</p>
+        <p>Use only for critical, high-profile technical issues with the GOV.UK site - such as pages not loading or search not working. Before reporting a problem,
+        please check <%= link_to "the GOV.UK status page", "https://status.publishing.service.gov.uk/" %> to see if the problem is already being dealt with.</p>
       </div>
     </div>
     <div class="row add-bottom-padding add-top-padding">


### PR DESCRIPTION
This asks the user to check GOV.UK's statuspage before contacting the on-call team. This might save them a call, reassure them that the issue is being dealt with, and reduce distractions for the team. 


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
