### PR TITLE
[PP-7948] Bump govuk_publishing_components 67.0.1 -> 68.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
     govuk_personalisation (1.2.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (67.0.1)
+    govuk_publishing_components (68.3.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,4 @@
 //= require govuk_publishing_components/dependencies
-//= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/lib/cookie-functions
 //= require ./domain-config
 


### PR DESCRIPTION
v68 bumps govuk-frontend (a Node package) to v6. The only thing that appears to affect us here is the removal of layout-header.js, but we weren't relying on it (and weren't even loading it until the very recent 3c5f103b1cab89b03471a81acbe160bd06e2904f)