### PR TITLE
Sch 1997 improve the search support form

### DIFF
--- a/app/controllers/report_an_issue_with_govuk_search_results_requests_controller.rb
+++ b/app/controllers/report_an_issue_with_govuk_search_results_requests_controller.rb
@@ -19,6 +19,7 @@ protected
       :results_problem,
       :change_requested,
       :change_justification,
+      :evidence_availability,
     ).to_h
   end
 end

--- a/app/controllers/report_an_issue_with_govuk_search_results_requests_controller.rb
+++ b/app/controllers/report_an_issue_with_govuk_search_results_requests_controller.rb
@@ -20,6 +20,7 @@ protected
       :change_requested,
       :change_justification,
       :evidence_availability,
+      :evidence_description,
     ).to_h
   end
 end

--- a/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
+++ b/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
@@ -5,7 +5,6 @@ module Support
 
       validates :search_query, presence: true
       validates :results_problem, presence: true
-      validates :change_justification, presence: true
 
       def self.label
         "Report an issue with GOV.UK search results"

--- a/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
+++ b/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
@@ -1,7 +1,7 @@
 module Support
   module Requests
     class ReportAnIssueWithGovukSearchResultsRequest < Request
-      attr_accessor :search_query, :results_problem, :change_requested, :change_justification, :evidence_availability
+      attr_accessor :search_query, :results_problem, :change_requested, :change_justification, :evidence_availability, :evidence_description
 
       validates :search_query, presence: true
       validates :results_problem, presence: true

--- a/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
+++ b/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
@@ -5,7 +5,6 @@ module Support
 
       validates :search_query, presence: true
       validates :results_problem, presence: true
-      validates :change_requested, presence: true
       validates :change_justification, presence: true
 
       def self.label

--- a/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
+++ b/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
@@ -13,7 +13,7 @@ module Support
       end
 
       def self.description
-        "Report a problem with specific search results from the new GOV.UK search engine."
+        "Report a problem or request a change to search results on GOV.UK."
       end
     end
   end

--- a/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
+++ b/app/models/support/requests/report_an_issue_with_govuk_search_results_request.rb
@@ -1,10 +1,23 @@
 module Support
   module Requests
     class ReportAnIssueWithGovukSearchResultsRequest < Request
-      attr_accessor :search_query, :results_problem, :change_requested, :change_justification
+      attr_accessor :search_query, :results_problem, :change_requested, :change_justification, :evidence_availability
 
       validates :search_query, presence: true
       validates :results_problem, presence: true
+      validates :evidence_availability, inclusion: { in: %w[yes no not_sure] }
+
+      def formatted_evidence_availability
+        Hash[evidence_availability_options].key(evidence_availability)
+      end
+
+      def evidence_availability_options
+        [
+          ["Yes – using analytics data (for example Google Analytics)", "yes"],
+          ["No", "no"],
+          ["Not sure", "not_sure"],
+        ]
+      end
 
       def self.label
         "Report an issue with GOV.UK search results"

--- a/app/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket.rb
+++ b/app/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket.rb
@@ -15,7 +15,7 @@ module Zendesk
         [
           Zendesk::LabelledSnippet.new(on: @request, field: :search_query, label: "What search queries are not working well?"),
           Zendesk::LabelledSnippet.new(on: @request, field: :results_problem, label: "What is the problem with the search results?"),
-          Zendesk::LabelledSnippet.new(on: @request, field: :change_requested, label: "What change do you want to make to the search results?"),
+          Zendesk::LabelledSnippet.new(on: @request, field: :change_requested, label: "Which pages are showing incorrectly and how should they be changed?"),
           Zendesk::LabelledSnippet.new(on: @request, field: :change_justification, label: "Why is this change necessary?"),
         ]
       end

--- a/app/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket.rb
+++ b/app/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket.rb
@@ -13,7 +13,7 @@ module Zendesk
 
       def comment_snippets
         [
-          Zendesk::LabelledSnippet.new(on: @request, field: :search_query, label: "What search query did you use?"),
+          Zendesk::LabelledSnippet.new(on: @request, field: :search_query, label: "What search queries are not working well?"),
           Zendesk::LabelledSnippet.new(on: @request, field: :results_problem, label: "What is the problem with the search results?"),
           Zendesk::LabelledSnippet.new(on: @request, field: :change_requested, label: "What change do you want to make to the search results?"),
           Zendesk::LabelledSnippet.new(on: @request, field: :change_justification, label: "Why is this change necessary?"),

--- a/app/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket.rb
+++ b/app/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket.rb
@@ -18,6 +18,7 @@ module Zendesk
           Zendesk::LabelledSnippet.new(on: @request, field: :change_requested, label: "Which pages are showing incorrectly and how should they be changed?"),
           Zendesk::LabelledSnippet.new(on: @request, field: :change_justification, label: "Why is this change necessary?"),
           Zendesk::LabelledSnippet.new(on: @request, field: :formatted_evidence_availability, label: "Is there evidence that users are searching for these queries?"),
+          Zendesk::LabelledSnippet.new(on: @request, field: :evidence_description, label: "What is the evidence that users are searching for these queries?"),
         ]
       end
     end

