### PR TITLE
[PP-7929] Increase GdsApi timeout to 60s

### DIFF
--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,6 +1,6 @@
 require "gds_api/base"
 
-GdsApi::Base.default_options = { timeout: 30 }
+GdsApi::Base.default_options = { timeout: 60 }
 
 if %w[development test].include? Rails.env
   GdsApi::Base.default_options[:disable_cache] = true


### PR DESCRIPTION
We recently fixed the Helm Charts configuration so that the nginx timeout is in line with the 30s timeout configured here: https://github.com/alphagov/govuk-helm-charts/commit/ade2e8f4e6f29adefa6eecb8a69823c8a42cde28e. Previously nginx was timing out requests after 15s despite this app setting

We know that requests for feedback can be slow. Over the last 15 days there were 190 requests that took 10 seconds, 75 over 30 seconds, 49 over 60 seconds, and 23 over 120 seconds. The three worst offenders took just over 30 minutes(!)

We've therefore decided to raise the timeout further to 60s - which a few other apps already use - so that more requests will resolve before timing out. For those that take longer than a minute, caching should mean that a single refresh is sufficient for the vast majority of requests

Related Helm Charts change: https://github.com/alphagov/govuk-helm-charts/pull/4382