### PR TITLE
Add "Fact Check Manager" option to Technical Fault Report

### DIFF
--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -24,6 +24,7 @@ module Support
         "content_data" => "Content Data",
         "content_tagger" => "Content Tagger",
         "email_alerts" => "Email alerts",
+        "fact_check_manager" => "Fact Check Manager",
         "feedback_explorer" => "Feedback explorer",
         "gov_uk_content" => "GOV.UK: content",
         "local_links_manager" => "Local Links Manager",


### PR DESCRIPTION
Zendesk will be configured separately to triage these tickets, following the comment at the top of this file.
