### PR TITLE
[PP-7957] Add Content API to technical fault report form

### DIFF
--- a/app/models/support/requests/technical_fault_report.rb
+++ b/app/models/support/requests/technical_fault_report.rb
@@ -21,6 +21,7 @@ module Support
       # ("Conditions" -> "Tags" -> "Contains at least one of the following")
       OPTIONS = {
         "collections_publisher" => "Collections Publisher",
+        "content_api" => "Content API",
         "content_data" => "Content Data",
         "content_tagger" => "Content Tagger",
         "email_alerts" => "Email alerts",


### PR DESCRIPTION
This will allow users to report issues with the Content API.

These tickets will be assigned to `GOV.UK 2nd Line--Alerts and Issues` until we ask a Zendesk admin to set up a trigger for tickets tagged with `fault_with_content_api`.

As an aside, I've also removed Maslow from the list as this app is no longer available to publishers.