### PR TITLE
[SCH-620] Update 'Report an issue with GOV.UK search results' support form

### DIFF
--- a/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
+++ b/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
@@ -1,4 +1,10 @@
-<p>GOV.UK is introducing a new search engine to power <%= link_to "GOV.UK site search", "https://www.gov.uk/search/all" %>. The search engine will continue to learn and improve over time, making search results more relevant.</p>
+<p>GOV.UK site search learns from how people use it, so search results change and improve over time. A page not appearing high in results today may appear higher in the future. </p>
+<p>In most cases, the search engine will deliver highly relevant results without manual changes. However, there may be occasions where we need to step in to make sure certain pages appear higher or lower in results.</p>
+<p>If you think this is needed, use this form to tell the GOV.UK search team about issues with search results that might stop users finding what they need. For example:</p>
+<ul>
+  <li>Important pages that should appear near the top of search results but are too low</li>
+  <li>Pages not appearing in search results at all</li>
+</ul>
 
 <div id="feedback-type">
   <div class="form-group">

--- a/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
+++ b/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
@@ -1,11 +1,3 @@
-<div class="alert alert-info">
-  <p>Only use this form to report problems with specific GOV.UK site search results. Do not use this form for general feedback on the new GOV.UK search engine.</p>
-  <p>
-    Use <%= link_to "this tool to give general feedback on search results", "https://try-new-search-engine.publishing.service.gov.uk" %>.
-    This uses the standard login details for GOV.UK product testing or contact <%= mail_to "try-new-search-engine@digital.cabinet-office.gov.uk" %> for a login.
-  </p>
-</div>
-
 <p>GOV.UK is introducing a new search engine to power <%= link_to "GOV.UK site search", "https://www.gov.uk/search/all" %>. The search engine will continue to learn and improve over time, making search results more relevant.</p>
 
 <div id="feedback-type">


### PR DESCRIPTION
# What's changed and why?

Re-route the form to the Web Support group instead of the Performance Analytics group and remove the blue banner at the top of the form, which linked to the old evaluation tool.

# Expected changes

## Before
<img width="1219" height="429" alt="Screenshot 2025-09-01 at 14 29 18" src="https://github.com/user-attachments/assets/e2b2f9f0-5c07-4bf7-b917-356996bd59da" />

## After

<img width="1219" height="429" alt="Screenshot 2025-09-01 at 16 14 38" src="https://github.com/user-attachments/assets/b75b2b42-8f8a-46b1-811b-4f6fbcf191e3" />


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
