### PR TITLE
Bump js-yaml from 4.2.0 to 4.3.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1938,13 +1938,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Dependabot failed to do this. I think it's tripping up on us having both a v3 and a v4 `js-yaml` - it says "The latest possible version of js-yaml that can be installed is 3.15.0" even though the v4 `js-yaml` is what it wants to update

I did this with `yarn up --recursive js-yaml`