### PR TITLE
[PP-7296] Design systemise change user form

### DIFF
--- a/app/controllers/change_existing_user_requests_controller.rb
+++ b/app/controllers/change_existing_user_requests_controller.rb
@@ -1,4 +1,9 @@
 class ChangeExistingUserRequestsController < RequestsController
+  def new
+    @use_design_system = true
+    super
+  end
+
 protected
 
   def new_request

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,9 +1,13 @@
 require "sidekiq/api"
 
 class RequestsController < AuthorisationController
+  include ErrorsHelper
+
   def new
     @request = new_request
     authorize! :new, @request
+
+    render :new, layout: "design_system" if @use_design_system
   end
 
   def create
@@ -20,8 +24,13 @@ class RequestsController < AuthorisationController
     else
       respond_to do |format|
         format.html do
-          flash.now[:alert] = @request.errors.full_messages.join('\n')
-          render :new, status: :bad_request
+          if params[:use_design_system]
+            @use_design_system = true
+            render :new, status: :bad_request, layout: "design_system"
+          else
+            flash.now[:alert] = @request.errors.full_messages.join('\n')
+            render :new, status: :bad_request
+          end
         end
         format.json { render json: { "errors" => @request.errors.to_a }, status: :bad_request }
       end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -18,7 +18,17 @@ class RequestsController < AuthorisationController
     if @request.valid?
       save_to_zendesk(@request)
       respond_to do |format|
-        format.html { redirect_to acknowledge_path }
+        format.html do
+          if params[:use_design_system]
+            flash[:success_alert] = {
+              message: "Thank you!",
+              description: "Thanks for sending us your request. We'll review your request and get back to you within 2 working days.",
+            }
+            redirect_to root_path
+          else
+            redirect_to acknowledge_path
+          end
+        end
         format.json { head :created }
       end
     else

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -1,0 +1,12 @@
+module ErrorsHelper
+  def errors_for(errors, attribute)
+    return nil if errors.blank?
+
+    errors.filter_map { |error|
+      if error.attribute == attribute
+        { text: error.full_message }
+      end
+    }
+    .presence
+  end
+end

--- a/app/views/change_existing_user_requests/_request_details.html.erb
+++ b/app/views/change_existing_user_requests/_request_details.html.erb
@@ -1,54 +1,48 @@
-<p><%= f.object.class.description %></p>
+<p class="govuk-body"><%= f.object.class.description %></p>
 
-<div class="alert alert-info alert-block">
-  <p>
-    You do not need to submit a request if you're a super organisation admin or organisation admin and you're requesting to:
-    <ul>
-    <li>change an account's permissions for a 'devolved' application, including upgrading an account to 'editor' in Whitehall Publisher</li>
+<%= render "govuk_publishing_components/components/inset_text", {} do %>
+  <p class="govuk-body">
+    You do not need to submit a request if you're a super organisation admin or
+    organisation admin and you're requesting to:
+  </p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>
+      change an account's permissions for a 'devolved' application, including
+      upgrading an account to 'editor' in Whitehall Publisher
+    </li>
     <li>reset 2-step verification for an account</li>
     <li>unsuspend an account</li>
     <li>resend a signup ('account invitation') email for an account</li>
-    </ul>
-    <br>
-    Find out <%= link_to 'how to manage your organisation’s accounts in the "Introduction and access to Whitehall publisher" guidance', 'https://www.gov.uk/guidance/how-to-publish-on-gov-uk/introduction-and-access-to-whitehall-publisher#manage-your-organisations-accounts' %>.
+  </ul>
+  <p class="govuk-body">
+    Find out
+    <%= link_to 'how to manage your organisation’s accounts in the "Introduction and access to Whitehall publisher" guidance',
+      "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/introduction-and-access-to-whitehall-publisher#manage-your-organisations-accounts",
+      class: "govuk-link"
+    %>.
   </p>
-</div>
+<% end %>
 
-<div class="row">
-  <div class="col-md-6">
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :name do %>
-          User's name<abbr title="required">*</abbr>
-        <% end %>
-      </span>
-      <span class="form-wrapper">
-        <%= f.text_field :name, required: true, aria: { required: true }, class: "form-control" %>
-      </span>
-    </div>
+<%= render "govuk_publishing_components/components/input", {
+  label: { text: "User's name (required)" },
+  name: "support_requests_change_existing_user_request[name]",
+  width: 20,
+  error_items: errors_for(@request.errors, :name)
+} %>
 
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :email do %>
-          User's email<abbr title="required">*</abbr>
-        <% end %>
-      </span>
-      <span class="form-wrapper">
-        <%= f.email_field :email, required: true, aria: { required: true }, class: "form-control" %>
-      </span>
-    </div>
+<%= render "govuk_publishing_components/components/input", {
+  label: { text: "User's email (required)" },
+  name: "support_requests_change_existing_user_request[email]",
+  width: 20,
+  error_items: errors_for(@request.errors, :email)
+} %>
 
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :additional_comments do %>
-          What do you want to change?<abbr title="required">*</abbr>
-        <% end %>
-      </span>
-      <span class="form-wrapper">
-        <%= f.text_area :additional_comments, required: true, aria: { required: true }, class: "input-md-6 form-control", rows: 6, cols: 50 %>
-      </span>
-    </div>
+<%= render "govuk_publishing_components/components/textarea", {
+  label: { text: "What do you want to change? (required)" },
+  name: "support_requests_change_existing_user_request[additional_comments]",
+  error_items: errors_for(@request.errors, :additional_comments)
+} %>
 