--- a/app/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket.rb
+++ b/app/models/zendesk/ticket/report_an_issue_with_govuk_search_results_request_ticket.rb
@@ -17,6 +17,7 @@ module Zendesk
           Zendesk::LabelledSnippet.new(on: @request, field: :results_problem, label: "What is the problem with the search results?"),
           Zendesk::LabelledSnippet.new(on: @request, field: :change_requested, label: "Which pages are showing incorrectly and how should they be changed?"),
           Zendesk::LabelledSnippet.new(on: @request, field: :change_justification, label: "Why is this change necessary?"),
+          Zendesk::LabelledSnippet.new(on: @request, field: :formatted_evidence_availability, label: "Is there evidence that users are searching for these queries?"),
         ]
       end
     end

--- a/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
+++ b/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
@@ -49,11 +49,11 @@
   <div class="form-group">
     <span class="form-label">
       <%= f.label :change_justification do %>
-        Explain why this change is necessary, including the impact on users and the number of users affected.
+        If applicable, explain why this change is necessary. Why are the current search results bad for users?
       <% end %>
     </span>
     <span class="form-wrapper">
-      <%= f.text_area :change_justification, required: true, aria: { required: true }, class: "input-md-6 form-control", rows: 6, cols: 50 %>
+      <%= f.text_area :change_justification, class: "input-md-6 form-control", rows: 6, cols: 50 %>
     </span>
   </div>
 </div>

--- a/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
+++ b/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
@@ -13,7 +13,7 @@
         What search queries are not working well?<abbr title="required">*</abbr>
       <% end %>
     </span>
-    <p class="help-block" id="query-hint">
+    <p class="help-block hint-block--md-6" id="query-hint">
       Include the exact words users type into search. You can include more than one query (for example: universal credit payment, UC payment).
     </p>
     <span class="form-wrapper">
@@ -34,7 +34,7 @@
 
   <div class="form-group">
     <span class="form-label">
-      <%= f.label :change_requested do %>
+      <%= f.label :change_requested, class: "hint-block--md-6" do %>
         If applicable, which pages are missing, or showing too high or low in results? If the pages are showing do you think they should be higher, lower, or removed?
       <% end %>
     </span>
@@ -48,7 +48,7 @@
 
   <div class="form-group">
     <span class="form-label">
-      <%= f.label :change_justification do %>
+      <%= f.label :change_justification, class: "hint-block--md-6" do %>
         If applicable, explain why this change is necessary. Why are the current search results bad for users?
       <% end %>
     </span>

--- a/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
+++ b/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
@@ -35,11 +35,14 @@
   <div class="form-group">
     <span class="form-label">
       <%= f.label :change_requested do %>
-        What change do you want to make to the search results? Include URLs for any pages you want the search to show.
+        If applicable, which pages are missing, or showing too high or low in results? If the pages are showing do you think they should be higher, lower, or removed?
       <% end %>
     </span>
+    <p class="help-block" id="change-hint">
+      Please include the URLs or pages.
+    </p>
     <span class="form-wrapper">
-      <%= f.text_area :change_requested, required: true, aria: { required: true }, class: "input-md-6 form-control", rows: 6, cols: 50 %>
+      <%= f.text_area :change_requested, aria: { describedby: "change-hint" }, class: "input-md-6 form-control", rows: 6, cols: 50 %>
     </span>
   </div>
 

--- a/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
+++ b/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
@@ -74,4 +74,15 @@
       <% end %>
     </span>
   </div>
+
+  <div class="form-group">
+    <span class="form-label">
+      <%= f.label :evidence_description do %>
+        If applicable, summarise the evidence that users are searching for these queries.
+      <% end %>
+    </span>
+    <span class="form-wrapper">
+      <%= f.text_area :evidence_description, class: "input-md-6 form-control", rows: 6, cols: 50 %>
+    </span>
+  </div>
 </div>

