### PR TITLE
Remove job/worker aliases

### DIFF
--- a/app/sidekiq/zendesk_ticket_job.rb
+++ b/app/sidekiq/zendesk_ticket_job.rb
@@ -27,5 +27,3 @@ private
 
   class TicketNameTooLong < StandardError; end
 end
-
-ZendeskTicketWorker = ZendeskTicketJob ## TODO: Remove once queued jobs at the time of the upgrade are complete


### PR DESCRIPTION
These were added in de02541c726313aaee8b4916de2bf8cf3818f2d2 when the workers were renamed to jobs, so the enqueued jobs would not fail when the class was renamed.

They can now be removed as all the enqueued jobs would have finished a long time ago.