-    <%= render partial: "support/collaborators", locals: { f: f } %>
-  </div>
-</div>
+<%= render partial: "support/collaborators", locals: { f: f } %>
+
+<%= hidden_field_tag "use_design_system", true %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -25,6 +25,11 @@
     <main class="govuk-main-wrapper" id="main-content" role="main">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
+          <% if flash[:success_alert] %>
+            <%= render "govuk_publishing_components/components/success_alert",
+              flash[:success_alert].symbolize_keys
+            %>
+          <% end %>
           <h1 class="govuk-heading-xl">
             <%= yield(:header) %>
           </h1>

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -6,5 +6,11 @@
 <%= form_for @request, url: { action: "create" }, html: { novalidate: false } do |f| %>
   <%= render partial: "request_details", locals: { f: f } %>
 
-  <%= f.submit value: "Submit", class: "btn btn-success" %>
+  <% if @use_design_system %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Submit"
+    } %>
+  <% else %>
+    <%= f.submit value: "Submit", class: "btn btn-success" %>
+  <% end %>
 <% end %>

--- a/app/views/support/_collaborators.html.erb
+++ b/app/views/support/_collaborators.html.erb
@@ -1,15 +1,24 @@
 <%= f.fields_for :requester do |r| %>
-  <div class="form-group">
-    <span class="form-label">
-      <%= r.label :collaborator_emails, "Who needs a copy of this request?" %>
-    </span>
-    <p class="help-block hint-block--md-6" id="collaborators-hint">
-      Separate email addresses with commas.
-    </p>
-    <span class="form-wrapper">
-      <%= r.text_field :collaborator_emails, required: false, class: "input-md-6 form-control", value: r.object.collaborator_emails.join(", "), aria: {
-        describedby: "collaborators-hint"
-      } %>
-    </span>
-  </div>
+  <% if @use_design_system %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: { text: "Who needs a copy of this request?" },
+      hint: "Separate email addresses with commas.",
+      value: r.object.collaborator_emails.join(", "),
+      name: "support_requests_change_existing_user_request[requester_attributes][collaborator_emails]"
+    } %>
+  <% else %>
+    <div class="form-group">
+      <span class="form-label">
+        <%= r.label :collaborator_emails, "Who needs a copy of this request?" %>
+      </span>
+      <p class="help-block hint-block--md-6" id="collaborators-hint">
+        Separate email addresses with commas.
+      </p>
+      <span class="form-wrapper">
+        <%= r.text_field :collaborator_emails, required: false, class: "input-md-6 form-control", value: r.object.collaborator_emails.join(", "), aria: {
+          describedby: "collaborators-hint"
+        } %>
+      </span>
+    </div>
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,16 @@ en:
   activemodel:
     errors:
       models:
+        support/requests/change_existing_user_request:
+          format: '%{message}'
+          attributes:
+            name:
+              blank: Enter a name
+            email:
+              blank: Enter an email address
+              invalid: Enter an email address in the correct format, like name@example.com
+            additional_comments:
+              blank: Provide details of what you want to change
         support/requests/create_new_user_or_training_request:
           format: '%{message}'
           attributes:

--- a/spec/helpers/errors_helper_spec.rb
+++ b/spec/helpers/errors_helper_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe ErrorsHelper, type: :helper do
+  include ErrorsHelper
+
+  describe "#errors_for" do
+    before do
+      @object_with_no_errors = ErrorTestObject.new("title", Time.zone.today)
+      @object_with_errors = ErrorTestObject.new(nil, nil)
+      @object_with_unrelated_errors = ErrorTestObject.new("title", nil)
+      @object_with_no_errors.validate
+      @object_with_errors.validate
+      @object_with_unrelated_errors.validate
+    end
+
+    it "returns errors in a govuk_publishing_components error_items format" do
+      expect(@object_with_errors.errors[:title].count).to eq(1)
+
+      result = errors_for(@object_with_errors.errors, :title)
+      expect(result).to eq([{ text: "Title can't be blank" }])
+    end
+
+    it "returns all errors when there are multiple" do
+      expect(@object_with_errors.errors[:date].count).to eq(2)
+
+      result = errors_for(@object_with_errors.errors, :date)
+      expect(result).to eq([
+        { text: "Date can't be blank" },
+        { text: "Date is invalid" },
+      ])
+    end
+
+    it "returns nil when there are unrelated errors" do
+      expect(@object_with_unrelated_errors.errors).not_to be_blank
+
+      result = errors_for(@object_with_unrelated_errors.errors, :title)
+      expect(result).to be_nil
+    end
+
+    it "returns nil when there are no errors" do
+      expect(@object_with_no_errors.errors).to be_blank
+
+      result = errors_for(@object_with_no_errors.errors, :title)
+      expect(result).to be_nil
+    end
+  end
+end
+
+class ErrorTestObject
+  include ActiveModel::Model
+  attr_accessor :title, :date
+
+  validates :title, :date, presence: true
+  validate :date_is_a_date
+
+  def initialize(title, date)
+    @title = title
+    @date = date
+  end
+
+  def date_is_a_date
+    errors.add(:date, :invalid) unless date.is_a?(Date)
+  end
+end


### PR DESCRIPTION
- Add support for using the Design System for request forms (all but the last commit)
- Use the Design System for the "Change an existing user's account" form (final commit)

The former could be its own PR, but it probably makes more sense with the added context of the final commit

## Screen captures

<img width="2352" height="3220" alt="image" src="https://github.com/user-attachments/assets/ad27eee8-9d79-4f5b-8e94-e9a1a3817a41" />

https://github.com/user-attachments/assets/fe4819e2-5ddb-4e00-872c-a7ab80e5dc52