--- a/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
+++ b/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
@@ -10,7 +10,7 @@
   <div class="form-group">
     <span class="form-label">
       <%= f.label :search_query do %>
-        What search queries are not working well?
+        What search queries are not working well?<abbr title="required">*</abbr>
       <% end %>
     </span>
     <p class="help-block" id="query-hint">
@@ -24,7 +24,7 @@
   <div class="form-group">
     <span class="form-label">
       <%= f.label :results_problem do %>
-        What is the problem with the search results?
+        What is the problem with the search results?<abbr title="required">*</abbr>
       <% end %>
     </span>
     <span class="form-wrapper">
@@ -60,7 +60,7 @@
   <div class="form-group">
     <span class="form-label">
       <%= f.label :evidence_availability do %>
-        Is there evidence that users are searching for these queries?
+        Is there evidence that users are searching for these queries?<abbr title="required">*</abbr>
       <% end %>
     </span>
     <span class="form-wrapper">

--- a/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
+++ b/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
@@ -10,11 +10,14 @@
   <div class="form-group">
     <span class="form-label">
       <%= f.label :search_query do %>
-        What search query did you use, for example “Universal Credit”?
+        What search queries are not working well?
       <% end %>
     </span>
+    <p class="help-block" id="query-hint">
+      Include the exact words users type into search. You can include more than one query (for example: universal credit payment, UC payment).
+    </p>
     <span class="form-wrapper">
-      <%= f.text_area :search_query, required: true, aria: { required: true }, class: "input-md-6 form-control", rows: 6, cols: 50 %>
+      <%= f.text_area :search_query, required: true, aria: { required: true, describedby: "query-hint" }, class: "input-md-6 form-control", rows: 6, cols: 50 %>
     </span>
   </div>
 

--- a/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
+++ b/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
@@ -1,10 +1,10 @@
-<p>GOV.UK site search learns from how people use it, so search results change and improve over time. A page not appearing high in results today may appear higher in the future. </p>
-<p>In most cases, the search engine will deliver highly relevant results without manual changes. However, there may be occasions where we need to step in to make sure certain pages appear higher or lower in results.</p>
-<p>If you think this is needed, use this form to tell the GOV.UK search team about issues with search results that might stop users finding what they need. For example:</p>
+<p>GOV.UK site search learns from how people use it, so search results change and improve over time. However, there may be occasions where we need to step in to make sure certain pages appear higher or lower in results.</p>
+<p>Use this form to tell the GOV.UK search team about issues with search results that are stopping users finding what they need. For example:</p>
 <ul>
-  <li>Important pages that should appear near the top of search results but are too low</li>
-  <li>Pages not appearing in search results at all</li>
+  <li>pages that should appear at the top of search results but are too low</li>
+  <li>pages not appearing in search results at all</li>
 </ul>
+<p>We’ll review your request and may contact you for more information. Requests are prioritised based on user impact and severity.</p>
 
 <div id="feedback-type">
   <div class="form-group">

--- a/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
+++ b/app/views/report_an_issue_with_govuk_search_results_requests/_request_details.html.erb
@@ -56,4 +56,22 @@
       <%= f.text_area :change_justification, class: "input-md-6 form-control", rows: 6, cols: 50 %>
     </span>
   </div>
+
+  <div class="form-group">
+    <span class="form-label">
+      <%= f.label :evidence_availability do %>
+        Is there evidence that users are searching for these queries?
+      <% end %>
+    </span>
+    <span class="form-wrapper">
+      <%= f.collection_radio_buttons :evidence_availability, f.object.evidence_availability_options, :last, :last, required: true, aria: { required: true } do |builder| %>
+      <div class="radio">
+        <%= builder.label(class: "custom-control-label") do %>
+          <%= builder.radio_button(class: "custom-control-input") %>
+          <%= builder.object.first %>
+        <% end %>
+      </div>
+      <% end %>
+    </span>
+  </div>
 </div>

