### PR TITLE
Add link class to correct style

### DIFF
--- a/app/views/content_advice_requests/_request_details.html.erb
+++ b/app/views/content_advice_requests/_request_details.html.erb
@@ -5,15 +5,15 @@
     Check what you need to include if you’re requesting:
   </p>
   <ul class="govuk-list govuk-list--bullet">
-    <li><%= link_to "a short URL", "https://guidance.publishing.service.gov.uk/accounts-support/make-content-requests/ask-short-url/" %></li>
-    <li><%= link_to "an organisation or sub-organisation page", "https://guidance.publishing.service.gov.uk/accounts-support/make-content-requests/ask-new-organisation/" %></li>
-    <li><%= link_to "a group page", "https://guidance.publishing.service.gov.uk/publish-update-retire-content/organisations-people/groups/" %></li>
-    <li><%= link_to "a topical event page", "https://guidance.publishing.service.gov.uk/publish-update-retire-content/promotional-social/topical-events/" %></li>
-    <li><%= link_to "a manual", "https://guidance.publishing.service.gov.uk/publish-update-retire-content/other-content-types/manuals/" %></li>
+    <li><%= link_to "a short URL", "https://guidance.publishing.service.gov.uk/accounts-support/make-content-requests/ask-short-url/", class: "govuk-link" %></li>
+    <li><%= link_to "an organisation or sub-organisation page", "https://guidance.publishing.service.gov.uk/accounts-support/make-content-requests/ask-new-organisation/", class: "govuk-link" %></li>
+    <li><%= link_to "a group page", "https://guidance.publishing.service.gov.uk/publish-update-retire-content/organisations-people/groups/", class: "govuk-link" %></li>
+    <li><%= link_to "a topical event page", "https://guidance.publishing.service.gov.uk/publish-update-retire-content/promotional-social/topical-events/", class: "govuk-link" %></li>
+    <li><%= link_to "a manual", "https://guidance.publishing.service.gov.uk/publish-update-retire-content/other-content-types/manuals/", class: "govuk-link" %></li>
   </ul>
   <p class="govuk-body">
     If your request is about 'mainstream' GOV.UK content managed by GDS content designers, use the 
-    <%= link_to "‘request a content change or new content on mainstream GOV.UK content’ form", new_content_change_request_path %>.
+    <%= link_to "‘request a content change or new content on mainstream GOV.UK content’ form", new_content_change_request_path, class: "govuk-link" %>.
   </p>
 <% end %>
 


### PR DESCRIPTION
While GOV.UK Publishing Components add link styling automatically within certain contexts, it doesn't appear to happen here.
