### PR TITLE
Add supporting content to content advice requests form

### DIFF
--- a/app/views/content_advice_requests/_request_details.html.erb
+++ b/app/views/content_advice_requests/_request_details.html.erb
@@ -1,5 +1,22 @@
 <p class="govuk-body"><%= f.object.class.description %></p>
 
+<%= render "govuk_publishing_components/components/inset_text", {} do %>
+  <p class="govuk-body">
+    Check what you need to include if you’re requesting:
+  </p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li><%= link_to "a short URL", "https://guidance.publishing.service.gov.uk/accounts-support/make-content-requests/ask-short-url/" %></li>
+    <li><%= link_to "an organisation or sub-organisation page", "https://guidance.publishing.service.gov.uk/accounts-support/make-content-requests/ask-new-organisation/" %></li>
+    <li><%= link_to "a group page", "https://guidance.publishing.service.gov.uk/publish-update-retire-content/organisations-people/groups/" %></li>
+    <li><%= link_to "a topical event page", "https://guidance.publishing.service.gov.uk/publish-update-retire-content/promotional-social/topical-events/" %></li>
+    <li><%= link_to "a manual", "https://guidance.publishing.service.gov.uk/publish-update-retire-content/other-content-types/manuals/" %></li>
+  </ul>
+  <p class="govuk-body">
+    If your request is about 'mainstream' GOV.UK content managed by GDS content designers, use the 
+    <%= link_to "‘request a content change or new content on mainstream GOV.UK content’ form", new_content_change_request_path %>.
+  </p>
+<% end %>
+
 <%= render "govuk_publishing_components/components/input", {
   label: { text: "Title of request" },
   hint: "For example, \"Advice on content\"",


### PR DESCRIPTION
This pull request adds supporting content to the content advice and help form to direct publishers to check guidance for what they need to include in their request.

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