--- a/spec/controllers/report_an_issue_with_govuk_search_results_requests_controller_spec.rb
+++ b/spec/controllers/report_an_issue_with_govuk_search_results_requests_controller_spec.rb
@@ -15,6 +15,5 @@ describe ReportAnIssueWithGovukSearchResultsRequestsController, type: :controlle
     expect(controller).to have_rendered(:new)
     expect(response.body).to have_css(".alert", text: /Search query can't be blank/)
     expect(response.body).to have_css(".alert", text: /Results problem can't be blank/)
-    expect(response.body).to have_css(".alert", text: /Change justification can't be blank/)
   end
 end

--- a/spec/controllers/report_an_issue_with_govuk_search_results_requests_controller_spec.rb
+++ b/spec/controllers/report_an_issue_with_govuk_search_results_requests_controller_spec.rb
@@ -15,7 +15,6 @@ describe ReportAnIssueWithGovukSearchResultsRequestsController, type: :controlle
     expect(controller).to have_rendered(:new)
     expect(response.body).to have_css(".alert", text: /Search query can't be blank/)
     expect(response.body).to have_css(".alert", text: /Results problem can't be blank/)
-    expect(response.body).to have_css(".alert", text: /Change requested can't be blank/)
     expect(response.body).to have_css(".alert", text: /Change justification can't be blank/)
   end
 end

--- a/spec/features/report_an_issue_with_govuk_search_results_spec.rb
+++ b/spec/features/report_an_issue_with_govuk_search_results_spec.rb
@@ -26,7 +26,10 @@ improve-search-results
 improvement-justification
 
 [Is there evidence that users are searching for these queries?]
-Not sure",
+Not sure
+
+[What is the evidence that users are searching for these queries?]
+search-evidence-summary",
     )
 
     user_reports_issue_with_search_results(
@@ -35,6 +38,7 @@ Not sure",
       change_requested: "improve-search-results",
       change_justification: "improvement-justification",
       evidence_availability: "Not sure",
+      evidence_description: "search-evidence-summary",
     )
 
     expect(request).to have_been_made
@@ -51,6 +55,7 @@ private
     fill_in "If applicable, which pages are missing, or showing too high or low in results? If the pages are showing do you think they should be higher, lower, or removed?", with: details[:change_requested]
     fill_in "If applicable, explain why this change is necessary. Why are the current search results bad for users?", with: details[:change_justification]
     choose details[:evidence_availability]
+    fill_in "If applicable, summarise the evidence that users are searching for these queries.", with: details[:evidence_description]
     user_submits_the_request_successfully
   end
 end

--- a/spec/features/report_an_issue_with_govuk_search_results_spec.rb
+++ b/spec/features/report_an_issue_with_govuk_search_results_spec.rb
@@ -45,7 +45,7 @@ private
     fill_in "What search queries are not working well?", with: details[:search_query]
     fill_in "What is the problem with the search results?", with: details[:results_problem]
     fill_in "If applicable, which pages are missing, or showing too high or low in results? If the pages are showing do you think they should be higher, lower, or removed?", with: details[:change_requested]
-    fill_in "Explain why this change is necessary, including the impact on users and the number of users affected.", with: details[:change_justification]
+    fill_in "If applicable, explain why this change is necessary. Why are the current search results bad for users?", with: details[:change_justification]
     user_submits_the_request_successfully
   end
 end

--- a/spec/features/report_an_issue_with_govuk_search_results_spec.rb
+++ b/spec/features/report_an_issue_with_govuk_search_results_spec.rb
@@ -19,7 +19,7 @@ search-query
 [What is the problem with the search results?]
 search-result-problem
 
-[What change do you want to make to the search results?]
+[Which pages are showing incorrectly and how should they be changed?]
 improve-search-results
 
 [Why is this change necessary?]
@@ -44,7 +44,7 @@ private
     expect(page).to have_content("Report an issue with GOV.UK search results")
     fill_in "What search queries are not working well?", with: details[:search_query]
     fill_in "What is the problem with the search results?", with: details[:results_problem]
-    fill_in "What change do you want to make to the search results? Include URLs for any pages you want the search to show.", with: details[:change_requested]
+    fill_in "If applicable, which pages are missing, or showing too high or low in results? If the pages are showing do you think they should be higher, lower, or removed?", with: details[:change_requested]
     fill_in "Explain why this change is necessary, including the impact on users and the number of users affected.", with: details[:change_justification]
     user_submits_the_request_successfully
   end

--- a/spec/features/report_an_issue_with_govuk_search_results_spec.rb
+++ b/spec/features/report_an_issue_with_govuk_search_results_spec.rb
@@ -13,7 +13,7 @@ feature "Report an issue with GOV.UK search results" do
       "requester" => hash_including("name" => "John Smith", "email" => "john.smith@email.co.uk"),
       "tags" => %w[govt_form site_search],
       "description" =>
-"[What search query did you use?]
+"[What search queries are not working well?]
 search-query
 
 [What is the problem with the search results?]
@@ -42,7 +42,7 @@ private
     visit "/"
     click_on "Report an issue with GOV.UK search results"
     expect(page).to have_content("Report an issue with GOV.UK search results")
-    fill_in "What search query did you use, for example “Universal Credit”?", with: details[:search_query]
+    fill_in "What search queries are not working well?", with: details[:search_query]
     fill_in "What is the problem with the search results?", with: details[:results_problem]
     fill_in "What change do you want to make to the search results? Include URLs for any pages you want the search to show.", with: details[:change_requested]
     fill_in "Explain why this change is necessary, including the impact on users and the number of users affected.", with: details[:change_justification]

--- a/spec/features/report_an_issue_with_govuk_search_results_spec.rb
+++ b/spec/features/report_an_issue_with_govuk_search_results_spec.rb
@@ -23,7 +23,10 @@ search-result-problem
 improve-search-results
 
 [Why is this change necessary?]
-improvement-justification",
+improvement-justification
+
+[Is there evidence that users are searching for these queries?]
+Not sure",
     )
 
     user_reports_issue_with_search_results(
@@ -31,6 +34,7 @@ improvement-justification",
       results_problem: "search-result-problem",
       change_requested: "improve-search-results",
       change_justification: "improvement-justification",
+      evidence_availability: "Not sure",
     )
 
     expect(request).to have_been_made
@@ -46,6 +50,7 @@ private
     fill_in "What is the problem with the search results?", with: details[:results_problem]
     fill_in "If applicable, which pages are missing, or showing too high or low in results? If the pages are showing do you think they should be higher, lower, or removed?", with: details[:change_requested]
     fill_in "If applicable, explain why this change is necessary. Why are the current search results bad for users?", with: details[:change_justification]
+    choose details[:evidence_availability]
     user_submits_the_request_successfully
   end
 end

--- a/spec/models/support/requests/report_an_issue_with_govuk_search_results_request_spec.rb
+++ b/spec/models/support/requests/report_an_issue_with_govuk_search_results_request_spec.rb
@@ -6,7 +6,7 @@ module Support
       def request(options = {})
         described_class.new(options).tap(&:valid?)
       end
-      
+
       it { should validate_presence_of(:search_query) }
       it { should validate_presence_of(:results_problem) }
 

--- a/spec/models/support/requests/report_an_issue_with_govuk_search_results_request_spec.rb
+++ b/spec/models/support/requests/report_an_issue_with_govuk_search_results_request_spec.rb
@@ -5,7 +5,6 @@ module Support
     describe ReportAnIssueWithGovukSearchResultsRequest do
       it { should validate_presence_of(:search_query) }
       it { should validate_presence_of(:results_problem) }
-      it { should validate_presence_of(:change_justification) }
     end
   end
 end

--- a/spec/models/support/requests/report_an_issue_with_govuk_search_results_request_spec.rb
+++ b/spec/models/support/requests/report_an_issue_with_govuk_search_results_request_spec.rb
@@ -3,8 +3,25 @@ require "rails_helper"
 module Support
   module Requests
     describe ReportAnIssueWithGovukSearchResultsRequest do
+      def request(options = {})
+        described_class.new(options).tap(&:valid?)
+      end
+      
       it { should validate_presence_of(:search_query) }
       it { should validate_presence_of(:results_problem) }
+
+      it { should allow_value("yes").for(:evidence_availability) }
+      it { should allow_value("no").for(:evidence_availability) }
+      it { should allow_value("not_sure").for(:evidence_availability) }
+      it { should_not allow_value("xxx").for(:evidence_availability) }
+
+      it "provides evidence_availability choices" do
+        expect(request.evidence_availability_options).to_not be_empty
+      end
+
+      it "provides formatted evidence_availability" do
+        expect(request(evidence_availability: "not_sure").formatted_evidence_availability).to eq("Not sure")
+      end
     end
   end
 end

--- a/spec/models/support/requests/report_an_issue_with_govuk_search_results_request_spec.rb
+++ b/spec/models/support/requests/report_an_issue_with_govuk_search_results_request_spec.rb
@@ -5,7 +5,6 @@ module Support
     describe ReportAnIssueWithGovukSearchResultsRequest do
       it { should validate_presence_of(:search_query) }
       it { should validate_presence_of(:results_problem) }
-      it { should validate_presence_of(:change_requested) }
       it { should validate_presence_of(:change_justification) }
     end
   end


### PR DESCRIPTION
Changes to the support form for search to make it more useful and usable. 

See JIRA ticket for requirements: https://gov-uk.atlassian.net/browse/SCH-1997 

This is how the new version of the form looks:

<img width="607" height="707" alt="Screenshot 2026-07-14 at 11 27 56" src="https://github.com/user-attachments/assets/0363f150-e0c3-418c-af59-a218e7c718bf" />

