### PR TITLE
[PP-7948] Fix ES6 setup

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/lib/cookie-functions
 //= require ./domain-config
 

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -8,4 +8,3 @@
 // which will ensure they are never loaded.
 
 //= require govuk_publishing_components/components/skip-link
-//= require govuk_publishing_components/components/layout-header

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,6 @@
   <%= stylesheet_link_tag "legacy/application", :media => "all" %>
   <%= stylesheet_link_tag "application", :media => "all" %>
   <%= javascript_include_tag "legacy/application" %>
-  <%= javascript_include_tag 'es6-components', type: "module" %>
 <% end %>
 
 <% content_for :favicon do %>

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,0 +1,3 @@
+GovukPublishingComponents.configure do |config|
+  config.use_es6_components = true
+end


### PR DESCRIPTION
This fixes how we source the es6-components.js script and moves one of the component scripts required there into the general script since it doesn't require ES6 support

I've run the app locally to confirm this leads to the `script` being sourced (and confirmed in production that it isn't at the moment)