### PR TITLE
[PP-7765] Display error messages in Feedback Explorer form

### DIFF
--- a/app/controllers/anonymous_feedback/explore_controller.rb
+++ b/app/controllers/anonymous_feedback/explore_controller.rb
@@ -30,6 +30,7 @@ class AnonymousFeedback::ExploreController < AuthorisationController
       redirect_to @explore.redirect_path
     else
       new
+      flash.now[:alert] = @explore.errors.full_messages.join('\n')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/models/support/requests/anonymous/explore.rb
+++ b/app/models/support/requests/anonymous/explore.rb
@@ -62,12 +62,12 @@ module Support
             uri = URI.parse(path_or_url)
             valid = !uri.path.nil?
             if list_of_urls.present?
-              errors.add(:list_of_urls, "#{path_or_url} is not valid. Must contain only valid URLs") unless valid
+              errors.add(:list_of_urls, "#{path_or_url} is not a URL in the correct format. Enter only URLs and separate them with commas.") unless valid
             else
-              errors.add(:uploaded_list, "#{path_or_url} is not valid. Must contain only valid URLs") unless valid
+              errors.add(:uploaded_list, "#{path_or_url} is not a URL in the correct format. Enter only URLs and separate them with commas.") unless valid
             end
           rescue URI::InvalidURIError
-            errors.add(:base, "#{path_or_url} is not valid. Must contain only valid URLs")
+            errors.add(:base, "\"#{path_or_url}\" is not a URL in the correct format. Enter only URLs and separate them with commas.")
           end
         end
       end

--- a/spec/controllers/anonymous_feedback/explore_controller_spec.rb
+++ b/spec/controllers/anonymous_feedback/explore_controller_spec.rb
@@ -26,10 +26,20 @@ describe AnonymousFeedback::ExploreController, type: :controller do
     login_as create(:user, organisation_slug: "cabinet-office")
   end
 
-  it "shows the new form again for invalid requests" do
+  it "shows the new form again with an error message for invalid requests" do
     post :create, params: { support_requests_anonymous_explore_by_multiple_paths: { list_of_urls: "" } }
     expect(response).to have_http_status(422)
     expect(assigns(:explore_by_multiple_paths)).to be_present
+    expect(flash[:alert]).to eq "Please provide a valid list of urls."
+  end
+
+  it "shows the new form again with an error message for invalid url" do
+    post :create, params: { support_requests_anonymous_explore_by_multiple_paths: {
+      uploaded_list: fixture_file_upload(Rails.root.join("spec/fixtures/list_of_bad_urls.csv"), "text/plain"),
+    } }
+    expect(response).to have_http_status(422)
+    expect(assigns(:explore_by_multiple_paths)).to be_present
+    expect(flash[:alert]).to include "is not a URL in the correct format"
   end
 
   it "shows the new form again for invalid organisation requests" do

--- a/spec/models/support/requests/anonymous/explore_by_multiple_paths_spec.rb
+++ b/spec/models/support/requests/anonymous/explore_by_multiple_paths_spec.rb
@@ -8,9 +8,9 @@ module Support
         it { should allow_value("https://www.gov.uk/test").for(:list_of_urls) }
         it { should allow_value("/vat-rates, https://www.gov.uk/bank-holidays, /guidance/").for(:list_of_urls) }
         it { should allow_value(fixture_file_upload(Rails.root.join("spec/fixtures/list_of_urls.csv"), "text/plain")).for(:uploaded_list) }
-        it { should_not allow_value("https:aaaa").for(:list_of_urls).with_message("https:aaaa is not valid. Must contain only valid URLs") }
-        it { should_not allow_value("/vat-rates, https:aaaa, /guidance/").for(:list_of_urls).with_message("https:aaaa is not valid. Must contain only valid URLs") }
-        it { should_not allow_value(fixture_file_upload(Rails.root.join("spec/fixtures/list_of_bad_urls.csv"), "text/plain")).for(:uploaded_list).with_message("https:aaaa is not valid. Must contain only valid URLs") }
+        it { should_not allow_value("https:aaaa").for(:list_of_urls).with_message("https:aaaa is not a URL in the correct format. Enter only URLs and separate them with commas.") }
+        it { should_not allow_value("/vat-rates, https:aaaa, /guidance/").for(:list_of_urls).with_message("https:aaaa is not a URL in the correct format. Enter only URLs and separate them with commas.") }
+        it { should_not allow_value(fixture_file_upload(Rails.root.join("spec/fixtures/list_of_bad_urls.csv"), "text/plain")).for(:uploaded_list).with_message("https:aaaa is not a URL in the correct format. Enter only URLs and separate them with commas.") }
 
         it "raises an error if `uploaded_list` and `list_of_urls` are blank" do
           @explore_by_multiple_paths = ExploreByMultiplePaths.new(uploaded_list: nil, list_of_urls: nil)


### PR DESCRIPTION
When a user provides an invalid list of URLs or uploads an invalid file, no error message was displayed. This will help users can take a corrective action before contacting us via support.

It updates the wording to confirm to the Design Standard "Tell the user what’s gone wrong and how to fix it." 
https://design-system.service.gov.uk/patterns/validation/


<kbd><img width="714" height="797" alt="Screenshot 2026-06-01 at 20 27 32" src="https://github.com/user-attachments/assets/8dcf7a2d-e265-4cd9-a8f4-9adffb406c87" /></kbd>
