### PR TITLE
Update GTM container ID [WHIT-3365]

### DIFF
--- a/app/assets/javascripts/domain-config.js
+++ b/app/assets/javascripts/domain-config.js
@@ -6,7 +6,7 @@ window.GOVUK.vars.extraDomains = [
     name: 'production',
     domains: ['support.publishing.service.gov.uk'],
     initialiseGA4: true,
-    id: 'GTM-P93SHJ4Z'
+    id: 'GTM-KHZP7S7Q'
   },
   {
     name: 'staging',
@@ -17,7 +17,7 @@ window.GOVUK.vars.extraDomains = [
     name: 'integration',
     domains: ['support.integration.publishing.service.gov.uk'],
     initialiseGA4: true,
-    id: 'GTM-P93SHJ4Z',
+    id: 'GTM-KHZP7S7Q',
     auth: '8jHx-VNEguw67iX9TBC6_g',
     preview: 'env-50'
   }


### PR DESCRIPTION
## What

Update the GTM container ID

## Why

Request from PAs

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
